### PR TITLE
fix(core): unescape quoted scalars in the core.yaml parser

### DIFF
--- a/repro/parse-real-cores.mjs
+++ b/repro/parse-real-cores.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// No-regression harness for the quoted-scalar escape fix.
+//
+// Loads every core.yaml that ships with (or lives in) this repo through
+// the real loader and prints a stable, fully-ordered dump of the parsed
+// result. Run it before and after a change to src/db/core.mjs and diff the
+// two outputs: identical output means ordinary core definitions parse
+// exactly as they did.
+//
+// Run: node repro/parse-real-cores.mjs
+
+import { readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadCore, parseCoreYaml } from '../src/db/core.mjs';
+import { readFile } from 'node:fs/promises';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+
+function findCoreYaml(dir, found = []) {
+  for (const entry of readdirSync(dir)) {
+    if (entry === '.git' || entry === 'node_modules') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) findCoreYaml(full, found);
+    else if (entry === 'core.yaml') found.push(full);
+  }
+  return found;
+}
+
+const files = findCoreYaml(root).sort();
+if (files.length === 0) {
+  console.error('no core.yaml found — the harness would prove nothing');
+  process.exit(1);
+}
+
+let failed = 0;
+for (const file of files) {
+  const rel = relative(root, file);
+  console.log(`=== ${rel} ===`);
+  try {
+    // loadCore = parseCoreYaml + validateCore, the real entry point.
+    const core = await loadCore(file);
+    // Re-parse the raw text too, so a validation-only difference cannot
+    // hide a parse difference.
+    const raw = parseCoreYaml(await readFile(file, 'utf8'));
+    if (JSON.stringify(core) !== JSON.stringify(raw)) {
+      console.log('  !! loadCore and parseCoreYaml disagree');
+      failed++;
+    }
+    console.log(JSON.stringify(core, null, 2));
+  } catch (error) {
+    console.log(`  !! FAILED TO LOAD: ${error.message}`);
+    failed++;
+  }
+}
+
+console.log(`\n${files.length} core file(s), ${failed} failure(s)`);
+process.exit(failed === 0 ? 0 : 1);

--- a/repro/yaml-scalar-escapes.mjs
+++ b/repro/yaml-scalar-escapes.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+// Reproduction for the quoted-scalar escape bug in src/db/core.mjs.
+//
+// The core-definition parser is hand-rolled (the package ships no YAML
+// dependency). Its `parseScalar` recognised a quoted scalar by its first
+// and last character and then returned `s.slice(1, -1)` — the quotes came
+// off, but the escape sequences inside never did. A `verify` command
+// written with escaped quotes therefore loaded, validated, and appeared
+// correct in every listing, while the string actually handed to the shell
+// still carried literal backslashes.
+//
+// The method that found it, and the method used here: assert against the
+// string the parser RETURNS, not the string as written in the file. The
+// two look identical in a YAML listing and are not the same string.
+//
+// No test framework is available. Plain assertions, expected-vs-actual on
+// failure, non-zero exit if anything fails.
+//
+// Run: node repro/yaml-scalar-escapes.mjs
+
+import { execFileSync } from 'node:child_process';
+import { parseCoreYaml } from '../src/db/core.mjs';
+
+let failures = 0;
+let passes = 0;
+
+function check(name, actual, expected) {
+  const ok = actual === expected;
+  if (ok) {
+    passes++;
+    console.log(`  PASS  ${name}`);
+  } else {
+    failures++;
+    console.log(`  FAIL  ${name}`);
+    console.log(`          expected: ${JSON.stringify(expected)}`);
+    console.log(`          actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+function checkThrows(name, fn) {
+  try {
+    const value = fn();
+    failures++;
+    console.log(`  FAIL  ${name}`);
+    console.log(`          expected: a thrown error`);
+    console.log(`          actual:   returned ${JSON.stringify(value)}`);
+  } catch {
+    passes++;
+    console.log(`  PASS  ${name}`);
+  }
+}
+
+// Parses a one-layer core and hands back that layer. String.raw is used at
+// every call site so the YAML in this file is byte-for-byte the YAML a core
+// author would type.
+function layerFrom(verify, commit = '"chore: demo"') {
+  const yaml = [
+    'id: demo',
+    'layers:',
+    '  - id: only',
+    '    scope: [src/**]',
+    `    verify: ${verify}`,
+    `    commit: ${commit}`,
+  ].join('\n');
+  return parseCoreYaml(yaml).layers[0];
+}
+
+// ---------------------------------------------------------------------
+console.log('\n1. escaped quotes in a double-quoted scalar (the reported bug)');
+// In the file:  verify: "export PATH=\"$HOME/bin:$PATH\"; echo PATH=$PATH"
+{
+  const src = String.raw`"export PATH=\"$HOME/bin:$PATH\"; echo PATH=$PATH"`;
+  check(
+    'backslash-escaped quotes are unescaped',
+    layerFrom(src).verify,
+    'export PATH="$HOME/bin:$PATH"; echo PATH=$PATH',
+  );
+}
+
+// ---------------------------------------------------------------------
+console.log('\n2. the parsed string, run as a shell command');
+// This is the check that exposed the bug: run what the parser returned,
+// not what the file says. With the backslashes left in, sh sees \" as a
+// literal quote character and the assignment's value carries parasitic
+// quotes, producing an invalid PATH.
+{
+  const src = String.raw`"export PATH=\"$HOME/bin:$PATH\"; printf %s \"$PATH\""`;
+  const verify = layerFrom(src).verify;
+  let output;
+  try {
+    output = execFileSync('/bin/sh', ['-c', verify], {
+      encoding: 'utf8',
+      env: { HOME: '/home/u', PATH: '/usr/bin' },
+    });
+  } catch (error) {
+    output = `<command failed: ${error.message}>`;
+  }
+  check('PATH built by the parsed command has no parasitic quotes', output, '/home/u/bin:/usr/bin');
+}
+
+// ---------------------------------------------------------------------
+console.log('\n3. the rest of the double-quoted escape set');
+{
+  check('\\\\ becomes a single backslash', layerFrom(String.raw`"a\\b"`).verify, 'a\\b');
+  check('\\n becomes a newline', layerFrom(String.raw`"a\nb"`).verify, 'a\nb');
+  check('\\t becomes a tab', layerFrom(String.raw`"a\tb"`).verify, 'a\tb');
+  check('\\r becomes a carriage return', layerFrom(String.raw`"a\rb"`).verify, 'a\rb');
+  check('\\/ becomes a slash', layerFrom(String.raw`"a\/b"`).verify, 'a/b');
+  check('\\0 becomes NUL', layerFrom(String.raw`"a\0b"`).verify, 'a\0b');
+  check('\\xNN is a hex escape', layerFrom(String.raw`"a\x41b"`).verify, 'aAb');
+  check(
+    '\\uNNNN is a unicode escape',
+    layerFrom('"a\\u00e9b"').verify,
+    'aéb',
+  );
+  // A backslash that escapes nothing meaningful must be loud, never silent.
+  checkThrows('an unknown escape is rejected', () => layerFrom(String.raw`"a\qb"`).verify);
+  checkThrows('an unterminated double-quoted scalar is rejected', () =>
+    layerFrom(String.raw`"a\"`).verify);
+}
+
+// ---------------------------------------------------------------------
+console.log("\n4. single-quoted scalars ('' is YAML's escape for a quote)");
+{
+  check(
+    "'' becomes one literal quote",
+    layerFrom(`'echo it''s fine'`).verify,
+    "echo it's fine",
+  );
+  check(
+    'a backslash in a single-quoted scalar stays literal',
+    layerFrom(`'grep -E "a\\d" .'`).verify,
+    'grep -E "a\\d" .',
+  );
+  checkThrows('an unterminated single-quoted scalar is rejected', () =>
+    layerFrom(`'abc`).verify);
+}
+
+// ---------------------------------------------------------------------
+console.log('\n5. a # after an escaped quote is not a comment');
+// stripComment tracked quote state without honouring backslashes, so the
+// escaped quote read as the end of the string and everything from the
+// following # onward was discarded as a comment — silently truncating the
+// command.
+{
+  const src = String.raw`"echo \"tag#1\" && test -f a"`;
+  check(
+    'the value survives a # inside the quoted scalar',
+    layerFrom(src).verify,
+    'echo "tag#1" && test -f a',
+  );
+}
+
+// ---------------------------------------------------------------------
+console.log('\n6. no regression: ordinary scalars parse as before');
+{
+  const yaml = [
+    '# a leading comment',
+    'id: demo-core',
+    'layers:',
+    '  - id: schema',
+    '    scope: [packages/db/src/schema/**, packages/db/src/index.ts]',
+    '    verify: pnpm nx test db    # trailing comment',
+    '    commit: "feat(schema): tables"',
+    '    exclusive: true',
+    '    verify_radius: [packages/db/**]',
+    '  - id: api',
+    "    depends_on: schema",
+    '    scope: [apps/api/**]',
+    "    verify: 'pnpm nx test api'",
+    '    commit: feat(api): endpoints',
+  ].join('\n');
+  const core = parseCoreYaml(yaml);
+  check('top-level id', core.id, 'demo-core');
+  check('layer count', String(core.layers.length), '2');
+  check('unquoted verify, comment stripped', core.layers[0].verify, 'pnpm nx test db');
+  check('double-quoted commit', core.layers[0].commit, 'feat(schema): tables');
+  check('inline list first entry', core.layers[0].scope[0], 'packages/db/src/schema/**');
+  check('inline list second entry', core.layers[0].scope[1], 'packages/db/src/index.ts');
+  check('exclusive flag', String(core.layers[0].exclusive), 'true');
+  check('verify_radius', core.layers[0].verify_radius.join('|'), 'packages/db/**');
+  check('depends_on', core.layers[1].depends_on, 'schema');
+  check('single-quoted verify', core.layers[1].verify, 'pnpm nx test api');
+  check('unquoted commit with a colon', core.layers[1].commit, 'feat(api): endpoints');
+  check('default verify_radius is null', String(core.layers[1].verify_radius), 'null');
+  check('default exclusive is false', String(core.layers[1].exclusive), 'false');
+}
+
+console.log(`\n${passes} passed, ${failures} failed`);
+process.exit(failures === 0 ? 0 : 1);

--- a/src/db/core.mjs
+++ b/src/db/core.mjs
@@ -8,6 +8,19 @@
 // subset is all a core definition ever needs, so this hand-rolled parser
 // covers it without adding a YAML dependency, the same "no dependency"
 // stance src/db/schema.mjs takes with node:sqlite.
+//
+// Quoted scalars are unescaped properly, because `verify` is a shell
+// command and a half-parsed command is worse than an unparsed one:
+//   - double-quoted: the YAML escape set — \" \\ \/ \n \t \r \0 \a \b
+//     \v \f \e \<space> \N \_ \L \P, plus \xNN, \uNNNN and \UNNNNNNNN.
+//     An unrecognised escape, a trailing backslash and an unterminated
+//     quote all throw, so a scalar this parser cannot represent fails
+//     loudly instead of reaching the shell with its backslashes intact.
+//   - single-quoted: no backslash escapes at all; `''` is the only
+//     escape and yields one literal quote.
+// Still outside the subset: multi-line (block) scalars, and a comma
+// inside a quoted entry of an inline list, which parseInlineList splits
+// on regardless.
 
 import { readFile } from 'node:fs/promises';
 
@@ -17,6 +30,16 @@ function stripComment(line) {
   let inDouble = false;
   for (let i = 0; i < line.length; i++) {
     const ch = line[i];
+    // Inside a double-quoted scalar a backslash escapes the next
+    // character, so `\"` must not be read as the closing quote — without
+    // this, a '#' later in the same scalar looks like it sits outside the
+    // string and the value is silently truncated at that point.
+    // Single-quoted scalars have no backslash escape; their `''` escape
+    // toggles inSingle off and straight back on, which lands correctly.
+    if (inDouble && ch === '\\') {
+      i++;
+      continue;
+    }
     if (ch === "'" && !inDouble) inSingle = !inSingle;
     else if (ch === '"' && !inSingle) inDouble = !inDouble;
     else if (ch === '#' && !inSingle && !inDouble) return line.slice(0, i);
@@ -24,13 +47,120 @@ function stripComment(line) {
   return line;
 }
 
+// The single-character escapes YAML defines for a double-quoted scalar
+// (spec 5.7, "Escaped Characters"). `\<space>` and `\/` are included; the
+// line-continuation `\<newline>` is not, because a core definition's
+// scalars are always single-line.
+const ESCAPES = new Map([
+  ['0', '\0'],
+  ['a', '\x07'],
+  ['b', '\b'],
+  ['t', '\t'],
+  ['\t', '\t'],
+  ['n', '\n'],
+  ['v', '\v'],
+  ['f', '\f'],
+  ['r', '\r'],
+  ['e', '\x1b'],
+  [' ', ' '],
+  ['"', '"'],
+  ['/', '/'],
+  ['\\', '\\'],
+  ['N', '\u0085'], // next line
+  ['_', '\u00a0'], // non-breaking space
+  ['L', '\u2028'], // line separator
+  ['P', '\u2029'], // paragraph separator
+]);
+
+// The hex escapes, keyed by how many hex digits each consumes.
+const HEX_ESCAPES = new Map([
+  ['x', 2],
+  ['u', 4],
+  ['U', 8],
+]);
+
+// Index of the quote that closes a double-quoted scalar opened at 0, or
+// -1 if the scalar is unterminated. A backslash escapes whatever follows.
+function closingDoubleQuote(s) {
+  for (let i = 1; i < s.length; i++) {
+    if (s[i] === '\\') i++;
+    else if (s[i] === '"') return i;
+  }
+  return -1;
+}
+
+// The single-quoted equivalent. There is no backslash escape here — the
+// only escape is `''`, which stands for one literal quote.
+function closingSingleQuote(s) {
+  for (let i = 1; i < s.length; i++) {
+    if (s[i] !== "'") continue;
+    if (s[i + 1] === "'") i++;
+    else return i;
+  }
+  return -1;
+}
+
+function unescapeDoubleQuoted(body, raw) {
+  if (!body.includes('\\')) return body;
+  let out = '';
+  for (let i = 0; i < body.length; i++) {
+    if (body[i] !== '\\') {
+      out += body[i];
+      continue;
+    }
+    const code = body[i + 1];
+    const simple = ESCAPES.get(code);
+    if (simple !== undefined) {
+      out += simple;
+      i++;
+      continue;
+    }
+    const width = HEX_ESCAPES.get(code);
+    if (width !== undefined) {
+      const digits = body.slice(i + 2, i + 2 + width);
+      if (digits.length !== width || !/^[0-9A-Fa-f]+$/.test(digits)) {
+        throw new Error(
+          `invalid \\${code} escape (expected ${width} hex digits) in: ${raw}`,
+        );
+      }
+      out += String.fromCodePoint(parseInt(digits, 16));
+      i += 1 + width;
+      continue;
+    }
+    // An unrecognised escape is an error rather than a pass-through. A
+    // verify command whose backslashes survive into the shell is the
+    // silent-wrong-value failure this whole function exists to prevent.
+    throw new Error(
+      code === undefined
+        ? `trailing backslash in double-quoted scalar: ${raw}`
+        : `unknown escape "\\${code}" in double-quoted scalar: ${raw}`,
+    );
+  }
+  return out;
+}
+
+// Unwraps a quoted scalar and resolves its escapes, or returns a plain
+// scalar as-is. Escapes matter because `verify` is a shell command: a
+// scalar whose backslashes are left in place still loads, still
+// validates, and still lists correctly, but runs as a different command
+// than the one written.
 function parseScalar(raw) {
   const s = raw.trim();
-  if (
-    (s.startsWith('"') && s.endsWith('"')) ||
-    (s.startsWith("'") && s.endsWith("'"))
-  ) {
-    return s.slice(1, -1);
+  if (s.startsWith('"')) {
+    const end = closingDoubleQuote(s);
+    if (end === -1) throw new Error(`unterminated double-quoted scalar: ${raw}`);
+    if (end !== s.length - 1) {
+      throw new Error(`unexpected content after a double-quoted scalar: ${raw}`);
+    }
+    return unescapeDoubleQuoted(s.slice(1, end), raw);
+  }
+  if (s.startsWith("'")) {
+    const end = closingSingleQuote(s);
+    if (end === -1) throw new Error(`unterminated single-quoted scalar: ${raw}`);
+    if (end !== s.length - 1) {
+      throw new Error(`unexpected content after a single-quoted scalar: ${raw}`);
+    }
+    return s.slice(1, end).replaceAll("''", "'");
   }
   return s;
 }


### PR DESCRIPTION
The hand-rolled `core.yaml` parser does not unescape quoted scalars. It recognises a quoted scalar by its first and last character and strips exactly those two, with no unescaping step at all — `src/db/core.mjs`, `parseScalar` before this change:

```js
function parseScalar(raw) {
  const s = raw.trim();
  if (
    (s.startsWith('"') && s.endsWith('"')) ||
    (s.startsWith("'") && s.endsWith("'"))
  ) {
    return s.slice(1, -1);
  }
  return s;
}
```

## Why it matters

An escaped quote is the only single-line way to write a nested quote inside a shell `verify` command. Parsing

```yaml
verify: "export PATH=\"$HOME/bin:$PATH\"; echo PATH=$PATH"
```

and then running **what the parser returned** through `sh` gives:

```
parsed:  export PATH=\"$HOME/bin:$PATH\"; echo PATH=$PATH
sh says: PATH="/home/u/bin:/usr/local/sbin:..."
```

The parasitic quotes end up inside the value and the resulting `PATH` is invalid. The failure is silent in the worst way: the YAML loads, `loadCore` validates, every layer appears correctly, and only the runtime behaviour is wrong. It was found only by extracting the string exactly as the parser returned it and running *that*, rather than the string as written in the file.

## Two more defects with the same root cause

Both found while confirming the first:

- **`''` in a single-quoted scalar is not unescaped either.** `'echo it''s fine'` returns `echo it''s fine`.
- **`stripComment` toggles quote state without honouring backslashes**, so `verify: "echo \"tag#1\" && test -f a"` parsed to `"echo \"tag` — silently, since the mangled remainder no longer ends in a quote and falls through the `startsWith`/`endsWith` test unstripped.

## The fix

Implementing the escapes rather than rejecting them: the single-quoted fallback was broken the same way, so rejection would have left core authors with no working form for a nested quote. The unescaping is ~40 lines with no new dependency.

- Double-quoted scalars take the YAML 5.7 escape set: `\" \\ \/ \n \t \r \0 \a \b \v \f \e \<space> \N \_ \L \P`, plus `\xNN`, `\uNNNN`, `\UNNNNNNNN`.
- Single-quoted scalars take `''` as one literal quote, with no backslash escapes.
- The closing quote is found by scanning with escapes honoured, not by testing the last character.
- `stripComment` skips the character after a backslash while inside a double-quoted scalar.
- Where the parser still cannot represent something — unknown escape, trailing backslash, unterminated or improperly closed quote — it **throws**. The residual gap is loud, never a plausible-looking wrong string.
- The header comment documents the supported set and what remains outside it.

## Evidence

`repro/yaml-scalar-escapes.mjs` — plain assertions, prints expected vs actual, non-zero exit (no test framework is available in this repo). It includes the method that found the bug: it executes the parsed string through `/bin/sh` and asserts the resulting `PATH` has no parasitic quotes.

- **Before:** 14 passed, 15 failed, exit 1
- **After:** 29 passed, 0 failed, exit 0

Section 6 is a no-regression baseline of ordinary parsing — unquoted values, trailing comments, inline lists, `exclusive`, `verify_radius`, `depends_on`, an unquoted commit message containing a colon. It passed *before* the fix too, so it pins existing behaviour rather than describing the new one.

`repro/parse-real-cores.mjs` loads both shipped cores (`src/golden-cores/full-stack-app/core.yaml`, `src/golden-cores/landing-page/core.yaml`) through the real `loadCore` and dumps the parsed structure. The before-vs-after diff is **empty** — both parse identically. `node scripts/check.mjs` passes.

## One behaviour change worth flagging

A malformed scalar such as `verify: "echo hi" && test` previously returned the raw line including quotes; it now throws `unexpected content after a double-quoted scalar`. That is intentional — silent-wrong becomes loud — but it is a change. Neither shipped core contains such a pattern (the identical diff proves it), though an authored `.hedgehog/core.yaml` in the wild that relied on the old behaviour would now fail visibly at load time.

Not fixed, as out of scope: `parseInlineList` splits on `,` unconditionally, so a comma inside a quoted `scope` entry still breaks. Now documented in the header comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
