### PR TITLE
fix(db): stop `db rebuild` from destroying the committed intent files

### DIFF
--- a/repro/add-intent-safety.mjs
+++ b/repro/add-intent-safety.mjs
@@ -1,0 +1,143 @@
+// Reproduction: the two properties of the write path that made the
+// rebuild destructive in the first place, plus the safety net.
+//
+//   A. `normalizeIntent` must round-trip its OWN output. It writes
+//      `requirements` but reads `rules`/`constraints`/`acceptance`, so
+//      feeding a written intent file back through it yields zero
+//      requirements. That asymmetry is what emptied the record.
+//
+//   B. `addIntent` must not write the intent file before the DB insert.
+//      With write-first, an insert that fails leaves a rewritten (and
+//      possibly emptied) permanent record behind with nothing in the DB
+//      to show for it.
+//
+//   C. Overwriting a non-empty intent file with a zero-requirement one
+//      must fail loudly rather than silently empty a committed record.
+//
+// Runs entirely inside a temp dir created by the harness.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { normalizeIntent, addIntent } from '../src/db/intent.mjs';
+import { openDb, dbInit, DB_PATH } from '../src/db/init.mjs';
+import {
+  intentFixture,
+  makeProject,
+  snapshotIntents,
+  diffSnapshots,
+  check,
+  assert,
+  assertEqual,
+  finish,
+} from './harness.mjs';
+
+console.log('repro: addIntent / normalizeIntent must not destroy a written record\n');
+
+// 14 rules + 4 constraints + 4 acceptance = 22 requirements, the count
+// the real project's `card` module lost.
+const seed = intentFixture({ id: 'card', rules: 14, constraints: 4, acceptance: 4 });
+const cardPath = () => join(root, '.hedgehog', 'intents', 'card.json');
+
+const root = await makeProject([seed]);
+console.log(`  temp project: ${root}`);
+console.log(`  card.json carries ${seed.requirements.length} requirements\n`);
+
+await dbInit(DB_PATH);
+const db = openDb();
+
+// --- A. normalizeIntent round-trips its own output --------------------
+
+check('A. normalizeIntent round-trips its own output', () => {
+  const fromInput = normalizeIntent({
+    id: 'roundtrip',
+    goal: 'g',
+    outcome: 'o',
+    rules: ['r1', 'r2'],
+    constraints: ['c1'],
+    acceptance: ['a1'],
+  });
+  assertEqual(fromInput.requirements.length, 4, 'requirements from the input shape');
+
+  const again = normalizeIntent(fromInput);
+  assertEqual(again.requirements.length, 4, 'requirements after re-normalizing the output shape');
+  assertEqual(
+    JSON.stringify(again.requirements),
+    JSON.stringify(fromInput.requirements),
+    'requirements should survive a round trip unchanged',
+  );
+});
+
+check('A2. normalizeIntent preserves a real on-disk intent record', () => {
+  assertEqual(
+    normalizeIntent(JSON.parse(readFileSync(cardPath(), 'utf8'))).requirements.length,
+    seed.requirements.length,
+    'requirements after normalizing the committed file',
+  );
+});
+
+// --- B. a failed DB insert must not have touched the file -------------
+
+const beforeAdd = await snapshotIntents(root);
+await addIntent(db, seed);
+const afterAdd = await snapshotIntents(root);
+
+check('B1. a successful add leaves the committed record byte-identical', () => {
+  const problems = diffSnapshots(beforeAdd, afterAdd);
+  assert(problems.length === 0, `add rewrote the record:\n  ${problems.join('\n  ')}`);
+});
+
+// `card` is now in the DB, so re-adding the same id hits the PRIMARY KEY
+// constraint. The file must be untouched when the insert fails.
+let duplicateError = null;
+try {
+  await addIntent(db, { id: 'card', goal: 'a different goal', outcome: 'o' });
+} catch (err) {
+  duplicateError = err;
+}
+const afterDuplicate = await snapshotIntents(root);
+
+check('B2. a failed DB insert does not rewrite the intent file', () => {
+  assert(duplicateError !== null, 'expected the duplicate-id add to fail');
+  const problems = diffSnapshots(afterAdd, afterDuplicate);
+  assert(
+    problems.length === 0,
+    `a failed insert still rewrote the intent file:\n  ${problems.join('\n  ')}`,
+  );
+});
+
+// --- C. refuse to empty a non-empty record ----------------------------
+
+// Drop the DB row so the insert would now succeed: only the file guard
+// stands between a zero-requirement record and the committed 22.
+db.exec("DELETE FROM intents WHERE id = 'card'");
+
+let guardError = null;
+try {
+  await addIntent(db, { id: 'card', goal: 'g', outcome: 'o' });
+} catch (err) {
+  guardError = err;
+}
+const afterGuard = await snapshotIntents(root);
+console.log(`  guard error: ${guardError ? guardError.message : '(none — the record was overwritten)'}`);
+console.log('');
+
+check('C1. refuses to overwrite a non-empty intent file with an empty one', () => {
+  assert(
+    guardError !== null,
+    'expected addIntent to refuse emptying a committed record of 22 requirements',
+  );
+  assert(
+    /requirement/i.test(guardError.message),
+    `error should explain the refusal, got: ${guardError.message}`,
+  );
+});
+
+check('C2. the record on disk still holds all 22 requirements', () => {
+  const onDisk = JSON.parse(readFileSync(cardPath(), 'utf8'));
+  assertEqual(onDisk.requirements.length, 22, 'requirements still on disk');
+  const problems = diffSnapshots(afterAdd, afterGuard);
+  assert(problems.length === 0, `record changed:\n  ${problems.join('\n  ')}`);
+});
+
+db.close();
+finish('add-intent-safety');

--- a/repro/add-intent-write-failure.mjs
+++ b/repro/add-intent-write-failure.mjs
@@ -1,0 +1,186 @@
+// Reproduction: a failed intent-file write must not strand the intent in
+// the derived database.
+//
+// `addIntent` inserts before it writes, so that a record the DB rejects
+// never reaches the permanent record. Done naively that trades one
+// asymmetry for its mirror image: the insert commits, the file write
+// fails, and the intent now exists ONLY in `.hedgehog/hedgehog.db` —
+// which is gitignored and derived. The command reports failure, a retry
+// hits the PRIMARY KEY constraint, and `db rebuild` can't recover the
+// intent because it was never written to the record it replays from.
+// That is a dead end for the user.
+//
+// The lever is an unwritable intents directory (chmod 0555): `writeFile`
+// fails with EACCES after the inserts have run.
+//
+// Asserts:
+//   1. the add fails loudly
+//   2. NOTHING is left in the DB — no intents row, no requirements rows
+//   3. retrying the identical add once the directory is writable SUCCEEDS
+//      rather than hitting the PRIMARY KEY constraint
+//   4. the permanent record then holds the intent in full
+//   5. a rebuild from a deleted DB reconstructs it
+//   6. no partial or temp file is left behind, and the intent files that
+//      were already committed are byte-identical throughout
+//
+// Runs entirely inside a temp dir created by the harness.
+
+import { chmod, readdir, rm } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { addIntent } from '../src/db/intent.mjs';
+import { rebuildDb } from '../src/db/rebuild.mjs';
+import { openDb, dbInit, DB_PATH } from '../src/db/init.mjs';
+import {
+  intentFixture,
+  makeProject,
+  snapshotIntents,
+  diffSnapshots,
+  check,
+  assert,
+  assertEqual,
+  finish,
+} from './harness.mjs';
+
+console.log('repro: a failed intent-file write must not strand the intent in the DB\n');
+
+if (process.getuid && process.getuid() === 0) {
+  console.log('  running as root — chmod cannot make a directory unwritable.');
+  console.log('  This reproduction needs an unprivileged user.');
+  process.exit(1);
+}
+
+const seed = intentFixture({ id: 'board', rules: 4, constraints: 1, acceptance: 1 });
+// The intent whose file write is going to fail.
+const ledger = intentFixture({ id: 'ledger', dependsOn: ['board'], rules: 7, constraints: 2, acceptance: 1 });
+
+const root = await makeProject([seed]);
+const intentsDir = join(root, '.hedgehog', 'intents');
+console.log(`  temp project: ${root}`);
+console.log(`  adding "ledger" (${ledger.requirements.length} requirements) with the intents dir unwritable\n`);
+
+await dbInit(DB_PATH);
+const db = openDb();
+
+// `board` must already be in the DB for ledger's depends_on FK.
+await addIntent(db, seed);
+const afterSeed = await snapshotIntents(root);
+
+// --- 1/2. the strand -------------------------------------------------
+
+await chmod(intentsDir, 0o555);
+
+let writeError = null;
+try {
+  await addIntent(db, ledger);
+} catch (err) {
+  writeError = err;
+}
+
+const intentRow = db.prepare('SELECT id FROM intents WHERE id = ?').get('ledger');
+const requirementCount = db
+  .prepare('SELECT COUNT(*) AS n FROM requirements WHERE intent_id = ?')
+  .get('ledger').n;
+const dependencyCount = db
+  .prepare('SELECT COUNT(*) AS n FROM intent_dependencies WHERE intent_id = ?')
+  .get('ledger').n;
+
+await chmod(intentsDir, 0o755);
+
+console.log(`  add error:            ${writeError ? writeError.message : '(none)'}`);
+console.log(`  intents row for ledger: ${intentRow ? 'PRESENT  <-- STRANDED' : 'absent'}`);
+console.log(`  requirements rows:      ${requirementCount}`);
+console.log(`  intent_dependencies:    ${dependencyCount}`);
+console.log('');
+
+check('1. the add fails loudly', () => {
+  assert(writeError !== null, 'expected the add to fail when the intents dir is unwritable');
+  assert(
+    /EACCES|permission denied/i.test(writeError.message),
+    `expected a write error, got: ${writeError.message}`,
+  );
+});
+
+check('2. a failed file write leaves nothing behind in the DB', () => {
+  assert(
+    intentRow === undefined,
+    'the intents row survived a failed file write — the intent is stranded in the derived DB, ' +
+      'invisible to `db rebuild` and un-retryable through `intent add`',
+  );
+  assertEqual(requirementCount, 0, 'stranded requirements rows');
+  assertEqual(dependencyCount, 0, 'stranded intent_dependencies rows');
+});
+
+// --- 3/4. the retry is not a dead end --------------------------------
+
+let retryError = null;
+try {
+  await addIntent(db, ledger);
+} catch (err) {
+  retryError = err;
+}
+
+check('3. retrying the identical add succeeds once the write can land', () => {
+  assert(
+    retryError === null,
+    `the retry failed: ${retryError && retryError.message}` +
+      (retryError && /UNIQUE|PRIMARY KEY/i.test(retryError.message)
+        ? '  <-- dead end: the first attempt claimed the id and the record never got it'
+        : ''),
+  );
+});
+
+check('4. the permanent record then holds the intent in full', () => {
+  const onDisk = JSON.parse(readFileSync(join(intentsDir, 'ledger.json'), 'utf8'));
+  assertEqual(onDisk.requirements.length, ledger.requirements.length, 'requirements on disk');
+  assertEqual(
+    JSON.stringify(onDisk.depends_on),
+    JSON.stringify(ledger.depends_on),
+    'depends_on on disk',
+  );
+});
+
+// --- 5. the record is authoritative ----------------------------------
+
+const beforeRebuild = await snapshotIntents(root);
+db.close();
+
+// Throw the derived artifact away entirely, exactly as a fresh clone
+// (or bin/cli.mjs#ensureDb) would find it.
+for (const suffix of ['', '-wal', '-shm']) {
+  await rm(join(root, `.hedgehog/hedgehog.db${suffix}`), { force: true });
+}
+await dbInit(DB_PATH);
+const freshDb = openDb();
+const rebuildResult = await rebuildDb(freshDb, { corePath: '.hedgehog/core.yaml' });
+const rebuiltRequirements = freshDb
+  .prepare('SELECT COUNT(*) AS n FROM requirements WHERE intent_id = ?')
+  .get('ledger').n;
+
+check('5. a rebuild reconstructs the intent from the permanent record', () => {
+  assertEqual(rebuildResult.intentsReplayed, 2, 'intents replayed');
+  assertEqual(rebuiltRequirements, ledger.requirements.length, 'ledger requirements after rebuild');
+});
+
+const afterRebuild = await snapshotIntents(root);
+const strayFiles = (await readdir(intentsDir)).filter((n) => !n.endsWith('.json'));
+
+check('6a. no partial or temp file is left in the intents directory', () => {
+  assert(strayFiles.length === 0, `stray files left behind: ${strayFiles.join(', ')}`);
+});
+
+check('6b. the already-committed intent files are byte-identical throughout', () => {
+  for (const [label, snapshot] of [
+    ['after the failed write / retry', beforeRebuild],
+    ['after the rebuild', afterRebuild],
+  ]) {
+    const problems = diffSnapshots(
+      new Map([['board.json', afterSeed.get('board.json')]]),
+      new Map([['board.json', snapshot.get('board.json')]]),
+    );
+    assert(problems.length === 0, `board.json changed ${label}:\n  ${problems.join('\n  ')}`);
+  }
+});
+
+freshDb.close();
+finish('add-intent-write-failure');

--- a/repro/harness.mjs
+++ b/repro/harness.mjs
@@ -1,0 +1,238 @@
+// Shared harness for the `hedgehog db rebuild` data-loss reproductions.
+//
+// Everything here happens inside a freshly-created temp directory
+// (`mkdtemp` under the OS temp dir). No reproduction ever touches a real
+// project's `.hedgehog/` — the fixtures are written from scratch into a
+// directory this file creates, and the process chdirs into it because
+// `rebuildDb` resolves both the DB path and the intents directory
+// relative to `process.cwd()`.
+//
+// No test framework and no `sqlite3` binary are available, so the
+// assertions are plain functions and the DB is read through
+// `node:sqlite` (Node >= 22.5).
+
+import { mkdtemp, mkdir, writeFile, readFile, readdir } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// ---------------------------------------------------------------------
+// assertions
+// ---------------------------------------------------------------------
+
+const failures = [];
+
+export function check(label, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${label}`);
+  } catch (err) {
+    failures.push(`${label}: ${err.message}`);
+    console.log(`  FAIL  ${label}`);
+    console.log(`        ${err.message.split('\n').join('\n        ')}`);
+  }
+}
+
+export function assert(cond, message) {
+  if (!cond) throw new Error(message);
+}
+
+export function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}\n  expected: ${expected}\n  actual:   ${actual}`);
+  }
+}
+
+export function finish(name) {
+  console.log('');
+  if (failures.length === 0) {
+    console.log(`${name}: OK`);
+    process.exit(0);
+  }
+  console.log(`${name}: ${failures.length} failure(s)`);
+  for (const f of failures) console.log(`  - ${f}`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------
+// fixtures
+// ---------------------------------------------------------------------
+
+// A minimal module-axis core: two layers, trivial verify commands. The
+// reproductions never run the verify commands (rebuild doesn't), they
+// only need `planTasks` to have something to compile against.
+const CORE_YAML = `id: repro-core
+layers:
+  - id: schema
+    scope: [src/{module}/schema.ts]
+    verify: node -e "process.exit(0)"
+    commit: "feat({module}): schema"
+  - id: service
+    depends_on: schema
+    scope: [src/{module}/service.ts]
+    verify: node -e "process.exit(0)"
+    commit: "feat({module}): service"
+`;
+
+function statements(prefix, count) {
+  return Array.from({ length: count }, (_, i) => `${prefix} statement ${i + 1}`);
+}
+
+// Builds one intent in exactly the on-disk shape `addIntent` writes:
+// normalizeIntent's OUTPUT — `requirements: [{id, kind, statement}]`, not
+// the `rules`/`constraints`/`acceptance` input arrays. This is what a
+// real, committed `.hedgehog/intents/<id>.json` looks like on a project
+// whose intents were added through `hedgehog intent add`.
+export function intentFixture({ id, dependsOn = [], rules, constraints, acceptance, priority = 100 }) {
+  const requirements = [];
+  const push = (kind, list) =>
+    list.forEach((statement, index) => {
+      requirements.push({
+        id: `${id}-${kind}-${index + 1}`.toUpperCase(),
+        kind,
+        statement,
+      });
+    });
+  push('rule', statements(`${id} rule`, rules));
+  push('constraint', statements(`${id} constraint`, constraints));
+  push('acceptance', statements(`${id} acceptance`, acceptance));
+
+  return {
+    id,
+    goal: `goal for ${id}`,
+    outcome: `outcome for ${id}`,
+    priority,
+    requirements,
+    depends_on: dependsOn,
+  };
+}
+
+// Four intents whose ALPHABETICAL filename order contradicts their
+// DEPENDENCY order:
+//
+//   alphabetical: automation, board, card, list
+//   dependency:   board -> list -> card -> automation
+//
+// `card` carries 22 requirements and `list` carries 10 — the two
+// modules that lost exactly that many on the real project.
+export const OUT_OF_ORDER_INTENTS = [
+  intentFixture({ id: 'board', rules: 4, constraints: 1, acceptance: 1 }),
+  intentFixture({ id: 'list', dependsOn: ['board'], rules: 6, constraints: 2, acceptance: 2 }),
+  intentFixture({ id: 'card', dependsOn: ['list'], rules: 14, constraints: 4, acceptance: 4 }),
+  intentFixture({ id: 'automation', dependsOn: ['card'], rules: 3, constraints: 1, acceptance: 1 }),
+];
+
+// Same intents, but named so that alphabetical order already AGREES with
+// dependency order (a-board, b-list, c-card, d-automation). Isolates the
+// normalize/write-order defect from the replay-order defect.
+export const IN_ORDER_INTENTS = [
+  intentFixture({ id: 'a-board', rules: 4, constraints: 1, acceptance: 1 }),
+  intentFixture({ id: 'b-list', dependsOn: ['a-board'], rules: 6, constraints: 2, acceptance: 2 }),
+  intentFixture({ id: 'c-card', dependsOn: ['b-list'], rules: 14, constraints: 4, acceptance: 4 }),
+  intentFixture({ id: 'd-automation', dependsOn: ['c-card'], rules: 3, constraints: 1, acceptance: 1 }),
+];
+
+// A cycle, to prove the fixed replay reports it clearly instead of
+// looping or dying on a FOREIGN KEY error.
+export const CYCLIC_INTENTS = [
+  intentFixture({ id: 'alpha', dependsOn: ['gamma'], rules: 2, constraints: 0, acceptance: 0 }),
+  intentFixture({ id: 'beta', dependsOn: ['alpha'], rules: 2, constraints: 0, acceptance: 0 }),
+  intentFixture({ id: 'gamma', dependsOn: ['beta'], rules: 2, constraints: 0, acceptance: 0 }),
+];
+
+// ---------------------------------------------------------------------
+// temp project
+// ---------------------------------------------------------------------
+
+const git = (cwd, ...args) =>
+  execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+
+// Creates a throwaway git repo with `.hedgehog/core.yaml` and the given
+// intents under `.hedgehog/intents/`, and chdirs into it. Returns the
+// path. The intent files are written and committed BEFORE any rebuild
+// runs, so git itself is a second witness to whether they changed.
+export async function makeProject(intents, { commitSubjects = [] } = {}) {
+  const root = await mkdtemp(join(tmpdir(), 'hedgehog-repro-'));
+
+  git(root, 'init', '--quiet');
+  git(root, 'config', 'user.email', 'repro@example.invalid');
+  git(root, 'config', 'user.name', 'repro');
+  git(root, 'config', 'commit.gpgsign', 'false');
+
+  await mkdir(join(root, '.hedgehog', 'intents'), { recursive: true });
+  await writeFile(join(root, '.hedgehog', 'core.yaml'), CORE_YAML);
+  for (const intent of intents) {
+    await writeFile(
+      join(root, '.hedgehog', 'intents', `${intent.id}.json`),
+      JSON.stringify(intent, null, 2),
+    );
+  }
+  await writeFile(join(root, '.gitignore'), '.hedgehog/hedgehog.db\n');
+
+  git(root, 'add', '-A');
+  git(root, 'commit', '--quiet', '-m', 'chore: seed intents');
+
+  // Optional extra commits whose subjects match compiled task
+  // commit_messages, so markCompletedTasks has something to reconcile.
+  for (const subject of commitSubjects) {
+    git(root, 'commit', '--quiet', '--allow-empty', '-m', subject);
+  }
+
+  process.chdir(root);
+  return root;
+}
+
+// ---------------------------------------------------------------------
+// the byte-identical check
+// ---------------------------------------------------------------------
+
+const sha256 = (buf) => createHash('sha256').update(buf).digest('hex');
+
+export async function snapshotIntents(root) {
+  const dir = join(root, '.hedgehog', 'intents');
+  const names = (await readdir(dir)).filter((n) => n.endsWith('.json')).sort();
+  const snapshot = new Map();
+  for (const name of names) {
+    const bytes = await readFile(join(dir, name));
+    snapshot.set(name, { sha: sha256(bytes), size: bytes.length, bytes });
+  }
+  return snapshot;
+}
+
+// Reports the diff between two snapshots as a human-readable string, and
+// counts requirements so a silent emptying is named as such rather than
+// only as a hash mismatch.
+export function diffSnapshots(before, after) {
+  const problems = [];
+  for (const [name, b] of before) {
+    const a = after.get(name);
+    if (!a) {
+      problems.push(`${name}: DELETED`);
+      continue;
+    }
+    if (a.sha === b.sha) continue;
+    let detail = `sha ${b.sha.slice(0, 12)} -> ${a.sha.slice(0, 12)}, ${b.size}B -> ${a.size}B`;
+    try {
+      const bReq = JSON.parse(b.bytes.toString('utf8')).requirements?.length ?? '?';
+      const aReq = JSON.parse(a.bytes.toString('utf8')).requirements?.length ?? '?';
+      detail += `, requirements ${bReq} -> ${aReq}`;
+      if (bReq > 0 && aReq === 0) detail += '  <-- PERMANENT RECORD EMPTIED';
+    } catch {
+      detail += ', (unparseable)';
+    }
+    problems.push(`${name}: ${detail}`);
+  }
+  for (const name of after.keys()) {
+    if (!before.has(name)) problems.push(`${name}: UNEXPECTED NEW FILE`);
+  }
+  return problems;
+}
+
+export function reportSnapshot(label, snapshot) {
+  console.log(`  ${label}`);
+  for (const [name, entry] of snapshot) {
+    const req = JSON.parse(entry.bytes.toString('utf8')).requirements?.length ?? '?';
+    console.log(`    ${name.padEnd(22)} ${entry.sha.slice(0, 16)}  ${String(entry.size).padStart(6)}B  ${String(req).padStart(3)} requirements`);
+  }
+}

--- a/repro/rebuild-cycle.mjs
+++ b/repro/rebuild-cycle.mjs
@@ -1,0 +1,65 @@
+// Reproduction: a genuine `depends_on` cycle across intent files.
+//
+// A dependency-ordered replay needs an answer for the case where no
+// order exists. This asserts the failure is a clear, named cycle error
+// rather than a FOREIGN KEY message, an infinite loop, or a partial
+// replay — and, as always, that the intent files on disk are untouched.
+//
+// Runs entirely inside a temp dir created by the harness.
+
+import { rebuildDb } from '../src/db/rebuild.mjs';
+import { openDb, dbInit, DB_PATH } from '../src/db/init.mjs';
+import {
+  CYCLIC_INTENTS,
+  makeProject,
+  snapshotIntents,
+  diffSnapshots,
+  reportSnapshot,
+  check,
+  assert,
+  finish,
+} from './harness.mjs';
+
+console.log('repro: rebuild reports a genuine depends_on cycle clearly\n');
+
+const root = await makeProject(CYCLIC_INTENTS);
+console.log(`  temp project: ${root}`);
+console.log('  cycle: alpha -> gamma -> beta -> alpha\n');
+
+const before = await snapshotIntents(root);
+reportSnapshot('before rebuild:', before);
+console.log('');
+
+await dbInit(DB_PATH);
+const db = openDb();
+
+let rebuildError = null;
+try {
+  await rebuildDb(db, { corePath: '.hedgehog/core.yaml' });
+} catch (err) {
+  rebuildError = err;
+}
+
+const after = await snapshotIntents(root);
+console.log(`  rebuild error: ${rebuildError ? rebuildError.message : '(none — rebuild succeeded)'}`);
+console.log('');
+
+check('1. rebuild fails with a cycle error naming the intents', () => {
+  assert(rebuildError !== null, 'expected the rebuild to fail on a cycle');
+  assert(
+    /cycle/i.test(rebuildError.message),
+    `error should name the cycle, got: ${rebuildError.message}`,
+  );
+  assert(
+    /alpha|beta|gamma/.test(rebuildError.message),
+    `error should name at least one intent in the cycle, got: ${rebuildError.message}`,
+  );
+});
+
+check('2. every intent JSON file is byte-identical after the failed rebuild', () => {
+  const problems = diffSnapshots(before, after);
+  assert(problems.length === 0, `intent files changed on disk:\n  ${problems.join('\n  ')}`);
+});
+
+db.close();
+finish('rebuild-cycle');

--- a/repro/rebuild-out-of-order.mjs
+++ b/repro/rebuild-out-of-order.mjs
@@ -1,0 +1,84 @@
+// Reproduction: `hedgehog db rebuild` against intents whose alphabetical
+// filename order contradicts their `depends_on` order.
+//
+// Fixtures: automation -> card -> list -> board (dependency order is the
+// reverse-ish of alphabetical). `card` carries 22 requirements and `list`
+// 10 — the two counts lost on the real project.
+//
+// Asserts:
+//   1. the rebuild completes
+//   2. every `.hedgehog/intents/*.json` file is BYTE-IDENTICAL afterwards
+//   3. the DB ends up holding every requirement the files declare
+//
+// Runs entirely inside a temp dir created by the harness.
+
+import { rebuildDb } from '../src/db/rebuild.mjs';
+import { openDb, dbInit, DB_PATH } from '../src/db/init.mjs';
+import {
+  OUT_OF_ORDER_INTENTS,
+  makeProject,
+  snapshotIntents,
+  diffSnapshots,
+  reportSnapshot,
+  check,
+  assert,
+  assertEqual,
+  finish,
+} from './harness.mjs';
+
+console.log('repro: rebuild with alphabetical order contradicting depends_on order\n');
+
+const root = await makeProject(OUT_OF_ORDER_INTENTS, {
+  commitSubjects: ['feat(board): schema'],
+});
+console.log(`  temp project: ${root}`);
+console.log('  replay order (alphabetical): automation, board, card, list');
+console.log('  dependency order:            board, list, card, automation\n');
+
+const before = await snapshotIntents(root);
+reportSnapshot('before rebuild:', before);
+console.log('');
+
+await dbInit(DB_PATH);
+const db = openDb();
+
+let rebuildError = null;
+let result = null;
+try {
+  result = await rebuildDb(db, { corePath: '.hedgehog/core.yaml' });
+} catch (err) {
+  rebuildError = err;
+}
+
+const after = await snapshotIntents(root);
+reportSnapshot('after rebuild:', after);
+console.log('');
+
+check('1. rebuild completes without throwing', () => {
+  assert(
+    rebuildError === null,
+    `rebuild threw: ${rebuildError && rebuildError.message}`,
+  );
+  assertEqual(result.intentsReplayed, OUT_OF_ORDER_INTENTS.length, 'intents replayed');
+});
+
+check('2. every intent JSON file is byte-identical after the rebuild', () => {
+  const problems = diffSnapshots(before, after);
+  assert(problems.length === 0, `intent files changed on disk:\n  ${problems.join('\n  ')}`);
+});
+
+check('3. the DB holds every requirement the intent files declare', () => {
+  for (const intent of OUT_OF_ORDER_INTENTS) {
+    const row = db
+      .prepare('SELECT COUNT(*) AS n FROM requirements WHERE intent_id = ?')
+      .get(intent.id);
+    assertEqual(
+      row ? row.n : 0,
+      intent.requirements.length,
+      `requirement rows for intent "${intent.id}"`,
+    );
+  }
+});
+
+db.close();
+finish('rebuild-out-of-order');

--- a/repro/rebuild-preserves-intent-files.mjs
+++ b/repro/rebuild-preserves-intent-files.mjs
@@ -1,0 +1,94 @@
+// Reproduction: the destructive rewrite, isolated from the ordering bug.
+//
+// Same four intents, renamed so alphabetical order already AGREES with
+// dependency order (a-board, b-list, c-card, d-automation). The rebuild
+// therefore never hits a FOREIGN KEY error — and still destroys the
+// permanent record, because the replay path writes each intent file back
+// out through `normalizeIntent`, which reads the INPUT fields
+// (rules/constraints/acceptance) that an already-written file no longer
+// has, and writes the OUTPUT field (requirements) as `[]`.
+//
+// Asserts:
+//   1. the rebuild completes
+//   2. every `.hedgehog/intents/*.json` file is BYTE-IDENTICAL afterwards
+//   3. git reports no modification to the committed intent files
+//   4. the DB holds every requirement the files declare
+//
+// Runs entirely inside a temp dir created by the harness.
+
+import { execFileSync } from 'node:child_process';
+import { rebuildDb } from '../src/db/rebuild.mjs';
+import { openDb, dbInit, DB_PATH } from '../src/db/init.mjs';
+import {
+  IN_ORDER_INTENTS,
+  makeProject,
+  snapshotIntents,
+  diffSnapshots,
+  reportSnapshot,
+  check,
+  assert,
+  assertEqual,
+  finish,
+} from './harness.mjs';
+
+console.log('repro: rebuild must not rewrite the committed intent files\n');
+
+const root = await makeProject(IN_ORDER_INTENTS);
+console.log(`  temp project: ${root}`);
+console.log('  alphabetical order already matches dependency order\n');
+
+const before = await snapshotIntents(root);
+reportSnapshot('before rebuild:', before);
+console.log('');
+
+await dbInit(DB_PATH);
+const db = openDb();
+
+let rebuildError = null;
+let result = null;
+try {
+  result = await rebuildDb(db, { corePath: '.hedgehog/core.yaml' });
+} catch (err) {
+  rebuildError = err;
+}
+
+const after = await snapshotIntents(root);
+reportSnapshot('after rebuild:', after);
+console.log('');
+
+const gitStatus = execFileSync('git', ['status', '--porcelain', '.hedgehog/intents'], {
+  cwd: root,
+  encoding: 'utf8',
+}).trim();
+console.log(`  git status .hedgehog/intents: ${gitStatus === '' ? '(clean)' : `\n${gitStatus}`}`);
+console.log('');
+
+check('1. rebuild completes without throwing', () => {
+  assert(rebuildError === null, `rebuild threw: ${rebuildError && rebuildError.message}`);
+  assertEqual(result.intentsReplayed, IN_ORDER_INTENTS.length, 'intents replayed');
+});
+
+check('2. every intent JSON file is byte-identical after the rebuild', () => {
+  const problems = diffSnapshots(before, after);
+  assert(problems.length === 0, `intent files changed on disk:\n  ${problems.join('\n  ')}`);
+});
+
+check('3. git sees no change to the committed intent files', () => {
+  assertEqual(gitStatus, '', 'git status of .hedgehog/intents should be clean');
+});
+
+check('4. the DB holds every requirement the intent files declare', () => {
+  for (const intent of IN_ORDER_INTENTS) {
+    const row = db
+      .prepare('SELECT COUNT(*) AS n FROM requirements WHERE intent_id = ?')
+      .get(intent.id);
+    assertEqual(
+      row ? row.n : 0,
+      intent.requirements.length,
+      `requirement rows for intent "${intent.id}"`,
+    );
+  }
+});
+
+db.close();
+finish('rebuild-preserves-intent-files');

--- a/repro/run.mjs
+++ b/repro/run.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Runs every reproduction in its own child process — each one chdirs
+// into its own temp directory, so they can't share one. Exits non-zero
+// if any reproduction fails.
+//
+//   node repro/run.mjs
+
+import { spawnSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, '..');
+
+const NOT_A_REPRO = new Set(['run.mjs', 'harness.mjs']);
+
+const REPROS = readdirSync(here)
+  .filter((name) => name.endsWith('.mjs') && !NOT_A_REPRO.has(name))
+  .sort();
+
+let failed = 0;
+for (const name of REPROS) {
+  console.log(`${'='.repeat(72)}\n${name}\n${'='.repeat(72)}`);
+  const res = spawnSync(process.execPath, [join(here, name)], {
+    cwd: root,
+    stdio: 'inherit',
+  });
+  if (res.status !== 0) failed++;
+  console.log('');
+}
+
+console.log('='.repeat(72));
+if (failed === 0) {
+  console.log(`all ${REPROS.length} reproductions passed`);
+  process.exit(0);
+}
+console.log(`${failed} of ${REPROS.length} reproductions FAILED`);
+process.exit(1);

--- a/src/db/intent.mjs
+++ b/src/db/intent.mjs
@@ -25,12 +25,15 @@
 //     re-normalizing an already-written file (which is exactly what a
 //     replay does) yields zero requirements and the rewrite empties the
 //     record.
-//   * the DB insert happens BEFORE the file write, and a write that
-//     would drop a non-empty record to zero requirements is refused
+//   * the DB insert and the file write are all-or-nothing. The inserts
+//     run first (so a record the DB rejects never reaches the file) but
+//     the file write happens before COMMIT (so a failed write rolls the
+//     inserts back). Neither half can outlive the other, and a write
+//     that would drop a non-empty record to zero requirements is refused
 //     outright. Losing a committed intent is strictly worse than failing
 //     loudly.
 
-import { mkdir, writeFile, readFile } from 'node:fs/promises';
+import { mkdir, writeFile, readFile, rename, rm } from 'node:fs/promises';
 
 export const INTENTS_DIR = '.hedgehog/intents';
 
@@ -152,6 +155,27 @@ const prepareInsertIntentDependency = (db) =>
     VALUES (?, ?)
   `);
 
+// The INSERT statements themselves, with no transaction of their own, so
+// a caller that needs the file write inside the same transaction can
+// supply one. Every constraint that matters here — the intents PRIMARY
+// KEY, the requirements/intent_dependencies FOREIGN KEYs, the kind CHECK
+// — is immediate, not deferred, so a bad record fails on the offending
+// statement rather than at COMMIT. That's what lets addIntent below treat
+// "the inserts returned" as "the DB accepted this intent".
+function runIntentInserts(db, intent) {
+  const runInsertIntent = prepareInsertIntent(db);
+  const runInsertRequirement = prepareInsertRequirement(db);
+  const runInsertDependency = prepareInsertIntentDependency(db);
+
+  runInsertIntent.run(intent.id, intent.goal, intent.outcome, intent.priority);
+  for (const r of intent.requirements) {
+    runInsertRequirement.run(r.id, intent.id, r.kind, r.statement);
+  }
+  for (const dependsOnId of intent.depends_on) {
+    runInsertDependency.run(intent.id, dependsOnId);
+  }
+}
+
 // Writes a normalized intent's rows to `db` — one `intents` row, one
 // `requirements` row per rule/constraint/acceptance item, one
 // `intent_dependencies` row per depends_on entry — in one transaction,
@@ -159,19 +183,9 @@ const prepareInsertIntentDependency = (db) =>
 // replay reconstructs the derived DB from the permanent record and has
 // no business writing that record back out.
 export function insertIntentRows(db, intent) {
-  const runInsertIntent = prepareInsertIntent(db);
-  const runInsertRequirement = prepareInsertRequirement(db);
-  const runInsertDependency = prepareInsertIntentDependency(db);
-
   db.exec('BEGIN IMMEDIATE');
   try {
-    runInsertIntent.run(intent.id, intent.goal, intent.outcome, intent.priority);
-    for (const r of intent.requirements) {
-      runInsertRequirement.run(r.id, intent.id, r.kind, r.statement);
-    }
-    for (const dependsOnId of intent.depends_on) {
-      runInsertDependency.run(intent.id, dependsOnId);
-    }
+    runIntentInserts(db, intent);
     db.exec('COMMIT');
   } catch (err) {
     try {
@@ -236,29 +250,75 @@ export async function assertNonDestructiveWrite(intent, intentsDir = INTENTS_DIR
 
 // Writes the normalized intent to INTENTS_DIR/<id>.json, guarded against
 // emptying an existing record.
+//
+// Written to a sibling temp file and renamed into place: `rename(2)` is
+// atomic within a directory, so a crash or a full disk mid-write can
+// never leave a half-written intent behind. That matters more than usual
+// here, because assertNonDestructiveWrite refuses to overwrite a file it
+// can't parse — a truncated record would otherwise be its own dead end.
 export async function writeIntentFile(intent, intentsDir = INTENTS_DIR) {
   await assertNonDestructiveWrite(intent, intentsDir);
   await mkdir(intentsDir, { recursive: true });
-  await writeFile(intentFilePath(intent.id, intentsDir), JSON.stringify(intent, null, 2));
+
+  const finalPath = intentFilePath(intent.id, intentsDir);
+  const tempPath = `${finalPath}.tmp-${process.pid}`;
+  try {
+    await writeFile(tempPath, JSON.stringify(intent, null, 2));
+    await rename(tempPath, finalPath);
+  } catch (err) {
+    await rm(tempPath, { force: true }).catch(() => {});
+    throw err;
+  }
   return intent;
 }
 
 // Writes a normalized intent (see normalizeIntent) to `db` AND to
-// INTENTS_DIR/<id>.json.
+// INTENTS_DIR/<id>.json, atomically with respect to the DB: the file
+// write happens INSIDE the open transaction, immediately before COMMIT.
 //
-// Order matters: the destructive-write guard runs first (it's read-only,
-// so a refusal costs nothing), then the DB transaction, then the file.
-// The old order — file first, "belt and suspenders" against a failed DB
-// write — meant every failed insert still rewrote the permanent record,
-// which is the more expensive of the two failures by a wide margin. A DB
-// row without its file is recoverable (`intent add` again); a file
-// emptied under a passing command is not.
+// The ordering is load-bearing in both directions:
+//
+//   * The inserts run first, so a record the DB will reject (duplicate
+//     id, unknown depends_on) never reaches the file. The original bug
+//     was the opposite order — write, then insert — which meant every
+//     failed insert had already rewritten the permanent record, and
+//     because normalizeIntent didn't round-trip, rewritten to empty.
+//   * The write happens before COMMIT, so a write that fails rolls the
+//     inserts back. Otherwise the mirror-image failure appears: the
+//     intent exists only in the derived, gitignored DB, the command
+//     reports failure, a retry hits the PRIMARY KEY constraint, and a
+//     rebuild can't recover it because it was never in the permanent
+//     record. Both halves land or neither does.
+//
+// The only remaining failure — COMMIT itself failing after the file
+// landed — leaves the file without the row, which is the recoverable
+// direction: the file IS the source of truth, and `db rebuild` replays
+// it. A retry is fine too, since re-writing an identical record passes
+// the guard.
+//
+// This does hold the write transaction open across one small file write.
+// That's a sub-millisecond window against a 10s busy_timeout, and it buys
+// the invariant that the DB never holds an intent the permanent record
+// doesn't.
 export async function addIntent(db, record, { intentsDir = INTENTS_DIR } = {}) {
   const intent = normalizeIntent(record);
 
+  // Read-only, so a refusal costs nothing and needn't open a transaction.
   await assertNonDestructiveWrite(intent, intentsDir);
-  insertIntentRows(db, intent);
-  await writeIntentFile(intent, intentsDir);
+
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    runIntentInserts(db, intent);
+    await writeIntentFile(intent, intentsDir);
+    db.exec('COMMIT');
+  } catch (err) {
+    try {
+      db.exec('ROLLBACK');
+    } catch {
+      // Rollback failing must not mask the original error.
+    }
+    throw err;
+  }
 
   return intent;
 }

--- a/src/db/intent.mjs
+++ b/src/db/intent.mjs
@@ -15,8 +15,22 @@
 // INTENTS_DIR — the DB is a derived artifact (rebuildable via `hedgehog db
 // rebuild`), so the intent itself has to survive independently of it, as
 // plain text a PR can review and a fresh clone can replay.
+//
+// Because that file IS the permanent record, two properties matter more
+// than they look:
+//
+//   * `normalizeIntent` must round-trip its own output. It emits
+//     `requirements`, so it has to read `requirements` as well as the
+//     `rules`/`constraints`/`acceptance` input arrays — otherwise
+//     re-normalizing an already-written file (which is exactly what a
+//     replay does) yields zero requirements and the rewrite empties the
+//     record.
+//   * the DB insert happens BEFORE the file write, and a write that
+//     would drop a non-empty record to zero requirements is refused
+//     outright. Losing a committed intent is strictly worse than failing
+//     loudly.
 
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, writeFile, readFile } from 'node:fs/promises';
 
 export const INTENTS_DIR = '.hedgehog/intents';
 
@@ -26,13 +40,76 @@ const REQUIREMENT_KIND_FIELDS = {
   acceptance: 'acceptance',
 };
 
+const REQUIREMENT_KINDS = new Set(Object.keys(REQUIREMENT_KIND_FIELDS));
+
 function requirementId(intentId, kind, index) {
   return `${intentId}-${kind}-${index + 1}`.toUpperCase();
 }
 
-// Normalizes either source (parsed JSON file, or flags already collected
-// into the same shape) into the exact rows to insert. Throws on missing
-// required fields — id/goal/outcome are NOT NULL in the schema.
+export function intentFilePath(intentId, intentsDir = INTENTS_DIR) {
+  return `${intentsDir}/${intentId}.json`;
+}
+
+// Collects requirements from BOTH shapes this function can be handed:
+// the input arrays (`rules`/`constraints`/`acceptance`, from CLI flags or
+// a hand-written JSON file) and the already-normalized `requirements`
+// array this same function emits. Reading only the former is what made
+// re-normalizing a written file destructive.
+//
+// Ids are preserved when the entry carries one, generated per-kind by
+// position otherwise, and deduplicated by id so a record holding both
+// shapes doesn't double-count.
+function collectRequirements(record, intentId) {
+  const requirements = [];
+  const seenIds = new Set();
+  const perKindCount = { rule: 0, constraint: 0, acceptance: 0 };
+
+  const push = (kind, statement, explicitId) => {
+    if (!REQUIREMENT_KINDS.has(kind)) {
+      throw new Error(
+        `intent "${intentId}" has a requirement of unknown kind "${kind}" ` +
+          `(expected one of: ${[...REQUIREMENT_KINDS].join(', ')})`,
+      );
+    }
+    if (typeof statement !== 'string' || statement.trim() === '') {
+      throw new Error(`intent "${intentId}" has a ${kind} requirement with no statement`);
+    }
+    const id = explicitId ?? requirementId(intentId, kind, perKindCount[kind]);
+    perKindCount[kind]++;
+    if (seenIds.has(id)) return;
+    seenIds.add(id);
+    requirements.push({ id, kind, statement });
+  };
+
+  for (const [kind, field] of Object.entries(REQUIREMENT_KIND_FIELDS)) {
+    const statements = record[field] ?? [];
+    if (!Array.isArray(statements)) {
+      throw new Error(`intent "${intentId}" field "${field}" must be an array`);
+    }
+    for (const statement of statements) push(kind, statement);
+  }
+
+  const written = record.requirements ?? [];
+  if (!Array.isArray(written)) {
+    throw new Error(`intent "${intentId}" field "requirements" must be an array`);
+  }
+  for (const entry of written) {
+    if (entry === null || typeof entry !== 'object') {
+      throw new Error(`intent "${intentId}" has a malformed requirements entry`);
+    }
+    push(entry.kind, entry.statement, entry.id);
+  }
+
+  return requirements;
+}
+
+// Normalizes any accepted source (parsed JSON file — input shape or the
+// written output shape — or flags already collected into the same shape)
+// into the exact rows to insert. Throws on missing required fields —
+// id/goal/outcome are NOT NULL in the schema.
+//
+// Idempotent: normalizeIntent(normalizeIntent(x)) deep-equals
+// normalizeIntent(x). The replay path depends on that.
 export function normalizeIntent(record) {
   const { id, goal, outcome, priority, depends_on: dependsOn } = record;
 
@@ -40,13 +117,7 @@ export function normalizeIntent(record) {
   if (!goal) throw new Error('intent requires a goal');
   if (!outcome) throw new Error('intent requires an outcome');
 
-  const requirements = [];
-  for (const [kind, field] of Object.entries(REQUIREMENT_KIND_FIELDS)) {
-    const statements = record[field] ?? [];
-    statements.forEach((statement, index) => {
-      requirements.push({ id: requirementId(id, kind, index), kind, statement });
-    });
-  }
+  const requirements = collectRequirements(record, id);
 
   const dependsOnIds = dependsOn ?? [];
   if (dependsOnIds.includes(id)) {
@@ -63,39 +134,34 @@ export function normalizeIntent(record) {
   };
 }
 
-const insertIntent = (db) =>
+const prepareInsertIntent = (db) =>
   db.prepare(`
     INSERT INTO intents (id, goal, outcome, priority)
     VALUES (?, ?, ?, ?)
   `);
 
-const insertRequirement = (db) =>
+const prepareInsertRequirement = (db) =>
   db.prepare(`
     INSERT INTO requirements (id, intent_id, kind, statement)
     VALUES (?, ?, ?, ?)
   `);
 
-const insertIntentDependency = (db) =>
+const prepareInsertIntentDependency = (db) =>
   db.prepare(`
     INSERT INTO intent_dependencies (intent_id, depends_on_intent_id)
     VALUES (?, ?)
   `);
 
-// Writes a normalized intent (see normalizeIntent) to `db`: one `intents`
-// row, one `requirements` row per rule/constraint/acceptance item, one
-// `intent_dependencies` row per depends_on entry. All in one transaction.
-// Also writes the same normalized shape to INTENTS_DIR/<id>.json, ahead of
-// the DB transaction, so the intent is recoverable even if the DB write
-// fails after — belt and suspenders, not a two-phase commit.
-export async function addIntent(db, record) {
-  const intent = normalizeIntent(record);
-
-  await mkdir(INTENTS_DIR, { recursive: true });
-  await writeFile(`${INTENTS_DIR}/${intent.id}.json`, JSON.stringify(intent, null, 2));
-
-  const runInsertIntent = insertIntent(db);
-  const runInsertRequirement = insertRequirement(db);
-  const runInsertDependency = insertIntentDependency(db);
+// Writes a normalized intent's rows to `db` — one `intents` row, one
+// `requirements` row per rule/constraint/acceptance item, one
+// `intent_dependencies` row per depends_on entry — in one transaction,
+// and touches no files. This is the whole of what a rebuild needs: a
+// replay reconstructs the derived DB from the permanent record and has
+// no business writing that record back out.
+export function insertIntentRows(db, intent) {
+  const runInsertIntent = prepareInsertIntent(db);
+  const runInsertRequirement = prepareInsertRequirement(db);
+  const runInsertDependency = prepareInsertIntentDependency(db);
 
   db.exec('BEGIN IMMEDIATE');
   try {
@@ -115,6 +181,84 @@ export async function addIntent(db, record) {
     }
     throw err;
   }
+
+  return intent;
+}
+
+// Reads the intent file already on disk, if any. Returns null when the
+// file is absent; an unparseable file is also treated as "nothing to
+// protect" only for the count — the guard below still refuses to touch
+// it, since silently replacing a file we can't read is the same class of
+// mistake as emptying one we can.
+async function readExistingIntentFile(intentId, intentsDir) {
+  let text;
+  try {
+    text = await readFile(intentFilePath(intentId, intentsDir), 'utf8');
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return null;
+    throw err;
+  }
+  try {
+    return { text, record: JSON.parse(text) };
+  } catch {
+    return { text, record: null };
+  }
+}
+
+// The safety net. An intent file is a committed, permanent record; a
+// write that would take it from N requirements to zero is data loss, not
+// an update. Refuse it and say so, rather than leave the caller to
+// discover the loss in a later `git diff`.
+export async function assertNonDestructiveWrite(intent, intentsDir = INTENTS_DIR) {
+  const existing = await readExistingIntentFile(intent.id, intentsDir);
+  if (existing === null) return;
+
+  if (existing.record === null) {
+    throw new Error(
+      `refusing to overwrite ${intentFilePath(intent.id, intentsDir)}: ` +
+        `the existing file is not valid JSON, so it can't be checked for data loss. ` +
+        `Inspect or remove it by hand first.`,
+    );
+  }
+
+  const existingCount = Array.isArray(existing.record.requirements)
+    ? existing.record.requirements.length
+    : 0;
+  if (existingCount > 0 && intent.requirements.length === 0) {
+    throw new Error(
+      `refusing to overwrite ${intentFilePath(intent.id, intentsDir)}: ` +
+        `it holds ${existingCount} requirement(s) and the new record has none. ` +
+        `An intent file is the permanent record — emptying it would lose committed planning. ` +
+        `If this is intentional, delete the file explicitly first.`,
+    );
+  }
+}
+
+// Writes the normalized intent to INTENTS_DIR/<id>.json, guarded against
+// emptying an existing record.
+export async function writeIntentFile(intent, intentsDir = INTENTS_DIR) {
+  await assertNonDestructiveWrite(intent, intentsDir);
+  await mkdir(intentsDir, { recursive: true });
+  await writeFile(intentFilePath(intent.id, intentsDir), JSON.stringify(intent, null, 2));
+  return intent;
+}
+
+// Writes a normalized intent (see normalizeIntent) to `db` AND to
+// INTENTS_DIR/<id>.json.
+//
+// Order matters: the destructive-write guard runs first (it's read-only,
+// so a refusal costs nothing), then the DB transaction, then the file.
+// The old order — file first, "belt and suspenders" against a failed DB
+// write — meant every failed insert still rewrote the permanent record,
+// which is the more expensive of the two failures by a wide margin. A DB
+// row without its file is recoverable (`intent add` again); a file
+// emptied under a passing command is not.
+export async function addIntent(db, record, { intentsDir = INTENTS_DIR } = {}) {
+  const intent = normalizeIntent(record);
+
+  await assertNonDestructiveWrite(intent, intentsDir);
+  insertIntentRows(db, intent);
+  await writeIntentFile(intent, intentsDir);
 
   return intent;
 }

--- a/src/db/rebuild.mjs
+++ b/src/db/rebuild.mjs
@@ -2,22 +2,31 @@
 // source-of-truth files, for a fresh clone (no `.hedgehog/hedgehog.db`)
 // or after suspected corruption. The DB itself is a derived artifact:
 // everything it holds is either replayable from `.hedgehog/intents/*.json`
-// (via the same `addIntent`/`planTasks` path `intent add`/`plan` already
-// use) or recoverable from git history (which tasks' commits already
-// landed). What isn't recoverable — `verifications.output`, the ephemeral
+// (via the same normalize/insert path `intent add`/`plan` already use) or
+// recoverable from git history (which tasks' commits already landed).
+// What isn't recoverable — `verifications.output`, the ephemeral
 // diagnostics of a run that already passed — is an accepted loss; this
 // only reconciles `tasks.status`.
+//
+// A rebuild READS the permanent record. It never writes it: replay goes
+// through `insertIntentRows`, not `addIntent`, so no intent file is
+// touched even on a failed run. That matters because this path also
+// fires automatically when the DB is missing (bin/cli.mjs#ensureDb) — a
+// user who never typed `db rebuild` must not be able to lose planning to
+// it.
 
 import { readdir, readFile } from 'node:fs/promises';
 import { execSync } from 'node:child_process';
 import { applySchema } from './schema.mjs';
-import { addIntent, INTENTS_DIR } from './intent.mjs';
+import { normalizeIntent, insertIntentRows, INTENTS_DIR } from './intent.mjs';
 import { planTasks } from './plan.mjs';
 import { loadCore } from './core.mjs';
 
-// Alphabetical by filename so replay order is deterministic across
-// machines and runs — intents have no other natural ordering (priority
-// only matters once they're compiled into tasks by planTasks).
+// Alphabetical by filename, purely to make the *tie-break* deterministic
+// across machines and runs. It is NOT the replay order — see
+// orderIntentsForReplay: `intent_dependencies` rows have a FOREIGN KEY
+// onto `intents`, so an intent has to be inserted after everything it
+// depends_on regardless of what its filename sorts as.
 async function loadIntentFiles(intentsDir) {
   let entries;
   try {
@@ -32,20 +41,95 @@ function intentExists(db, id) {
   return db.prepare('SELECT 1 FROM intents WHERE id = ?').get(id) !== undefined;
 }
 
-// addIntent's INSERT is unconditional (an intent id is never re-added
-// through `intent add` in normal use), so rebuild — the one caller that
-// must also tolerate an already-populated DB, per "re-derive from
-// source-of-truth after suspected corruption" — skips any intent file
-// whose id is already present rather than letting the UNIQUE constraint
-// fail the whole run.
+// Topological sort over `depends_on`, tie-broken by the file order above
+// so two runs over the same directory always replay identically.
+//
+// An id that is depended on but has neither a file nor an existing row is
+// named outright rather than left to surface as "FOREIGN KEY constraint
+// failed" — the same goes for a genuine cycle, which no order can
+// satisfy.
+function orderIntentsForReplay(records, isSatisfied) {
+  const byId = new Map(records.map((r) => [r.intent.id, r]));
+
+  const ordered = [];
+  const visited = new Set();
+  const visiting = [];
+
+  function visit(id, requiredBy) {
+    if (visited.has(id)) return;
+
+    const cycleStart = visiting.indexOf(id);
+    if (cycleStart !== -1) {
+      const cycle = [...visiting.slice(cycleStart), id].join(' -> ');
+      throw new Error(
+        `intent depends_on cycle detected: ${cycle}. ` +
+          `Fix the depends_on lists in ${INTENTS_DIR} — no replay order can satisfy a cycle.`,
+      );
+    }
+
+    const entry = byId.get(id);
+    if (!entry) {
+      // Not a file in this directory. Fine if the DB already has it
+      // (rebuild tolerates an already-populated DB); otherwise the edge
+      // points at nothing and would fail the FOREIGN KEY.
+      if (isSatisfied(id)) return;
+      throw new Error(
+        `intent "${requiredBy}" depends_on "${id}", which has no intent file in ` +
+          `${INTENTS_DIR} and no row in the build graph. ` +
+          `Restore ${id}.json or remove it from "${requiredBy}"'s depends_on.`,
+      );
+    }
+
+    visiting.push(id);
+    for (const depId of entry.intent.depends_on) visit(depId, id);
+    visiting.pop();
+
+    visited.add(id);
+    ordered.push(entry);
+  }
+
+  for (const record of records) visit(record.intent.id, null);
+
+  return ordered;
+}
+
+// Reads every intent file, normalizes it, orders the set by depends_on,
+// and inserts the rows. Read-only with respect to the files themselves.
+//
+// The insert is unconditional (an intent id is never re-added through
+// `intent add` in normal use), so rebuild — the one caller that must also
+// tolerate an already-populated DB, per "re-derive from source-of-truth
+// after suspected corruption" — skips any intent whose id is already
+// present rather than letting the UNIQUE constraint fail the whole run.
+//
+// Ordering is resolved for the whole set BEFORE any row is written, so a
+// cycle or a dangling depends_on fails the run without having half-built
+// the graph.
 async function replayIntents(db, intentsDir) {
   const files = await loadIntentFiles(intentsDir);
-  let count = 0;
+
+  const records = [];
   for (const file of files) {
-    const text = await readFile(`${intentsDir}/${file}`, 'utf8');
-    const record = JSON.parse(text);
-    if (intentExists(db, record.id)) continue;
-    await addIntent(db, record);
+    const path = `${intentsDir}/${file}`;
+    let parsed;
+    try {
+      parsed = JSON.parse(await readFile(path, 'utf8'));
+    } catch (err) {
+      throw new Error(`could not read intent file ${path}: ${err.message}`);
+    }
+    try {
+      records.push({ file, intent: normalizeIntent(parsed) });
+    } catch (err) {
+      throw new Error(`invalid intent file ${path}: ${err.message}`);
+    }
+  }
+
+  const ordered = orderIntentsForReplay(records, (id) => intentExists(db, id));
+
+  let count = 0;
+  for (const { intent } of ordered) {
+    if (intentExists(db, intent.id)) continue;
+    insertIntentRows(db, intent);
     count++;
   }
   return count;
@@ -82,7 +166,7 @@ function markCompletedTasks(db, commitSubjects) {
 }
 
 // Rebuilds `db` from scratch: schema, then every committed intent
-// replayed through addIntent, then planTasks to re-derive tasks +
+// replayed in dependency order, then planTasks to re-derive tasks +
 // dependencies, then git history to reconcile which tasks already
 // completed. Returns a summary for the CLI to print.
 export async function rebuildDb(db, { corePath, intentsDir = INTENTS_DIR } = {}) {


### PR DESCRIPTION
`hedgehog db rebuild` destroys the committed intent files it is supposed to replay. On the project where this first surfaced, one module lost 10 requirements and another lost 22 in a single invocation. Because the rebuild fires **automatically** when the DB is missing but `.hedgehog/intents/` exists, a user can lose their planning record without ever typing the command.

Both causes are confirmed in the current code, with a reproduction for each.

## Cause 1 — replay ignores `depends_on`

`src/db/rebuild.mjs` sorts intents alphabetically and replays in that order:

```js
return entries.filter((name) => name.endsWith('.json')).sort();
```

`intent_dependencies.depends_on_intent_id` is `REFERENCES intents(id)` (`schema.mjs:27`) and `PRAGMA foreign_keys = ON` is set in both `schema.mjs` and `init.mjs`, so replaying an intent before its dependency throws `FOREIGN KEY constraint failed`.

## Cause 2 — write-before-insert, plus a normalize asymmetry

`src/db/intent.mjs` builds `requirements` from the *input* fields while the returned record carries the *output* field:

```js
const requirements = [];
for (const [kind, field] of Object.entries(REQUIREMENT_KIND_FIELDS)) {
  const statements = record[field] ?? [];   // rules / constraints / acceptance
```

…and writes the file before the insert:

```js
await writeFile(`${INTENTS_DIR}/${intent.id}.json`, JSON.stringify(intent, null, 2));
...
db.exec('BEGIN IMMEDIATE');
```

So re-normalizing an already-written file yields zero requirements, and the file is rewritten before — and regardless of — the insert.

## Two details that make it worse

- **The causes compound.** The FK crash in cause 1 happens *after* the current file has already been rewritten, so a rebuild that throws still leaves emptied records behind. That is why the original loss was total on a single attempt.
- **`rebuildDb`'s `intentsDir` option was never honoured on the write side** — `addIntent` hard-coded `INTENTS_DIR`, so a rebuild pointed at one directory could rewrite another. Removing writes from the replay path retires this.

## The fix

**`fix(db): stop intent writes from emptying the committed record`**
- `normalizeIntent` now reads `requirements` alongside the input arrays (preserving ids, deduplicating), so `normalize(normalize(x)) === normalize(x)`.
- `addIntent` inserts first, writes second.
- New `assertNonDestructiveWrite` refuses to overwrite an intent file holding N > 0 requirements with one holding none, and refuses to overwrite a file it cannot parse. It runs before the insert, so a refusal leaves nothing half-done.
- The DB insert is split out as `insertIntentRows` — a file-free path.

**`fix(db): replay intents in dependency order and never rewrite them`**
- Topological sort over `depends_on`, tie-broken by filename; the whole order resolves before any row is written.
- Cycles raise `intent depends_on cycle detected: alpha -> gamma -> beta -> alpha`.
- A `depends_on` naming neither a file nor an existing row is reported explicitly instead of surfacing as an FK error.
- Replay calls `insertIntentRows`, so **the rebuild path never writes an intent file at all**. A rebuild reads the permanent record; it does not rewrite it.

## Reproduction

`node repro/run.mjs` — 4 reproductions, `node:sqlite`, plain assertions, each in its own `mkdtemp` (no test framework is available in this repo). Fixtures use `automation → card → list → board`, where alphabetical order contradicts dependency order, with `card` carrying 22 requirements and `list` 10 — the real loss, reproduced.

Before, all 4 fail:

```
FAIL  2. every intent JSON file is byte-identical after the rebuild
      c-card.json: sha 229f65636910 -> 377815014018, 2715B -> 161B,
        requirements 22 -> 0  <-- PERMANENT RECORD EMPTIED
FAIL  1. rebuild completes without throwing
      rebuild threw: FOREIGN KEY constraint failed
```

After, all 4 pass, with sha256 per file plus `git status --porcelain .hedgehog/intents` as an independent witness. Also verified end-to-end through the real CLI in a throwaway repo, including the automatic rebuild that `ensureDb` triggers when the DB is missing: sha256 of all three intent files unchanged, `git status` clean. `node scripts/check.mjs` passes.

Commit 1 was verified green on its own with `rebuild.mjs` reverted, which isolates cause 2 as fully addressed by the `intent.mjs` change alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
