### PR TITLE
feat(cli): add show, retry and targeted claim, so recovery stops needing raw SQL

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -334,7 +334,10 @@ ${bold('Usage')}
   npx @skyf0xx/hedgehog intent add [flags]        add an intent (rules/requirements/dependencies)
   npx @skyf0xx/hedgehog intent add --file <path>  add an intent from a JSON file
   npx @skyf0xx/hedgehog next                      print the task packet for one ready task
+  npx @skyf0xx/hedgehog show <task-id>            print the task packet for any task, at any status
   npx @skyf0xx/hedgehog claim --owner <owner> [--count <n>]   atomically claim up to n ready tasks
+  npx @skyf0xx/hedgehog claim <task-id> --owner <owner>   claim one specific task (breaks a starvation tie)
+  npx @skyf0xx/hedgehog retry <task-id>           return a blocked task to planned, so it can be rebuilt
   npx @skyf0xx/hedgehog release <task-id> --owner <owner>   hand a claimed task back to ready
   npx @skyf0xx/hedgehog renew <task-id> --owner <owner> [--minutes <n>]   extend a held lease
   npx @skyf0xx/hedgehog verify <task-id> --owner <owner>   run scope + verify checks, commit on pass
@@ -785,8 +788,11 @@ async function nextCommand() {
         const reason = BLOCKED_REASON_LABELS[task.blocked_reason] ?? task.blocked_reason;
         console.error(`  ${red('✗')} ${bold(task.id)}   ${task.layer}   ${dim(reason)}`);
       }
+      // `verify` refuses anything that isn't `building` and leased to
+      // the caller, so a blocked task has to go back through the queue
+      // — retry, claim, then verify — rather than straight to verify.
       console.error(
-        `\nFix the work, then re-run ${bold('hedgehog verify <task-id>')}.\n`,
+        `\nFix the work, then ${bold('hedgehog retry <task-id>')} and claim it again.\n`,
       );
       process.exitCode = 1;
       return;
@@ -857,19 +863,50 @@ async function verifyCommand(args) {
   }
 }
 
-// `hedgehog claim --owner <owner> [--count <n>]` — atomically claims up to
-// `count` mutually non-conflicting ready tasks (claimTasks's fan-out, item
-// 13) and prints each one's packet-level summary, plus which owner now
-// holds them.
+// Prints the full task packet for each task in `tasks`, read back from
+// the graph after the claim landed. Claiming moves a task to `building`,
+// which takes it out of `hedgehog next`'s candidate set — so if claim
+// doesn't print the packet here, the STATUS/ALLOWED SCOPE/VERIFICATION an
+// agent is supposed to be dispatched with is no longer reachable from any
+// command. (`hedgehog show <task-id>` reprints it later.)
+function printPackets(tasks) {
+  const db = openDb();
+  try {
+    for (const task of tasks) {
+      const packet = taskPacket(db, task.id);
+      if (!packet) continue;
+      console.log();
+      console.log(formatPacket(packet, taskStatusLine(packet.task)));
+    }
+  } finally {
+    db.close();
+  }
+  console.log();
+}
+
+// `hedgehog claim [<task-id>] --owner <owner> [--count <n>]` — atomically
+// claims up to `count` mutually non-conflicting ready tasks (claimTasks's
+// fan-out, item 13), or the one named task, and prints each claimed
+// task's full packet plus which owner now holds it.
 async function claimCommand(args) {
   await ensureDb();
 
+  // A leading non-flag argument names one specific task; without it this
+  // is the fan-out claim it has always been.
+  const taskId = args[0] && !args[0].startsWith('--') ? args[0] : undefined;
   const ownerIdx = args.indexOf('--owner');
   const owner = ownerIdx !== -1 ? args[ownerIdx + 1] : undefined;
   const countIdx = args.indexOf('--count');
   const count = countIdx !== -1 ? Number(args[countIdx + 1]) : 1;
   if (!owner) {
-    console.error(`${red('Usage:')} hedgehog claim --owner <owner> [--count <n>]\n`);
+    console.error(
+      `${red('Usage:')} hedgehog claim --owner <owner> [--count <n>]\n   or: hedgehog claim <task-id> --owner <owner>\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (taskId && countIdx !== -1) {
+    console.error(`${red('--count cannot be combined with a task id')} — a targeted claim takes exactly one task.\n`);
     process.exitCode = 1;
     return;
   }
@@ -877,6 +914,13 @@ async function claimCommand(args) {
   if (!(await exists(DB_PATH))) {
     console.error(`${red('No build graph found.')} Run ${bold('hedgehog db init')} first.\n`);
     process.exitCode = 1;
+    return;
+  }
+
+  printDbTarget();
+
+  if (taskId) {
+    await claimOneCommand(taskId, owner);
     return;
   }
 
@@ -902,6 +946,150 @@ async function claimCommand(args) {
     if (claimed.length > 1) console.log(`  ${bold(task.id)}`);
     console.log(`  ${dim('expires')}  ${task.lease_expires_at}`);
   }
+  printPackets(claimed);
+}
+
+// The targeted half of `claim`: one named task, or a non-zero exit
+// naming which precondition refused it. Never exits 0 without having
+// claimed something — an operator breaking a starvation tie has to be
+// able to tell "claimed" from "matched nothing" by exit code alone.
+async function claimOneCommand(taskId, owner) {
+  const db = openDb();
+  let result;
+  try {
+    result = claimTask(db, taskId, { owner });
+  } finally {
+    db.close();
+  }
+
+  if (result.claimed) {
+    console.log(`${green(bold('Claimed.'))} Task ${bold(taskId)} leased to ${bold(owner)}.`);
+    console.log(`  ${dim('expires')}  ${result.task.lease_expires_at}`);
+    printPackets([result.task]);
+    return;
+  }
+
+  process.exitCode = 1;
+
+  if (result.reason === 'no_such_task') {
+    console.error(`${red('No such task:')} ${bold(taskId)}${dim(` (in ${dbAbsPath()})`)}\n`);
+    return;
+  }
+  if (result.reason === 'not_claimable') {
+    const held = result.task.lease_owner ? `, leased to ${result.task.lease_owner}` : '';
+    console.error(
+      `${red('Not claimable.')} Task ${bold(taskId)} is ${bold(result.task.status)}${held}.\n` +
+        (result.task.status === 'blocked'
+          ? `\nReturn it to the queue first: ${bold(`hedgehog retry ${taskId}`)}\n`
+          : '\n'),
+    );
+    return;
+  }
+  if (result.reason === 'incomplete_dependencies') {
+    console.error(`${red('Not claimable.')} Task ${bold(taskId)} is waiting on:\n`);
+    for (const dep of result.incomplete) {
+      console.error(`  ${red('✗')} ${bold(dep.id)}   ${dep.layer}   ${dep.status}`);
+    }
+    console.error();
+    return;
+  }
+  if (result.reason === 'conflict') {
+    console.error(`${red('Not claimable.')} Task ${bold(taskId)} conflicts with work in flight:\n`);
+    for (const { task, kind } of result.conflicting) {
+      console.error(`  ${red('✗')} ${bold(task.id)}   ${task.status}   ${dim(`(${kind})`)}`);
+    }
+    console.error(
+      `\nWait for those to finish, or ${bold('hedgehog release')} them, then claim again.\n`,
+    );
+    return;
+  }
+  console.error(`${red('Not claimed.')} A concurrent claim took ${bold(taskId)} first.\n`);
+}
+
+// `hedgehog retry <task-id>` — the transition out of `blocked`, for any
+// blocked_reason. A failed verification and a scope violation are the
+// loop's normal failure cases, but `release` only accepts `building` and
+// `verify` only accepts a task leased to the caller, so before this
+// command a blocked task had no CLI path back into the queue at all.
+async function retryCommand(args) {
+  await ensureDb();
+
+  const taskId = args[0] && !args[0].startsWith('--') ? args[0] : undefined;
+  if (!taskId) {
+    console.error(`${red('Usage:')} hedgehog retry <task-id> [--owner <owner>]\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!(await exists(DB_PATH))) {
+    console.error(`${red('No build graph found.')} Run ${bold('hedgehog db init')} first.\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  printDbTarget();
+
+  const db = openDb();
+  let result;
+  try {
+    result = retryTask(db, taskId);
+  } finally {
+    db.close();
+  }
+
+  if (!result.retried) {
+    process.exitCode = 1;
+    if (result.reason === 'no_such_task') {
+      console.error(`${red('No such task:')} ${bold(taskId)}${dim(` (in ${dbAbsPath()})`)}\n`);
+      return;
+    }
+    console.error(
+      `${red('Not retried.')} Task ${bold(taskId)} is ${bold(result.task.status)}, not ${bold('blocked')}.\n`,
+    );
+    return;
+  }
+
+  const reason = BLOCKED_REASON_LABELS[result.from] ?? result.from;
+  console.log(
+    `${green(bold('Retried.'))} Task ${bold(taskId)} is back to ${bold('planned')} ${dim(`(was blocked: ${reason})`)}`,
+  );
+  console.log(`  ${dim('claim it with')}  hedgehog claim ${taskId} --owner <owner>`);
+}
+
+// `hedgehog show <task-id>` — the same packet `next` prints, for a task
+// named by id whatever its status. Read-only: claims nothing, changes
+// nothing.
+async function showCommand(args) {
+  await ensureDb();
+
+  const taskId = args[0];
+  if (!taskId) {
+    console.error(`${red('Usage:')} hedgehog show <task-id>\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!(await exists(DB_PATH))) {
+    console.error(`${red('No build graph found.')} Run ${bold('hedgehog db init')} first.\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const db = openDb();
+  let packet;
+  try {
+    packet = taskPacket(db, taskId);
+  } finally {
+    db.close();
+  }
+
+  if (!packet) {
+    console.error(`${red('No such task:')} ${bold(taskId)}${dim(` (in ${dbAbsPath()})`)}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(formatPacket(packet, taskStatusLine(packet.task)));
 }
 
 // `hedgehog release <task-id> --owner <owner>` — hands a claimed task
@@ -924,6 +1112,8 @@ async function releaseCommand(args) {
     process.exitCode = 1;
     return;
   }
+
+  printDbTarget();
 
   const db = openDb();
   let result;
@@ -975,6 +1165,8 @@ async function renewCommand(args) {
     return;
   }
 
+  printDbTarget();
+
   const db = openDb();
   let result;
   try {
@@ -1009,8 +1201,6 @@ async function statusCommand() {
     return;
   }
 
-  printDbTarget();
-
   const db = openDb();
   let result;
   try {
@@ -1033,8 +1223,6 @@ async function readyCommand() {
     process.exitCode = 1;
     return;
   }
-
-  printDbTarget();
 
   const db = openDb();
   let result;
@@ -1402,6 +1590,16 @@ async function main() {
 
   if (cmd === 'claim') {
     await claimCommand(args.slice(1));
+    return;
+  }
+
+  if (cmd === 'show') {
+    await showCommand(args.slice(1));
+    return;
+  }
+
+  if (cmd === 'retry') {
+    await retryCommand(args.slice(1));
     return;
   }
 

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -17,13 +17,26 @@ import { constants } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, relative, resolve } from 'node:path';
 import { spawn } from 'node:child_process';
-import { dbInit, DB_PATH, openDb } from '../src/db/init.mjs';
+import { dbInit, DB_PATH, dbAbsPath, openDb } from '../src/db/init.mjs';
 import { loadCore } from '../src/db/core.mjs';
 import { planTasks } from '../src/db/plan.mjs';
 import { addIntent, INTENTS_DIR } from '../src/db/intent.mjs';
-import { nextTask, formatNext, stalledTasks } from '../src/db/next.mjs';
+import {
+  nextTask,
+  formatNext,
+  formatPacket,
+  stalledTasks,
+  taskPacket,
+  taskStatusLine,
+} from '../src/db/next.mjs';
 import { verifyTask } from '../src/db/verify.mjs';
-import { claimTasks, releaseTask, renewLease } from '../src/db/claim.mjs';
+import {
+  claimTasks,
+  claimTask,
+  releaseTask,
+  renewLease,
+  retryTask,
+} from '../src/db/claim.mjs';
 import { readyTasks, formatReady } from '../src/db/ready.mjs';
 import { graphStatus, formatStatus } from '../src/db/status.mjs';
 import { whyPath, formatWhy } from '../src/db/why.mjs';
@@ -187,6 +200,17 @@ const exists = (p) =>
     () => false,
   );
 
+// Printed by every command that writes to the build graph, before it
+// writes. DB_PATH is relative (`.hedgehog/hedgehog.db`), so which
+// database a command actually opens depends entirely on the directory it
+// was run from — a recovery command run one directory up silently opens
+// (or creates) a different database, matches nothing, and reports
+// success. Naming the absolute path on every write makes that visible in
+// the output instead of only in the outcome.
+function printDbTarget() {
+  console.log(`  ${dim('db')}      ${dbAbsPath()}`);
+}
+
 // Runs once at the top of every command that needs the build graph. A
 // fresh clone has no `.hedgehog/hedgehog.db` (it's a derived artifact,
 // not committed) but does have `.hedgehog/intents/*.json` — the committed
@@ -326,6 +350,11 @@ ${bold('Usage')}
 
 Available cores: ${cores.join(', ')}
 Available hosts: ${availableHosts().join(', ')} (default: ${DEFAULT_HOST})
+
+Every command that writes to the build graph prints the absolute path of
+the database it opened, and exits non-zero when it matched no task —
+which database a relative path resolves to depends on the directory you
+ran from.
 
 After it runs, commit the payload, open your coding agent, and describe
 what you want to build — the planner agent runs planning intake, then
@@ -520,6 +549,7 @@ async function dbRebuildCommand() {
     return;
   }
 
+  printDbTarget();
   await dbInit(DB_PATH);
   const db = openDb();
   let result;
@@ -547,6 +577,7 @@ async function dbCommand(args) {
     process.exitCode = 1;
     return;
   }
+  printDbTarget();
   const { created, path } = await dbInit(DB_PATH);
   console.log(
     created
@@ -588,6 +619,7 @@ async function planCommand() {
     return;
   }
 
+  printDbTarget();
   const core = await loadCore(corePath);
   const db = openDb();
   let result;
@@ -707,6 +739,7 @@ async function intentCommand(args) {
     return;
   }
 
+  printDbTarget();
   const db = openDb();
   let intent;
   try {
@@ -783,6 +816,7 @@ async function verifyCommand(args) {
     return;
   }
 
+  printDbTarget();
   const db = openDb();
   let result;
   try {
@@ -900,8 +934,19 @@ async function releaseCommand(args) {
   }
 
   if (!result.released) {
-    console.error(`${red('Not released.')} Task ${bold(taskId)} is not leased to ${bold(owner)} as ${bold('building')}.\n`);
     process.exitCode = 1;
+    if (result.reason === 'no_such_task') {
+      console.error(`${red('No such task:')} ${bold(taskId)}${dim(` (in ${dbAbsPath()})`)}\n`);
+      return;
+    }
+    console.error(
+      `${red('Not released.')} Task ${bold(taskId)} is ${bold(result.task.status)}${
+        result.task.lease_owner ? `, leased to ${bold(result.task.lease_owner)}` : ''
+      } — not ${bold('building')} under ${bold(owner)}.\n` +
+        (result.task.status === 'blocked'
+          ? `\nReturn a blocked task to the queue with: ${bold(`hedgehog retry ${taskId}`)}\n`
+          : ''),
+    );
     return;
   }
 
@@ -939,8 +984,16 @@ async function renewCommand(args) {
   }
 
   if (!result.renewed) {
-    console.error(`${red('Not renewed.')} Task ${bold(taskId)} is not leased to ${bold(owner)}.\n`);
     process.exitCode = 1;
+    if (result.reason === 'no_such_task') {
+      console.error(`${red('No such task:')} ${bold(taskId)}${dim(` (in ${dbAbsPath()})`)}\n`);
+      return;
+    }
+    console.error(
+      `${red('Not renewed.')} Task ${bold(taskId)} is ${bold(result.task.status)}${
+        result.task.lease_owner ? `, leased to ${bold(result.task.lease_owner)}` : ''
+      } — not leased to ${bold(owner)}.\n`,
+    );
     return;
   }
 
@@ -955,6 +1008,8 @@ async function statusCommand() {
     process.exitCode = 1;
     return;
   }
+
+  printDbTarget();
 
   const db = openDb();
   let result;
@@ -978,6 +1033,8 @@ async function readyCommand() {
     process.exitCode = 1;
     return;
   }
+
+  printDbTarget();
 
   const db = openDb();
   let result;
@@ -1210,6 +1267,8 @@ async function frictionCommand(args) {
       process.exitCode = 1;
       return;
     }
+
+    printDbTarget();
 
     const db = openDb();
     let entry;

--- a/repro/01-retry-after-failed-verify.mjs
+++ b/repro/01-retry-after-failed-verify.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+// Gap 1: a failed verification leaves the task `blocked` with no way back.
+//
+// The documented recovery ("fix it and re-run hedgehog verify <task-id>")
+// cannot work: verify's Phase 0 asserts `status === 'building' &&
+// lease_owner === owner`, and blocking a task clears both. `release` only
+// accepts `building`. So before `hedgehog retry`, the only exit from
+// `blocked` is an UPDATE against the database by hand.
+
+import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { makeProject, hedgehog, hedgehogAllowFail, readTask, assert, assertIncludes, runRepro } from './lib.mjs';
+
+await runRepro('retry after a failed verify', async () => {
+  const { dir, dbPath, cleanup } = await makeProject();
+  try {
+    // Claim the one ready task and do its work.
+    const claim = hedgehog(dir, ['claim', '--owner', 'ag1']);
+    assertIncludes(claim.out, 'ALPHA-SCHEMA', 'claim should hand out the first layer');
+    await mkdir(join(dir, 'src/alpha'), { recursive: true });
+    await writeFile(join(dir, 'src/alpha/schema.txt'), 'schema\n');
+
+    // Make the layer's verify command fail, and gate it.
+    await writeFile(join(dir, 'FAIL'), '');
+    const failed = hedgehogAllowFail(dir, ['verify', 'ALPHA-SCHEMA', '--owner', 'ag1']);
+    assert(failed.code !== 0, 'a failing verify command must exit non-zero');
+    assertIncludes(failed.out, 'Verification failed', 'verify should report the failure');
+
+    const blocked = readTask(dbPath, 'ALPHA-SCHEMA');
+    assert(blocked.status === 'blocked', `expected blocked, got ${blocked.status}`);
+    assert(
+      blocked.blocked_reason === 'verification_failed',
+      `expected verification_failed, got ${blocked.blocked_reason}`,
+    );
+
+    // The documented path is a dead end: verify refuses a task it does
+    // not hold a lease on, and release refuses anything not `building`.
+    await rm(join(dir, 'FAIL'));
+    const reverify = hedgehogAllowFail(dir, ['verify', 'ALPHA-SCHEMA', '--owner', 'ag1']);
+    assert(reverify.code !== 0, 're-running verify on a blocked task should still fail');
+    assertIncludes(reverify.out, 'not leased', 'verify refuses a blocked task for lack of a lease');
+    const rerelease = hedgehogAllowFail(dir, ['release', 'ALPHA-SCHEMA', '--owner', 'ag1']);
+    assert(rerelease.code !== 0, 'release should refuse a blocked task');
+
+    // The new command: back to planned, lease invariant intact.
+    const retry = hedgehog(dir, ['retry', 'ALPHA-SCHEMA']);
+    assertIncludes(retry.out, 'Retried', 'retry should report the transition');
+    const retried = readTask(dbPath, 'ALPHA-SCHEMA');
+    assert(retried.status === 'planned', `expected planned after retry, got ${retried.status}`);
+    assert(retried.blocked_reason === null, 'retry must clear blocked_reason');
+    assert(retried.lease_owner === null, 'a non-building task must hold no lease');
+
+    // And the loop closes: claim it again, verify it, done.
+    hedgehog(dir, ['claim', 'ALPHA-SCHEMA', '--owner', 'ag1']);
+    const pass = hedgehog(dir, ['verify', 'ALPHA-SCHEMA', '--owner', 'ag1']);
+    assertIncludes(pass.out, 'Verified', 'the retried task should verify and commit');
+    assert(
+      readTask(dbPath, 'ALPHA-SCHEMA').status === 'complete',
+      'the retried task should end up complete',
+    );
+  } finally {
+    await cleanup();
+  }
+});

--- a/repro/02-retry-after-scope-violation.mjs
+++ b/repro/02-retry-after-scope-violation.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+// Gap 2: a scope violation blocks the task the same way, with the same
+// dead end — blocked_reason is `scope_violation` instead of
+// `verification_failed`, and every other command refuses it identically.
+
+import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { makeProject, hedgehog, hedgehogAllowFail, readTask, assert, assertIncludes, runRepro } from './lib.mjs';
+
+await runRepro('retry after a scope violation', async () => {
+  const { dir, dbPath, cleanup } = await makeProject();
+  try {
+    hedgehog(dir, ['claim', '--owner', 'ag1']);
+
+    // In scope, plus one file the task had no business writing.
+    await mkdir(join(dir, 'src/alpha'), { recursive: true });
+    await writeFile(join(dir, 'src/alpha/schema.txt'), 'schema\n');
+    await mkdir(join(dir, 'src/elsewhere'), { recursive: true });
+    await writeFile(join(dir, 'src/elsewhere/oops.txt'), 'out of scope\n');
+
+    const violated = hedgehogAllowFail(dir, ['verify', 'ALPHA-SCHEMA', '--owner', 'ag1']);
+    assert(violated.code !== 0, 'a scope violation must exit non-zero');
+    assertIncludes(violated.out, 'Scope violation', 'verify should name the violation');
+    assertIncludes(violated.out, 'src/elsewhere/oops.txt', 'verify should name the offending path');
+
+    const blocked = readTask(dbPath, 'ALPHA-SCHEMA');
+    assert(blocked.status === 'blocked', `expected blocked, got ${blocked.status}`);
+    assert(
+      blocked.blocked_reason === 'scope_violation',
+      `expected scope_violation, got ${blocked.blocked_reason}`,
+    );
+
+    // Same dead end as a failed verification.
+    const reverify = hedgehogAllowFail(dir, ['verify', 'ALPHA-SCHEMA', '--owner', 'ag1']);
+    assert(reverify.code !== 0, 'verify still refuses the blocked task');
+
+    // Fix the violation at its source, then retry.
+    await rm(join(dir, 'src/elsewhere'), { recursive: true, force: true });
+    const retry = hedgehog(dir, ['retry', 'ALPHA-SCHEMA']);
+    assertIncludes(retry.out, 'scope violation', 'retry should name what it recovered from');
+
+    const retried = readTask(dbPath, 'ALPHA-SCHEMA');
+    assert(retried.status === 'planned', `expected planned after retry, got ${retried.status}`);
+    assert(retried.blocked_reason === null, 'retry must clear blocked_reason');
+    assert(retried.lease_owner === null, 'a non-building task must hold no lease');
+
+    hedgehog(dir, ['claim', 'ALPHA-SCHEMA', '--owner', 'ag1']);
+    const pass = hedgehog(dir, ['verify', 'ALPHA-SCHEMA', '--owner', 'ag1']);
+    assertIncludes(pass.out, 'Verified', 'the retried task should verify and commit');
+  } finally {
+    await cleanup();
+  }
+});

--- a/repro/03-show-packet-for-claimed-task.mjs
+++ b/repro/03-show-packet-for-claimed-task.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// Gap 3: the packet is unreachable once a task is claimed.
+//
+// `claim` printed only the task id and lease expiry, and claiming moves
+// the task to `building` — which takes it out of `next`'s readiness
+// SELECT (status IN ('planned','ready') AND lease_owner IS NULL). So the
+// ALLOWED SCOPE and VERIFICATION an agent is meant to be dispatched with
+// existed only in the database. This asserts claim now prints the packet,
+// and that `show` reprints it afterwards.
+
+import { makeProject, hedgehog, hedgehogAllowFail, assert, assertIncludes, assertExcludes, runRepro } from './lib.mjs';
+
+await runRepro('show prints the packet for an already-claimed task', async () => {
+  const { dir, cleanup } = await makeProject();
+  try {
+    const claim = hedgehog(dir, ['claim', '--owner', 'ag1']);
+    assertIncludes(claim.out, 'ALLOWED SCOPE', 'claim should print the packet, not just the id');
+    assertIncludes(claim.out, 'src/alpha/schema.txt', "claim's packet should carry the scope globs");
+    assertIncludes(claim.out, 'VERIFICATION', "claim's packet should carry the verify command");
+
+    // next can no longer see it — this is what made the packet
+    // unreachable through any other command.
+    const next = hedgehogAllowFail(dir, ['next']);
+    assertExcludes(next.out, 'ALLOWED SCOPE', 'next cannot show a claimed task');
+
+    const show = hedgehog(dir, ['show', 'ALPHA-SCHEMA']);
+    assertIncludes(show.out, 'TASK  ALPHA-SCHEMA', 'show should name the task');
+    assertIncludes(show.out, 'BUILDING', 'show should report the real status, not READY');
+    assertIncludes(show.out, 'ag1', 'show should name the lease holder');
+    assertIncludes(show.out, 'ALLOWED SCOPE', 'show should print the allowed scope');
+    assertIncludes(show.out, 'src/alpha/schema.txt', 'show should print the scope globs');
+    assertIncludes(show.out, 'node verify.mjs', 'show should print the verification command');
+    assertIncludes(show.out, 'alpha must be correct', "show should print the intent's rules");
+
+    // It also works for a task that is not ready at all — the dependent
+    // layer, still waiting on this one.
+    const blockedPacket = hedgehog(dir, ['show', 'ALPHA-SERVICE']);
+    assertIncludes(blockedPacket.out, 'PLANNED', 'show should report a planned task as planned');
+    assertIncludes(
+      blockedPacket.out,
+      'Waiting on ALPHA-SCHEMA',
+      'show should name the dependency a not-ready task is waiting on',
+    );
+
+    const missing = hedgehogAllowFail(dir, ['show', 'NO-SUCH-TASK']);
+    assert(missing.code !== 0, 'show should exit non-zero for an unknown task id');
+    assertIncludes(missing.out, 'No such task', 'show should say the id matched nothing');
+  } finally {
+    await cleanup();
+  }
+});

--- a/repro/04-claim-specific-task.mjs
+++ b/repro/04-claim-specific-task.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Gap 4: there is no way to claim a specific task, so an `exclusive` task
+// starves.
+//
+// The fan-out walks candidates in (priority, id) order and takes the
+// first mutually non-conflicting set. An exclusive task conflicts with
+// everything, so any non-exclusive candidate sorting ahead of it takes
+// the slot — on every call, forever. This asserts the starvation, that a
+// targeted claim breaks it, and that a targeted claim still refuses to
+// break the conflict invariant that makes concurrency safe.
+
+import { makeProject, EXCLUSIVE_CORE, hedgehog, hedgehogAllowFail, readTask, assert, assertIncludes, assertExcludes, runRepro } from './lib.mjs';
+
+await runRepro('claim a specific task to break a starvation tie', async () => {
+  const { dir, dbPath, cleanup } = await makeProject({
+    core: EXCLUSIVE_CORE,
+    intents: ['alpha', 'beta'],
+  });
+  try {
+    // The exclusive task is ready and unleased...
+    const ready = hedgehog(dir, ['ready']);
+    assertIncludes(ready.out, 'ALPHA-ZINTEGRATE', 'the exclusive task should be in the ready set');
+    assertIncludes(ready.out, 'exclusive', 'ready should explain why it is held back');
+
+    // ...but the fan-out never hands it out, however large the batch.
+    const batch = hedgehog(dir, ['claim', '--owner', 'ag1', '--count', '10']);
+    assertIncludes(batch.out, 'ALPHA-SCHEMA', 'the batch claim takes the per-module layers');
+    assertIncludes(batch.out, 'BETA-SCHEMA', 'the batch claim takes both modules');
+    assert(
+      readTask(dbPath, 'ALPHA-ZINTEGRATE').status !== 'building',
+      'the exclusive task should have starved — that is the gap being reproduced',
+    );
+
+    // A targeted claim does not override the conflict rule: work is in
+    // flight that the exclusive task conflicts with, so it refuses, and
+    // says what it conflicts with.
+    const refused = hedgehogAllowFail(dir, ['claim', 'ALPHA-ZINTEGRATE', '--owner', 'ag2']);
+    assert(refused.code !== 0, 'a conflicting targeted claim must exit non-zero');
+    assertIncludes(refused.out, 'conflicts with work in flight', 'it should name the conflict');
+    assertIncludes(refused.out, 'ALPHA-SCHEMA', 'it should name the in-flight task');
+
+    // Once the batch is handed back, the targeted claim gets the task the
+    // fan-out would still never pick.
+    hedgehog(dir, ['release', 'ALPHA-SCHEMA', '--owner', 'ag1']);
+    hedgehog(dir, ['release', 'BETA-SCHEMA', '--owner', 'ag1']);
+    const stillStarved = hedgehog(dir, ['claim', '--owner', 'ag3', '--count', '10']);
+    assertExcludes(
+      stillStarved.out,
+      'TASK  ALPHA-ZINTEGRATE',
+      'even with nothing in flight, the fan-out still never picks the exclusive task',
+    );
+    hedgehog(dir, ['release', 'ALPHA-SCHEMA', '--owner', 'ag3']);
+    hedgehog(dir, ['release', 'BETA-SCHEMA', '--owner', 'ag3']);
+
+    const targeted = hedgehog(dir, ['claim', 'ALPHA-ZINTEGRATE', '--owner', 'ag2']);
+    assertIncludes(targeted.out, 'Claimed', 'the targeted claim should succeed');
+    assertIncludes(targeted.out, 'ALLOWED SCOPE', 'the targeted claim should print the packet');
+
+    const claimed = readTask(dbPath, 'ALPHA-ZINTEGRATE');
+    assert(claimed.status === 'building', `expected building, got ${claimed.status}`);
+    assert(claimed.lease_owner === 'ag2', `expected lease to ag2, got ${claimed.lease_owner}`);
+    assert(claimed.lease_expires_at !== null, 'a building task must carry a lease expiry');
+
+    // The other refusals: already leased, and a dependency not complete.
+    const twice = hedgehogAllowFail(dir, ['claim', 'ALPHA-ZINTEGRATE', '--owner', 'ag4']);
+    assert(twice.code !== 0, 'claiming an already-leased task must exit non-zero');
+    assertIncludes(twice.out, 'Not claimable', 'it should refuse a leased task');
+
+    const missing = hedgehogAllowFail(dir, ['claim', 'NO-SUCH-TASK', '--owner', 'ag2']);
+    assert(missing.code !== 0, 'claiming an unknown id must exit non-zero');
+    assertIncludes(missing.out, 'No such task', 'it should say the id matched nothing');
+  } finally {
+    await cleanup();
+  }
+});
+
+// The dependency refusal needs the default (chained) core.
+await runRepro('a targeted claim refuses a task whose dependencies are open', async () => {
+  const { dir, cleanup } = await makeProject();
+  try {
+    const refused = hedgehogAllowFail(dir, ['claim', 'ALPHA-SERVICE', '--owner', 'ag1']);
+    assert(refused.code !== 0, 'a targeted claim must not bypass dependency order');
+    assertIncludes(refused.out, 'waiting on', 'it should say what the task waits on');
+    assertIncludes(refused.out, 'ALPHA-SCHEMA', 'it should name the open dependency');
+  } finally {
+    await cleanup();
+  }
+});

--- a/repro/05-db-target-and-zero-rows.mjs
+++ b/repro/05-db-target-and-zero-rows.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// The silent-green failure this whole change is aimed at: hand-written
+// recovery SQL used a relative database path, ran from the wrong
+// directory, opened a different database, matched zero rows, printed
+// `undefined`, and exited zero.
+//
+// Two properties close that off: every command that writes to the build
+// graph prints the absolute path of the database it opened, and a
+// recovery command that matches no task exits non-zero.
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { makeProject, hedgehog, hedgehogAllowFail, assert, assertIncludes, runRepro } from './lib.mjs';
+
+await runRepro('write commands name the database they opened', async () => {
+  const { dir, dbPath, cleanup } = await makeProject();
+  try {
+    for (const args of [
+      ['claim', '--owner', 'ag1'],
+      ['renew', 'ALPHA-SCHEMA', '--owner', 'ag1'],
+      ['release', 'ALPHA-SCHEMA', '--owner', 'ag1'],
+      ['friction', 'add', 'a note'],
+    ]) {
+      const result = hedgehog(dir, args);
+      assertIncludes(
+        result.out,
+        dbPath,
+        `\`hedgehog ${args.join(' ')}\` should print the absolute database path it opened`,
+      );
+    }
+  } finally {
+    await cleanup();
+  }
+});
+
+await runRepro('recovery commands fail loudly when they match no task', async () => {
+  const { dir, cleanup } = await makeProject();
+  try {
+    for (const args of [
+      ['retry', 'NO-SUCH-TASK'],
+      ['claim', 'NO-SUCH-TASK', '--owner', 'ag1'],
+      ['release', 'NO-SUCH-TASK', '--owner', 'ag1'],
+      ['renew', 'NO-SUCH-TASK', '--owner', 'ag1'],
+      ['show', 'NO-SUCH-TASK'],
+    ]) {
+      const result = hedgehogAllowFail(dir, args);
+      assert(result.code !== 0, `\`hedgehog ${args.join(' ')}\` should exit non-zero, got ${result.code}`);
+      assertIncludes(result.out, 'No such task', `\`hedgehog ${args.join(' ')}\` should say so`);
+    }
+
+    // A task that exists but isn't blocked is a different mistake, and
+    // is reported as one rather than silently succeeding.
+    const notBlocked = hedgehogAllowFail(dir, ['retry', 'ALPHA-SCHEMA']);
+    assert(notBlocked.code !== 0, 'retry on a non-blocked task should exit non-zero');
+    assertIncludes(notBlocked.out, 'not blocked', 'retry should say why it refused');
+  } finally {
+    await cleanup();
+  }
+});
+
+await runRepro('a recovery command run in the wrong directory refuses', async () => {
+  const elsewhere = await mkdtemp(join(tmpdir(), 'hedgehog-repro-empty-'));
+  try {
+    const result = hedgehogAllowFail(elsewhere, ['retry', 'ALPHA-SCHEMA']);
+    assert(result.code !== 0, 'retry with no build graph should exit non-zero');
+    assertIncludes(result.out, 'No build graph found', 'it should say there is no graph here');
+  } finally {
+    await rm(elsewhere, { recursive: true, force: true });
+  }
+});

--- a/repro/lib.mjs
+++ b/repro/lib.mjs
@@ -1,0 +1,216 @@
+// Shared harness for the recovery-command reproductions.
+//
+// Each repro builds a throwaway Hedgehog project in its own temp
+// directory — a real git repo, a real authored core.yaml, a real build
+// graph — drives a task into one of the situations the CLI had no
+// command for, and asserts the new command resolves it. No test
+// framework and no sqlite3 binary are involved: assertions are plain
+// throws, state is read back through node:sqlite, and a failing repro
+// exits non-zero.
+//
+// Setup writes intents and compiles the graph by importing src/db
+// directly rather than shelling out to `hedgehog plan`, because plan
+// spawns a graph server and opens a browser on success — neither of
+// which belongs in a repro run.
+
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const PKG_ROOT = resolve(__dirname, '..');
+export const CLI = join(PKG_ROOT, 'bin/cli.mjs');
+
+export class AssertionError extends Error {}
+
+export function assert(condition, message) {
+  if (!condition) throw new AssertionError(message);
+}
+
+export function assertIncludes(haystack, needle, message) {
+  assert(
+    haystack.includes(needle),
+    `${message}\n  expected output to contain: ${JSON.stringify(needle)}\n  actual output:\n${indent(haystack)}`,
+  );
+}
+
+export function assertExcludes(haystack, needle, message) {
+  assert(
+    !haystack.includes(needle),
+    `${message}\n  expected output NOT to contain: ${JSON.stringify(needle)}\n  actual output:\n${indent(haystack)}`,
+  );
+}
+
+function indent(text) {
+  return text
+    .split('\n')
+    .map((line) => `    | ${line}`)
+    .join('\n');
+}
+
+// The default core: a two-layer chain on a module axis. `verify.mjs`
+// (written into the project below) fails whenever a `FAIL` sentinel file
+// exists, which is how a repro drives a verification failure on demand.
+export const DEFAULT_CORE = `id: repro-core
+layers:
+  - id: schema
+    scope: [src/{module}/schema.txt]
+    verify: node verify.mjs
+    commit: "feat({module}): schema"
+  - id: service
+    depends_on: schema
+    scope: [src/{module}/service.txt]
+    verify: node verify.mjs
+    commit: "feat({module}): service"
+`;
+
+// A core whose second layer is `exclusive: true` and sorts *after* the
+// per-module layer by task id — the starvation shape: the fan-out walks
+// candidates in (priority, id) order and takes the first non-conflicting
+// set, so an exclusive task with any non-exclusive candidate ahead of it
+// is never handed out, however many times claim runs.
+export const EXCLUSIVE_CORE = `id: repro-core
+layers:
+  - id: schema
+    scope: [src/{module}/schema.txt]
+    verify: node verify.mjs
+    commit: "feat({module}): schema"
+  - id: zintegrate
+    exclusive: true
+    scope: [src/integration.txt]
+    verify: node verify.mjs
+    commit: "feat({module}): integrate"
+`;
+
+const VERIFY_SCRIPT = `import { existsSync } from 'node:fs';
+// Exit 1 while the FAIL sentinel exists — the repro's switch for driving
+// a verification failure, and its switch for driving a pass afterward.
+process.exit(existsSync('FAIL') ? 1 : 0);
+`;
+
+const GITIGNORE = `.hedgehog/hedgehog.db
+.hedgehog/hedgehog.db-*
+.hedgehog/commit.lock
+.hedgehog/graph-server.json
+FAIL
+`;
+
+function git(cwd, args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: 'pipe' });
+}
+
+// Creates a throwaway project: git repo, core.yaml, verify script, seed
+// commit, build graph with `intents` compiled through `core`. Returns the
+// project directory (absolute) and a cleanup function.
+export async function makeProject({ core = DEFAULT_CORE, intents = ['alpha'] } = {}) {
+  const dir = await mkdtemp(join(tmpdir(), 'hedgehog-repro-'));
+
+  await mkdir(join(dir, '.hedgehog'), { recursive: true });
+  await writeFile(join(dir, '.hedgehog/core.yaml'), core);
+  await writeFile(join(dir, 'verify.mjs'), VERIFY_SCRIPT);
+  await writeFile(join(dir, '.gitignore'), GITIGNORE);
+
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'repro@example.com']);
+  git(dir, ['config', 'user.name', 'Hedgehog Repro']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', 'chore: seed']);
+
+  // The build graph is compiled in-process, from the project directory —
+  // DB_PATH and INTENTS_DIR are both relative, so cwd is what decides
+  // which project they land in.
+  const previousCwd = process.cwd();
+  process.chdir(dir);
+  try {
+    const { dbInit, openDb, DB_PATH } = await import('../src/db/init.mjs');
+    const { addIntent } = await import('../src/db/intent.mjs');
+    const { planTasks } = await import('../src/db/plan.mjs');
+    const { loadCore } = await import('../src/db/core.mjs');
+
+    await dbInit(DB_PATH);
+    const db = openDb();
+    try {
+      for (const id of intents) {
+        await addIntent(db, {
+          id,
+          goal: `build ${id}`,
+          outcome: `${id} works`,
+          rules: [`${id} must be correct`],
+        });
+      }
+      planTasks(db, await loadCore(join(dir, '.hedgehog/core.yaml')));
+    } finally {
+      db.close();
+    }
+  } finally {
+    process.chdir(previousCwd);
+  }
+
+  // Intents are committed state in a real project (planner commits
+  // them); leaving them untracked would make every later verify see them
+  // as touched-outside-scope.
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', 'chore: intents']);
+
+  return {
+    dir,
+    dbPath: join(dir, '.hedgehog/hedgehog.db'),
+    cleanup: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+// Runs the CLI in `cwd`, capturing exit code and combined output rather
+// than throwing on a non-zero exit — a refusing command is an expected
+// outcome here, not an exception.
+export function hedgehog(cwd, args) {
+  const result = execFileSync(process.execPath, [CLI, ...args], {
+    cwd,
+    encoding: 'utf8',
+    stdio: 'pipe',
+    // ExperimentalWarning: SQLite noise on stderr would otherwise land in
+    // every captured output string.
+    env: { ...process.env, NODE_NO_WARNINGS: '1', NO_COLOR: '1' },
+    // execFileSync throws on non-zero; catching below keeps the code.
+  });
+  return { code: 0, out: result };
+}
+
+export function hedgehogAllowFail(cwd, args) {
+  try {
+    return hedgehog(cwd, args);
+  } catch (err) {
+    return {
+      code: err.status ?? 1,
+      out: `${err.stdout ?? ''}${err.stderr ?? ''}`,
+    };
+  }
+}
+
+// Reads one task row straight out of the build graph, by absolute path —
+// the check that the CLI actually moved the state it claimed to move.
+export function readTask(dbPath, taskId) {
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    return db.prepare('SELECT * FROM tasks WHERE id = ?').get(taskId);
+  } finally {
+    db.close();
+  }
+}
+
+// Runs `body` with a fresh project, reports pass/fail, and exits
+// non-zero on failure so a runner (or CI) can gate on it.
+export async function runRepro(name, body) {
+  try {
+    await body();
+    console.log(`PASS  ${name}`);
+  } catch (err) {
+    console.error(`FAIL  ${name}`);
+    console.error(`  ${err.message}`);
+    if (!(err instanceof AssertionError) && err.stack) console.error(err.stack);
+    process.exitCode = 1;
+  }
+}

--- a/repro/run-all.mjs
+++ b/repro/run-all.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// Runs every reproduction in order and exits non-zero if any failed.
+//
+//   node repro/run-all.mjs
+
+import { readdir } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scripts = (await readdir(here))
+  .filter((f) => /^\d+-.*\.mjs$/.test(f))
+  .sort();
+
+let failed = 0;
+for (const script of scripts) {
+  try {
+    const out = execFileSync(process.execPath, [join(here, script)], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      env: { ...process.env, NODE_NO_WARNINGS: '1' },
+    });
+    process.stdout.write(out);
+  } catch (err) {
+    failed++;
+    process.stdout.write(`${err.stdout ?? ''}`);
+    process.stderr.write(`${err.stderr ?? ''}`);
+  }
+}
+
+if (failed > 0) {
+  console.error(`\n${failed} of ${scripts.length} reproduction script(s) failed.`);
+  process.exit(1);
+}
+console.log(`\nall ${scripts.length} reproduction script(s) passed.`);

--- a/src/db/claim.mjs
+++ b/src/db/claim.mjs
@@ -1,9 +1,17 @@
-// `hedgehog claim` / `release` / `renew` — lease-based task assignment.
-// See hedgehog-persistent-build-graph.md, "Claims", and the lease/claim
+// `hedgehog claim` / `release` / `renew` / `retry` — lease-based task
+// assignment and the one transition back out of `blocked`. See
+// hedgehog-persistent-build-graph.md, "Claims", and the lease/claim
 // columns added to `tasks` in schema.mjs.
+//
+// Every write in this file keeps the schema's lease invariant —
+// `CHECK ((lease_owner IS NULL) = (status NOT IN ('building','verifying')))`
+// — by setting status and the three lease columns in the same UPDATE:
+// a task entering `building` gets an owner, and a task leaving it (to
+// ready, planned, blocked) has all three cleared.
 
 import { inTransaction } from './init.mjs';
 import { conflicts } from './conflict.mjs';
+import { incompleteDependencies } from './next.mjs';
 
 // Same no-incomplete-dependency shape as next.mjs's READY_TASK_SQL, without
 // the LIMIT 1 — claimTasks may take more than one candidate per call.
@@ -104,6 +112,102 @@ export function claimTasks(db, { owner, count = 1, leaseMinutes = 45 }) {
   });
 }
 
+// Claims one named task for `owner`, bypassing the fan-out's ordering
+// without bypassing any of its safety rules. The batch claim above walks
+// candidates in `priority, id` order and takes the first non-conflicting
+// set, which means a task that conflicts with everything — an
+// `exclusive: true` layer — is only ever handed out when it happens to
+// sort ahead of every other candidate. Any non-exclusive candidate
+// sorting before it takes the slot instead, on every call, however many
+// times the loop runs: the exclusive task starves. This is the operator's
+// way to say which task to hand out, rather than editing the lease into
+// the database by hand.
+//
+// The four refusals below are exactly the fan-out's own preconditions,
+// checked against one named task instead of a candidate list, and each
+// one returns a reason rather than a bare false — a caller that can't say
+// *why* nothing was claimed is the silent-failure this command exists to
+// replace:
+//   no_such_task            — the id doesn't name a row
+//   not_claimable           — wrong status, or already leased
+//   incomplete_dependencies — a dependency isn't `complete` yet
+//   conflict                — conflicts with a task already in flight
+//   race_lost               — a concurrent claim won the atomic UPDATE
+export function claimTask(db, taskId, { owner, leaseMinutes = 45 }) {
+  return inTransaction(db, () => {
+    reapExpiredLeases(db);
+
+    const task = loadTask(db, taskId);
+    if (task === undefined) return { claimed: false, reason: 'no_such_task' };
+
+    if (!['planned', 'ready'].includes(task.status) || task.lease_owner !== null) {
+      return { claimed: false, reason: 'not_claimable', task };
+    }
+
+    const incomplete = incompleteDependencies(db, taskId);
+    if (incomplete.length > 0) {
+      return { claimed: false, reason: 'incomplete_dependencies', task, incomplete };
+    }
+
+    // Conflicting with something already building/verifying is the one
+    // refusal a targeted claim must keep: the whole point of the
+    // conflict predicate is that two overlapping tasks in one working
+    // tree corrupt each other's scope check and commit. Waiting for the
+    // neighbor to finish (or releasing it) is the fix, not overriding
+    // this.
+    const conflicting = [];
+    for (const other of findInFlightTasks(db)) {
+      if (other.id === task.id) continue;
+      const kind = conflicts(task, other);
+      if (kind !== null) conflicting.push({ task: other, kind });
+    }
+    if (conflicting.length > 0) {
+      return { claimed: false, reason: 'conflict', task, conflicting };
+    }
+
+    const result = claimOne(db).get(owner, leaseMinutes, task.id);
+    if (result === undefined) return { claimed: false, reason: 'race_lost', task };
+
+    return { claimed: true, task: loadTask(db, task.id) };
+  });
+}
+
+// Returns a `blocked` task to `planned`, so it can be claimed and built
+// again. Every blocked_reason is eligible: a failed verification and a
+// scope violation are the loop's expected failure cases (build, gate
+// rejects, fix, retry), and a reaped lease is a dead agent's task that a
+// live one has to be able to pick back up. Without this there is no
+// transition out of `blocked` at all — `releaseTask` only accepts
+// `building`, and `verifyTask` refuses anything that isn't `building`
+// and leased, so a blocked task is unreachable by every other command.
+//
+// `planned` rather than `ready`: it's the status `plan.mjs` writes for a
+// task that hasn't been built yet, and the readiness SELECT accepts both,
+// so the task re-enters the queue exactly where a freshly compiled one
+// would — still subject to its dependencies being complete.
+export function retryTask(db, taskId) {
+  return inTransaction(db, () => {
+    const task = loadTask(db, taskId);
+    if (task === undefined) return { retried: false, reason: 'no_such_task' };
+    if (task.status !== 'blocked') return { retried: false, reason: 'not_blocked', task };
+
+    const result = db
+      .prepare(
+        `
+        UPDATE tasks SET status = 'planned', blocked_reason = NULL,
+          lease_owner = NULL, lease_expires_at = NULL, leased_at = NULL
+        WHERE id = ? AND status = 'blocked'
+        RETURNING id
+      `,
+      )
+      .get(taskId);
+
+    if (result === undefined) return { retried: false, reason: 'not_blocked', task };
+
+    return { retried: true, from: task.blocked_reason, task: loadTask(db, taskId) };
+  });
+}
+
 // Releases `taskId` back to `ready` if `owner` currently holds its lease.
 // Scoped to `status = 'building'` — `verifying` is the engine's own
 // transient lease during verifyTask, not something an external release
@@ -124,7 +228,13 @@ export function releaseTask(db, taskId, owner) {
       )
       .get(taskId, owner);
 
-    return { released: result !== undefined };
+    if (result !== undefined) return { released: true };
+    // Which of the two failures this was, so the CLI can say "no such
+    // task" instead of implying the id exists but is held by someone
+    // else — a mistyped id and a genuinely un-held task are different
+    // problems with different fixes.
+    const task = loadTask(db, taskId);
+    return { released: false, reason: task === undefined ? 'no_such_task' : 'not_held', task };
   });
 }
 
@@ -142,6 +252,8 @@ export function renewLease(db, taskId, owner, minutes) {
       )
       .get(minutes, taskId, owner);
 
-    return { renewed: result !== undefined };
+    if (result !== undefined) return { renewed: true };
+    const task = loadTask(db, taskId);
+    return { renewed: false, reason: task === undefined ? 'no_such_task' : 'not_held', task };
   });
 }

--- a/src/db/next.mjs
+++ b/src/db/next.mjs
@@ -47,6 +47,26 @@ function loadTaskRequirements(db, taskId) {
     .all(taskId);
 }
 
+// The dependencies of `taskId` that aren't `complete` yet — the negation
+// of the readiness SELECT's NOT EXISTS clause, returned as rows rather
+// than a boolean. `next` never sees a non-empty list (its candidate set
+// is exactly the tasks with none), but `show` renders packets for tasks
+// at any point in the lifecycle, and claim.mjs's targeted claim has to
+// name what a specific task is still waiting on rather than refusing
+// with no reason.
+export function incompleteDependencies(db, taskId) {
+  return db
+    .prepare(
+      `
+      SELECT dep.* FROM dependencies d
+      JOIN tasks dep ON dep.id = d.depends_on_task_id
+      WHERE d.task_id = ? AND dep.status <> 'complete'
+      ORDER BY dep.priority, dep.id
+    `,
+    )
+    .all(taskId);
+}
+
 function loadDirectDependents(db, taskId) {
   return db
     .prepare(
@@ -84,20 +104,24 @@ function loadBlockedDownstream(db, taskId) {
   return result;
 }
 
-// Assembles the packet for `task` (already known ready) by querying its
-// intent, requirements, and blocked downstream chain. Returns null fields
-// never — every field here is NOT NULL on tasks, or defaults to an empty
-// list.
+// Assembles the packet for `task` by querying its intent, requirements,
+// blocked downstream chain, and any dependency not yet complete. Returns
+// null fields never — every field here is NOT NULL on tasks, or defaults
+// to an empty list. `incompleteDeps` is always empty for a task the
+// readiness SELECT picked; it's non-empty only for packets assembled by
+// `taskPacket` for a task that isn't ready.
 function assemblePacket(db, task) {
   const intent = loadIntent(db, task.intent_id);
   const requirements = loadTaskRequirements(db, task.id);
   const dependents = loadBlockedDownstream(db, task.id);
+  const incompleteDeps = incompleteDependencies(db, task.id);
 
   return {
     task,
     intent,
     requirements,
     dependents,
+    incompleteDeps,
   };
 }
 
@@ -105,6 +129,19 @@ function assemblePacket(db, task) {
 // SELECT), or null if no task is ready.
 export function nextTask(db) {
   const task = findReadyTask(db);
+  if (!task) return null;
+  return assemblePacket(db, task);
+}
+
+// The same packet for a task named by id, at any point in its lifecycle
+// — the read `next` can't perform once a task leaves the readiness
+// SELECT's candidate set. Claiming a task moves it to `building`, which
+// makes it invisible to `next` (status not in planned/ready, lease_owner
+// not null), so without this the packet an agent is supposed to work
+// from becomes unreachable through the CLI the moment it is handed out.
+// Returns null when no such task exists.
+export function taskPacket(db, taskId) {
+  const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(taskId);
   if (!task) return null;
   return assemblePacket(db, task);
 }
@@ -127,21 +164,47 @@ export function stalledTasks(db) {
     .all();
 }
 
+const BLOCKED_REASON_LABELS = {
+  verification_failed: 'verification failed',
+  scope_violation: 'scope violation',
+  lease_expired: 'lease expired',
+};
+
+// The STATUS line for a packet rendered outside the readiness query —
+// `next` always prints READY (its candidate set guarantees it), but a
+// packet for an already-claimed or blocked task has to say so, including
+// who holds the lease and until when, since that's what an operator
+// needs to decide between verify, release, renew, and retry.
+export function taskStatusLine(task) {
+  if (task.status === 'building' || task.status === 'verifying') {
+    return `${task.status.toUpperCase()}   leased to ${task.lease_owner}, expires ${task.lease_expires_at}`;
+  }
+  if (task.status === 'blocked') {
+    const reason = BLOCKED_REASON_LABELS[task.blocked_reason] ?? task.blocked_reason;
+    return `BLOCKED   ${reason} — return it to the queue with: hedgehog retry ${task.id}`;
+  }
+  return task.status.toUpperCase();
+}
+
 // Renders a packet into the STATUS / INTENT / RELEVANT RULES / WHY NOW /
 // BLOCKED DOWNSTREAM / ALLOWED SCOPE / VERIFICATION format. The spec
 // splits this across two examples — the `hedgehog next` display and "The
 // task packet" (which carries the intent and its rules) — but an agent
 // receives one thing, so the packet is one thing: everything the worker
 // needs to build the task without reading the plan.
-export function formatNext(packet) {
-  const { task, intent, requirements, dependents } = packet;
+//
+// `statusLine` is what goes on the STATUS row. `next` passes READY
+// literally, as it always has; `show` passes taskStatusLine(task), which
+// names the task's real state.
+export function formatPacket(packet, statusLine) {
+  const { task, intent, requirements, dependents, incompleteDeps = [] } = packet;
   const scopeGlobs = JSON.parse(task.scope_globs);
 
   const lines = [];
   lines.push(`TASK  ${task.id}`);
   lines.push(task.objective);
   lines.push('');
-  lines.push('STATUS   READY');
+  lines.push(`STATUS   ${statusLine}`);
   lines.push('');
   lines.push('INTENT');
   lines.push(`  ${intent.goal}`);
@@ -159,7 +222,13 @@ export function formatNext(packet) {
   lines.push('WHY NOW');
   lines.push(`  ✓ Intent "${intent.id}" compiled into the graph`);
   lines.push(`  ✓ Domain module "${task.module}" resolved`);
-  lines.push('  ✓ No incomplete dependencies');
+  if (incompleteDeps.length === 0) {
+    lines.push('  ✓ No incomplete dependencies');
+  } else {
+    for (const dep of incompleteDeps) {
+      lines.push(`  ✗ Waiting on ${dep.id}   ${dep.layer}   ${dep.status}`);
+    }
+  }
   lines.push('');
   lines.push('BLOCKED DOWNSTREAM');
   if (dependents.length === 0) {
@@ -177,4 +246,10 @@ export function formatNext(packet) {
   lines.push(`  ${task.verify_command}`);
 
   return lines.join('\n');
+}
+
+// `hedgehog next`'s rendering, unchanged: its task always came out of the
+// readiness SELECT, so STATUS is READY by construction.
+export function formatNext(packet) {
+  return formatPacket(packet, 'READY');
 }

--- a/src/db/status.mjs
+++ b/src/db/status.mjs
@@ -132,7 +132,10 @@ export function formatStatus({ counts, ready, inFlight, attention, total }) {
       lines.push(`  ${task.id}   ${task.layer}   ${reason}`);
     }
     lines.push('');
-    lines.push('  Fix the work, then re-run: hedgehog verify <task-id>');
+    // Not `verify` directly: a blocked task holds no lease, and verify
+    // refuses anything that isn't `building` under the calling owner.
+    // The way back in is retry (blocked → planned), then a claim.
+    lines.push('  Fix the work, then: hedgehog retry <task-id> && hedgehog claim <task-id> --owner <owner>');
   }
 
   return lines.join('\n');

--- a/src/db/status.mjs
+++ b/src/db/status.mjs
@@ -63,7 +63,7 @@ function loadReadyTasks(db) {
 // so without listing them here a build whose only remaining work is a
 // blocked task looks identical to a finished one — "READY (none)" with
 // no indication anything is wrong. Listing them is what makes the
-// fix-and-re-verify path in hedgehog-loop's Loop step 4 discoverable
+// fix-then-`retry` path in hedgehog-loop's Loop step 4 discoverable
 // from a fresh context.
 const ATTENTION_TASKS_SQL = `
   SELECT t.* FROM tasks t

--- a/src/skills/hedgehog-authored-loop/SKILL.md
+++ b/src/skills/hedgehog-authored-loop/SKILL.md
@@ -80,12 +80,14 @@ runtime detail.
    message from `core.yaml`, plus the updated build graph) and unlocks
    the next layer. On a scope violation or a failing check, the task
    moves to `blocked` with a `blocked_reason` of `scope_violation` or
-   `verification_failed`, and nothing downstream unlocks — fix it and
-   re-run `hedgehog verify <task-id> --owner <owner>`, don't hand-commit
-   around it.
+   `verification_failed`, and nothing downstream unlocks. Fix the work,
+   then run `hedgehog retry <task-id>` to return the task to `planned`,
+   claim it again, and verify again — `hedgehog verify` only accepts a
+   task you currently hold in `building`, so a blocked task has to go
+   back through `retry` and `claim` first. Don't hand-commit around it.
 
    A `blocked` task is not pickable by `hedgehog claim`, so `hedgehog
-   status` lists it under NEEDS ATTENTION with the task id to re-verify.
+   status` lists it under NEEDS ATTENTION with the task id to retry.
    If `hedgehog claim` returns nothing and the graph isn't actually done,
    fix that task — don't treat it as "nothing left to do."
 5. **Repeat** — `hedgehog claim --count N --owner <owner>` again for the

--- a/src/skills/hedgehog-landing-loop/SKILL.md
+++ b/src/skills/hedgehog-landing-loop/SKILL.md
@@ -185,8 +185,11 @@ paragraph algorithm, and their self-tests.
    above) and unlocks the next layer. On a scope violation or a failing
    check, the task moves to `blocked` with a `blocked_reason` of
    `scope_violation` or `verification_failed`, and nothing downstream
-   unlocks — fix it and re-run `hedgehog verify <task-id> --owner
-   <owner>`, don't hand-commit around it.
+   unlocks. Fix the work, then run `hedgehog retry <task-id>` to return
+   the task to `planned`, claim it again, and verify again — `hedgehog
+   verify` only accepts a task you currently hold in `building`, so a
+   blocked task has to go back through `retry` and `claim` first. Don't
+   hand-commit around it.
 5. **Repeat** — `hedgehog claim --owner <owner> --count <n>` again for
    the following layer.
 

--- a/src/skills/hedgehog-loop/SKILL.md
+++ b/src/skills/hedgehog-loop/SKILL.md
@@ -155,12 +155,14 @@ writes `docs/design/<module>.md`, not its own compiled layer — the
    the tables above, plus the updated build graph) and unlocks the next
    layer. On a scope violation or a failing check, the task moves to
    `blocked` with a `blocked_reason` of `scope_violation` or
-   `verification_failed`, and nothing downstream unlocks — fix it and
-   re-run `hedgehog verify <task-id> --owner <owner>`, don't hand-commit
-   around it.
+   `verification_failed`, and nothing downstream unlocks. Fix the work,
+   then run `hedgehog retry <task-id>` to return the task to `planned`,
+   claim it again, and verify again — `hedgehog verify` only accepts a
+   task you currently hold in `building`, so a blocked task has to go
+   back through `retry` and `claim` first. Don't hand-commit around it.
 
    A `blocked` task is not pickable by `hedgehog claim`, so `hedgehog
-   status` lists it under NEEDS ATTENTION with the task id to re-verify.
+   status` lists it under NEEDS ATTENTION with the task id to retry.
    If `hedgehog claim` returns nothing and the graph isn't actually done,
    fix that task — don't treat it as "nothing left to do."
 5. **Repeat** — `hedgehog claim --count N --owner <owner>` again for the


### PR DESCRIPTION
Across one full 36-task authored-core build, the operator had to drop out of the CLI and run raw `UPDATE` statements against `.hedgehog/hedgehog.db` **eight separate times** — for situations that are entirely normal in the intended workflow. This adds the missing commands, with reproductions.

## The four gaps, confirmed in the current code

**1. A failed verify is a dead end.** `verify.mjs` blocks the task and clears the lease. The recovery the loop skills document — "fix it and re-run `hedgehog verify <task-id> --owner <owner>`" — is **impossible**: `claimForVerify` asserts `if (task.status !== 'building' || task.lease_owner !== owner) throw`, and `releaseTask`'s UPDATE is `WHERE id = ? AND lease_owner = ? AND status = 'building'`. Nothing in the CLI writes `blocked → anything`. A failed verify is the *expected* case of the loop — build, gate rejects, fix, retry — not an anomaly.

**2. A scope violation is identical.** Same `setTaskStatus(..., 'blocked', ...)` path, same three refusals.

**3. `claim` printed no packet, and the packet then became unreachable.** The documented flow says claim returns a packet with STATUS / ALLOWED SCOPE / VERIFICATION per task; `claimCommand` printed only the id and lease expiry. And because `next.mjs`'s `READY_TASK_SQL` requires `status IN ('planned','ready') AND t.lease_owner IS NULL` while `claimOne` sets `status = 'building'`, `hedgehog next` then reports "No ready task" — so no command could print the scope and verify command the operator is supposed to delegate. Reading the `tasks` row out of SQLite by hand was the only path.

**4. No targeted claim.** `claimTasks` walks `ORDER BY t.priority, t.id` greedily and skips any candidate where `conflicts(...) !== null`. Since `conflicts` returns `'exclusive'` if *either* side is exclusive, an exclusive task is skipped whenever any non-exclusive candidate sorts ahead of it — **permanently**, not just while work is in flight. As the first layer of each module, a starved `exclusive` infra layer stops that whole module from starting.

## What this adds

- **`hedgehog show <task-id>`** — the `next` packet for any task at any status. `formatNext` still passes `'READY'`, so `next` output is byte-identical (verified by diffing `next`/`status`/`ready` output before vs after).
- **`hedgehog retry <task-id>`** — `blocked → planned` for every `blocked_reason`, clearing `blocked_reason` and all three lease columns in one UPDATE. The schema's `CHECK ((lease_owner IS NULL) = (status NOT IN ('building','verifying')))` holds.
- **`hedgehog claim <task-id> --owner <o>`** — keeps every fan-out precondition (status, lease, dependencies, conflict with in-flight work) and reports *which* one refused, exiting non-zero. Deliberately **no** `--force`: releasing or finishing the neighbour is the fix, not overriding the conflict rule.
- **`claim` now prints the full packet** for each task it hands out, after the unchanged summary lines.
- **Every write command prints `db  <absolute path>`**, and `retry` / targeted `claim` / `release` / `renew` / `show` exit non-zero with "No such task" on a zero-row match.

That last point closes a failure mode observed directly: a hand-written recovery script used a relative DB path, was run from the wrong directory, opened a different database, matched zero rows, printed `undefined`, and exited **zero**. A silent green success over the wrong database.

- **The three loop skills and the `status` hint now point at `retry`** instead of the re-verify that cannot work.

## Reproductions

`node repro/run-all.mjs` — standalone Node, `node:sqlite`, plain assertions, a throwaway git + graph project per case (no test framework is available in this repo).

- **Before** (implementation stashed): 5 of 5 scripts fail — `Unknown command: retry`, claim printing no `ALLOWED SCOPE`, the targeted claim not existing, no db path in output.
- **After**: all 8 named cases pass, including "a recovery command run in the wrong directory refuses".

`node scripts/check.mjs` is green, and `bin/cli.mjs` parses and runs at every one of the commits.

## Honest caveats

- Batch `claim` returning zero still exits **0**. That is a documented state the loop skills depend on ("if claim returns nothing and the graph isn't done…"), so changing it would break existing behaviour. Only the targeted commands fail loudly on no match.
- The `bin/cli.mjs` hunks were split into an observability commit and a new-commands commit; the import line lands in the earlier one, so that commit imports two symbols it does not yet use. Cosmetic — the CLI runs at every commit — and left alone rather than risking a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
