### PR TITLE
fix(verify): run git without a shell to stop command injection from file names and core.yaml

### DIFF
--- a/repro/fixture.mjs
+++ b/repro/fixture.mjs
@@ -1,0 +1,150 @@
+// Shared fixture for the repro scripts: a throwaway git repo with a
+// one-layer authored core, an intent compiled into a task, and that task
+// claimed — the exact state a build agent hands to `hedgehog verify`.
+//
+// Everything lives inside a fresh `mkdtemp` directory. Nothing outside it
+// is ever written or removed.
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+export const CLI = resolve(HERE, '..', 'bin', 'cli.mjs');
+
+export function git(cwd, args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: 'pipe' });
+}
+
+// Runs the real `hedgehog` CLI. A nonzero exit is a legitimate outcome
+// (a scope violation or a failing verify_command is exit 1), so it is
+// captured rather than thrown.
+export function hedgehog(cwd, args) {
+  try {
+    const stdout = execFileSync('node', [CLI, ...args], { cwd, encoding: 'utf8', stdio: 'pipe' });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      stdout: err.stdout ?? '',
+      stderr: err.stderr ?? String(err.message),
+    };
+  }
+}
+
+// `hedgehog plan` spawns a detached graph-viewer server per project.
+// These fixtures don't want one, and a repro run that leaves a dozen
+// stray node processes behind is bad manners.
+function stopGraphServer(repo) {
+  const pidfile = join(repo, '.hedgehog', 'graph-server.json');
+  // The detached server writes its own pidfile, which can land a moment
+  // after `plan` returns — poll briefly rather than racing it.
+  const deadline = Date.now() + 3000;
+  while (Date.now() < deadline) {
+    try {
+      const { pid } = JSON.parse(readFileSync(pidfile, 'utf8'));
+      if (pid) {
+        process.kill(pid);
+        return;
+      }
+    } catch {
+      // Not written yet, half-written, or the server is already gone.
+    }
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 50);
+  }
+}
+
+// `scope` is spliced into core.yaml's inline-list syntax verbatim, so
+// callers pass e.g. `src/**` or `src/**, docs/**`. `seed` is a map of
+// repo-relative path -> contents committed before the task is claimed.
+export function makeProject({ scope, verify = 'true', commit, seed = {} }) {
+  const root = mkdtempSync(join(tmpdir(), 'hedgehog-verify-repro-'));
+  const repo = join(root, 'repo');
+  mkdirSync(join(repo, 'src'), { recursive: true });
+  mkdirSync(join(repo, '.hedgehog'), { recursive: true });
+
+  git(repo, ['init', '-q']);
+  git(repo, ['config', 'user.email', 'repro@example.invalid']);
+  git(repo, ['config', 'user.name', 'repro']);
+  git(repo, ['config', 'commit.gpgsign', 'false']);
+
+  // The build graph, the commit lock and the graph-viewer pidfile are
+  // engine state, gitignored in every real Hedgehog project. The pidfile
+  // especially: the detached server rewrites and finally removes it on
+  // its own schedule, so a tracked copy shows up as a spurious
+  // working-tree change in whichever scenario happens to race it.
+  writeFileSync(
+    join(repo, '.gitignore'),
+    '.hedgehog/hedgehog.db*\n.hedgehog/commit.lock\n.hedgehog/graph-server.json\n',
+  );
+  writeFileSync(
+    join(repo, '.hedgehog', 'core.yaml'),
+    [
+      'id: repro',
+      'layers:',
+      '  - id: layer',
+      `    scope: [${scope}]`,
+      `    verify: ${verify}`,
+      `    commit: ${commit}`,
+      '',
+    ].join('\n'),
+  );
+  writeFileSync(join(repo, 'README.md'), 'repro fixture\n');
+  for (const [path, contents] of Object.entries(seed)) {
+    mkdirSync(dirname(join(repo, path)), { recursive: true });
+    writeFileSync(join(repo, path), contents);
+  }
+  git(repo, ['add', '-A']);
+  git(repo, ['commit', '-q', '-m', 'chore: seed']);
+
+  hedgehog(repo, ['db', 'init']);
+  hedgehog(repo, ['intent', 'add', '--id', 'demo', '--goal', 'g', '--outcome', 'o']);
+  hedgehog(repo, ['plan']);
+  stopGraphServer(repo);
+
+  // Real projects commit `.hedgehog/intents/*.json`; leaving them
+  // untracked would trip the scope gate before verify reaches the code
+  // under test.
+  git(repo, ['add', '-A', '.hedgehog']);
+  git(repo, ['commit', '-q', '-m', 'chore: intents']);
+
+  const claim = hedgehog(repo, ['claim', '--owner', 'repro']);
+  if (!/Claimed/.test(claim.stdout)) {
+    throw new Error(`fixture setup failed: claim did not succeed\n${claim.stdout}${claim.stderr}`);
+  }
+
+  return { root, repo, taskId: 'DEMO-LAYER' };
+}
+
+// Minimal assertion harness — no test framework is available.
+export function makeReporter() {
+  const results = [];
+  return {
+    check(scenario, name, expected, actual) {
+      const ok = JSON.stringify(expected) === JSON.stringify(actual);
+      results.push({ scenario, name, expected, actual, ok });
+      console.log(`  [${ok ? 'PASS' : 'FAIL'}] ${name}`);
+      if (!ok) {
+        console.log(`         expected: ${JSON.stringify(expected)}`);
+        console.log(`         actual:   ${JSON.stringify(actual)}`);
+      }
+    },
+    finish(passMessage, failMessage) {
+      const failed = results.filter((r) => !r.ok);
+      console.log('\n─────────────────────────────────────────────');
+      console.log(`${results.length - failed.length}/${results.length} checks passed`);
+      if (failed.length > 0) {
+        console.log(`\n${failMessage}`);
+        for (const f of failed) {
+          console.log(`  scenario ${f.scenario}: ${f.name}`);
+          console.log(`    expected: ${JSON.stringify(f.expected)}`);
+          console.log(`    actual:   ${JSON.stringify(f.actual)}`);
+        }
+        process.exit(1);
+      }
+      console.log(passMessage);
+    },
+  };
+}

--- a/repro/normal-verify.mjs
+++ b/repro/normal-verify.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+// No-regression harness for `hedgehog verify`, run against the real CLI
+// on throwaway projects. Nothing here involves a payload — the point is
+// that swapping `execSync` for `execFileSync` in src/db/verify.mjs left
+// ordinary behaviour byte-for-byte identical. This script passes both
+// before and after the fix.
+//
+// Covered:
+//   1. the happy path — multi-glob scope, `:(glob)` semantics, created vs
+//      modified artifact classification, exact commit subject, exactly
+//      the in-scope files staged, task `complete`, exit 0
+//   2. paths that are awkward for a shell but legitimate for git — spaces
+//      and quotes in a file name — still classified, staged and committed
+//   3. a touched path outside scope — `scope_violation`, exit 1, no commit
+//   4. a failing verify_command — `verification_failed`, exit 1, no commit
+//   5. a layer that touches nothing — no commit, still `complete`
+//
+// Every project lives inside its own `mkdtemp` directory.
+
+import { DatabaseSync } from 'node:sqlite';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { CLI, git, hedgehog, makeProject, makeReporter } from './fixture.mjs';
+
+const report = makeReporter();
+
+function write(repo, path, contents) {
+  mkdirSync(dirname(join(repo, path)), { recursive: true });
+  writeFileSync(join(repo, path), contents);
+}
+
+function committedFiles(repo) {
+  return git(repo, ['show', '--name-only', '--format=', 'HEAD']).trim().split('\n').filter(Boolean).sort();
+}
+
+function readGraph(repo, taskId) {
+  const db = new DatabaseSync(join(repo, '.hedgehog', 'hedgehog.db'), { readOnly: true });
+  try {
+    const task = db.prepare('SELECT status, blocked_reason FROM tasks WHERE id = ?').get(taskId);
+    const artifacts = db
+      .prepare('SELECT path, kind FROM artifacts WHERE task_id = ? ORDER BY path')
+      .all(taskId);
+    return { task, artifacts };
+  } finally {
+    db.close();
+  }
+}
+
+// ── 1. Happy path ──────────────────────────────────────────────────────
+function happyPath() {
+  console.log('\n1 — happy path: multi-glob scope, created + modified, exact commit');
+  const subject = 'feat(demo): layer';
+  const { repo, taskId } = makeProject({
+    scope: 'src/**, docs/**',
+    commit: subject,
+    seed: { 'src/existing.ts': 'export const existing = 0;\n', 'docs/old.md': 'old\n' },
+  });
+
+  write(repo, 'src/existing.ts', 'export const existing = 1;\n');
+  write(repo, 'src/nested/new.ts', 'export const created = 1;\n');
+  write(repo, 'docs/new.md', 'new\n');
+
+  const res = hedgehog(repo, ['verify', taskId, '--owner', 'repro']);
+  const { task, artifacts } = readGraph(repo, taskId);
+
+  report.check('1', 'verify exits 0', 0, res.status);
+  report.check('1', 'commit subject is exactly the core.yaml message', subject, git(repo, ['log', '-1', '--format=%s']).trim());
+  report.check('1', 'exactly the in-scope files are committed', ['docs/new.md', 'src/existing.ts', 'src/nested/new.ts'], committedFiles(repo));
+  report.check('1', 'task is complete', { status: 'complete', blocked_reason: null }, task);
+  report.check(
+    '1',
+    'artifacts classified created vs modified',
+    [
+      { path: 'docs/new.md', kind: 'created' },
+      { path: 'src/existing.ts', kind: 'modified' },
+      { path: 'src/nested/new.ts', kind: 'created' },
+    ],
+    artifacts,
+  );
+  report.check('1', 'working tree is clean afterwards', '', git(repo, ['status', '--porcelain']).trim());
+}
+
+// ── 2. Shell-awkward but legitimate file names ─────────────────────────
+// Spaces, semicolons, ampersands, parentheses, quotes, a leading dash.
+// Every one of these is inert inside the old double-quoted command line
+// *and* inert as an argv entry, so this scenario passes identically
+// before and after the fix — which is exactly what makes it useful as a
+// no-regression check rather than a second injection test.
+//
+// Deliberately excluded: a `"` in a file name. `git ls-files --others`
+// C-quotes such a path on output, so verify.mjs reads back the literal
+// `"src/has\"quote.ts"` (outer quotes included) and the subsequent `git
+// add` fails. That is a pre-existing path-decoding bug, present
+// identically before and after this change, and out of scope here.
+function awkwardNames() {
+  console.log('\n2 — file names that are awkward for a shell but legal for git');
+  const { repo, taskId } = makeProject({
+    scope: 'src/**',
+    commit: 'feat(demo): layer',
+    seed: { 'src/keep.ts': 'export const keep = 0;\n' },
+  });
+
+  const names = [
+    'src/a file.ts',
+    'src/semi;colon.ts',
+    'src/amp&and.ts',
+    'src/paren(1).ts',
+    "src/it's.ts",
+    'src/-leading-dash.ts',
+  ];
+  for (const n of names) write(repo, n, 'export const x = 1;\n');
+
+  const res = hedgehog(repo, ['verify', taskId, '--owner', 'repro']);
+  const { task, artifacts } = readGraph(repo, taskId);
+
+  report.check('2', 'verify exits 0', 0, res.status);
+  report.check('2', 'every awkward name is committed', [...names].sort(), committedFiles(repo));
+  report.check('2', 'task is complete', 'complete', task?.status);
+  report.check('2', 'every awkward name is recorded as created', [...names].sort().map((path) => ({ path, kind: 'created' })), artifacts);
+}
+
+// ── 3. Scope violation ─────────────────────────────────────────────────
+function scopeViolation() {
+  console.log('\n3 — a touched path outside scope');
+  const { repo, taskId } = makeProject({ scope: 'src/**', commit: 'feat(demo): layer' });
+  const headBefore = git(repo, ['rev-parse', 'HEAD']).trim();
+
+  write(repo, 'src/ok.ts', 'export const ok = 1;\n');
+  write(repo, 'outside/bad.ts', 'export const bad = 1;\n');
+
+  const res = hedgehog(repo, ['verify', taskId, '--owner', 'repro']);
+  const { task } = readGraph(repo, taskId);
+
+  report.check('3', 'verify exits 1', 1, res.status);
+  report.check('3', 'the offending path is reported', true, res.stderr.includes('outside/bad.ts'));
+  report.check('3', 'task is blocked with scope_violation', { status: 'blocked', blocked_reason: 'scope_violation' }, task);
+  report.check('3', 'no commit landed', headBefore, git(repo, ['rev-parse', 'HEAD']).trim());
+}
+
+// ── 4. Failing verify_command ──────────────────────────────────────────
+// Also pins that verify_command is still run through a shell, on purpose:
+// `exit 3` is shell syntax, not an executable.
+function verifyFailure() {
+  console.log('\n4 — a failing verify_command (still a shell command by design)');
+  const { repo, taskId } = makeProject({
+    scope: 'src/**',
+    verify: 'echo boom && exit 3',
+    commit: 'feat(demo): layer',
+  });
+  const headBefore = git(repo, ['rev-parse', 'HEAD']).trim();
+
+  write(repo, 'src/ok.ts', 'export const ok = 1;\n');
+  const res = hedgehog(repo, ['verify', taskId, '--owner', 'repro']);
+  const { task } = readGraph(repo, taskId);
+
+  report.check('4', 'verify exits 1', 1, res.status);
+  report.check('4', 'the shell exit code is surfaced', true, res.stderr.includes('exit 3'));
+  report.check('4', 'verify_command output is captured', true, res.stderr.includes('boom'));
+  report.check('4', 'task is blocked with verification_failed', { status: 'blocked', blocked_reason: 'verification_failed' }, task);
+  report.check('4', 'no commit landed', headBefore, git(repo, ['rev-parse', 'HEAD']).trim());
+}
+
+// ── 5. A layer that touches nothing ────────────────────────────────────
+function emptyChangeSet() {
+  console.log('\n5 — a layer that touches nothing');
+  const { repo, taskId } = makeProject({ scope: 'src/**', commit: 'feat(demo): layer' });
+  const headBefore = git(repo, ['rev-parse', 'HEAD']).trim();
+
+  const res = hedgehog(repo, ['verify', taskId, '--owner', 'repro']);
+  const { task, artifacts } = readGraph(repo, taskId);
+
+  report.check('5', 'verify exits 0', 0, res.status);
+  report.check('5', 'no commit landed', headBefore, git(repo, ['rev-parse', 'HEAD']).trim());
+  report.check('5', 'task is complete', 'complete', task?.status);
+  report.check('5', 'no artifacts recorded', [], artifacts);
+}
+
+console.log('Hedgehog `hedgehog verify` no-regression harness');
+console.log(`CLI under test: ${CLI}`);
+
+happyPath();
+awkwardNames();
+scopeViolation();
+verifyFailure();
+emptyChangeSet();
+
+report.finish('Ordinary `hedgehog verify` behaviour is unchanged.', 'REGRESSION — the following checks failed:');

--- a/repro/shell-injection.mjs
+++ b/repro/shell-injection.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// Reproduction for the command-injection flaw in `src/db/verify.mjs`.
+//
+// `verify.mjs` built git command lines by string interpolation and ran
+// them through `execSync`, i.e. through `/bin/sh`. Its quoting helper was
+// `JSON.stringify(path)`, which escapes `"` and `\` but leaves `$` and
+// backticks untouched — and the result landed inside double quotes in a
+// shell command, where both are still interpreted. Three inputs reach
+// those command lines:
+//
+//   A. a layer's `scope` globs, from `.hedgehog/core.yaml`
+//        -> `git diff --name-only HEAD${scopeArgs}`
+//        -> `git ls-files --others --exclude-standard${scopeArgs}`
+//   B. a layer's `commit` message, from `.hedgehog/core.yaml`
+//        -> `git commit -m ${JSON.stringify(commitMessage)}`
+//   C. the names of files in the working tree, read back out of
+//      `git diff --name-only` / `git ls-files --others`
+//        -> `git ls-tree -r --name-only HEAD -- ${quoted}`
+//        -> `git add -- ${quoted}`
+//
+// None of those are attacker-supplied in the classic sense — and that is
+// the point. In Hedgehog's model `core.yaml` is written by the
+// `hedgehog-core-design` agent and the files are written by build agents,
+// so a confused or prompt-injected agent turns a file name into a command
+// that the verification gate itself executes.
+//
+// This script drives the REAL CLI (`bin/cli.mjs verify`), not an
+// imitation: each scenario builds a throwaway git repo, runs the real
+// db-init / intent / plan / claim / verify sequence against it, and
+// checks whether a marker file appeared.
+//
+// Safety: every scenario runs entirely inside its own `mkdtemp` directory
+// and the only thing a payload ever does is create a file inside that
+// directory (`touch`/`printf` with a relative path). Nothing is deleted,
+// nothing outside the temp directory is written, and the temp directories
+// are left behind so the evidence can be inspected.
+//
+// Expected: FAILS against the unfixed code (markers appear), PASSES once
+// the call sites use `execFileSync('git', [...])`.
+
+import { writeFileSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { CLI, git, hedgehog, makeProject, makeReporter } from './fixture.mjs';
+
+const report = makeReporter();
+const presence = (p) => (existsSync(p) ? 'present' : 'absent');
+
+// ── Scenario A: a `scope` glob from core.yaml ───────────────────────────
+// `$(touch ../pwn-scope)` substitutes to the empty string, so the
+// pathspec git actually received was the innocent `:(glob)src/**` — the
+// injection left no trace in the command's behaviour, only in the side
+// effect.
+function scenarioScopeGlob() {
+  console.log('\nScenario A — scope glob from .hedgehog/core.yaml (git diff / git ls-files)');
+  const { root, repo, taskId } = makeProject({
+    scope: 'src/**$(touch ../pwn-scope)',
+    commit: 'feat(demo): layer',
+  });
+  const marker = join(root, 'pwn-scope');
+
+  writeFileSync(join(repo, 'src', 'a.ts'), 'export const a = 1;\n');
+  const res = hedgehog(repo, ['verify', taskId, '--owner', 'repro']);
+  console.log(`         (verify exit ${res.status}; temp dir ${root})`);
+
+  report.check('A', 'no marker created by the scope glob', 'absent', presence(marker));
+}
+
+// ── Scenario B: the `commit` message from core.yaml ─────────────────────
+// Two observable effects: the payload runs, and the injected text is
+// consumed by the shell instead of being recorded, so the commit subject
+// git stores is not the subject core.yaml declared.
+function scenarioCommitMessage() {
+  console.log('\nScenario B — commit message from .hedgehog/core.yaml (git commit -m)');
+  const declared = 'feat(demo): layer $(touch ../pwn-commit)';
+  const { root, repo, taskId } = makeProject({ scope: 'src/**', commit: declared });
+  const marker = join(root, 'pwn-commit');
+
+  writeFileSync(join(repo, 'src', 'a.ts'), 'export const a = 1;\n');
+  const res = hedgehog(repo, ['verify', taskId, '--owner', 'repro']);
+  const subject = git(repo, ['log', '-1', '--format=%s']).trim();
+  console.log(`         (verify exit ${res.status}; temp dir ${root})`);
+  console.log(`         recorded commit subject: ${JSON.stringify(subject)}`);
+
+  report.check('B', 'no marker created by the commit message', 'absent', presence(marker));
+  report.check('B', 'commit subject recorded verbatim', declared, subject);
+}
+
+// ── Scenario C: a file name in the working tree ─────────────────────────
+// Two payload names, one using `$( )` and one using backticks — neither
+// of which `JSON.stringify` escaped. The payload appends one byte per
+// execution, so the marker's size counts them: 4 bytes means both call
+// sites (`git ls-tree` and `git add`) ran both payloads. Innocent
+// siblings `src/evil.ts` / `src/tick.ts` exist so that the pathspecs the
+// substitutions collapse to still match real files and the flow runs to
+// completion — which also exposes the second half of the bug, namely
+// that the payload files themselves silently evade staging.
+function scenarioFileName() {
+  console.log('\nScenario C — file name in the working tree (git ls-tree / git add)');
+  const { root, repo, taskId } = makeProject({ scope: 'src/**', commit: 'feat(demo): layer' });
+  const marker = join(repo, 'pwn-count');
+  const payloadFiles = ['src/evil$(printf x >>pwn-count).ts', 'src/tick`printf x >>pwn-count`.ts'];
+
+  writeFileSync(join(repo, 'src', 'evil.ts'), 'export const evil = 1;\n');
+  writeFileSync(join(repo, 'src', 'tick.ts'), 'export const tick = 1;\n');
+  for (const f of payloadFiles) writeFileSync(join(repo, f), 'export const payload = 1;\n');
+
+  const res = hedgehog(repo, ['verify', taskId, '--owner', 'repro']);
+  const executions = existsSync(marker) ? statSync(marker).size : 0;
+  console.log(`         (verify exit ${res.status}; temp dir ${root})`);
+  console.log(`         payload executions recorded: ${executions}`);
+
+  let committed = [];
+  try {
+    committed = git(repo, ['show', '--name-only', '--format=', 'HEAD'])
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .sort();
+  } catch {
+    // no commit landed
+  }
+  console.log(`         files in the verify commit: ${committed.join(', ') || '(none)'}`);
+
+  report.check('C', 'no marker created by the file name', 'absent', presence(marker));
+  report.check(
+    'C',
+    'the payload-named files are actually staged',
+    payloadFiles,
+    payloadFiles.filter((f) => committed.includes(f)),
+  );
+}
+
+console.log('Hedgehog `hedgehog verify` command-injection reproduction');
+console.log(`CLI under test: ${CLI}`);
+
+scenarioScopeGlob();
+scenarioCommitMessage();
+scenarioFileName();
+
+report.finish(
+  'NOT VULNERABLE — no payload executed, the commit message was recorded verbatim,\nand every in-scope file was staged under its real name.',
+  'VULNERABLE — the following checks failed:',
+);

--- a/src/db/verify.mjs
+++ b/src/db/verify.mjs
@@ -44,10 +44,17 @@
 // it.
 //
 // No subprocess (git, verify_command) ever runs while a sqlite
-// transaction is open: every execSync call in this file happens before
-// BEGIN or after COMMIT, never between them.
+// transaction is open: every execSync/execFileSync call in this file
+// happens before BEGIN or after COMMIT, never between them.
+//
+// Every git invocation here goes through execFileSync with an argv array
+// — no shell, so nothing that reaches these commands (a layer's scope
+// globs, its commit message, or a file name read back out of the working
+// tree) can be interpreted as shell syntax. The one deliberate exception
+// is runVerifyCommand, whose verify_command is a shell command line by
+// definition.
 
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { DB_PATH } from './init.mjs';
 import { withCommitLock, LOCK_PATH } from './commitLock.mjs';
 import { reapExpiredLeases } from './claim.mjs';
@@ -62,11 +69,14 @@ function isEngineStatePath(path) {
   return path === DB_PATH || path.startsWith(`${DB_PATH}-`) || path === LOCK_PATH;
 }
 
-// Shell-safe quoting for paths interpolated into a git command line,
-// matching the JSON.stringify(path) convention used elsewhere in this
-// file for the same purpose.
-function quotePathspec(path) {
-  return JSON.stringify(path);
+// The `-- <pathspec>...` tail shared by the two diff commands below, as
+// argv entries rather than a command-line fragment. `pathspecs` present
+// but empty still emits a bare `--` (git reads that as "no restriction",
+// which is what an empty scope list has always meant here); absent emits
+// nothing at all. Pathspec magic (`:(glob)…`) reaches git untouched
+// precisely because nothing tokenizes these strings on the way.
+function pathspecArgs(pathspecs) {
+  return pathspecs ? ['--', ...pathspecs] : [];
 }
 
 // Working-tree diff (relative paths), optionally restricted to `pathspecs`
@@ -74,10 +84,13 @@ function quotePathspec(path) {
 // — covers modified, added, deleted, and untracked files, everything the
 // agent could have touched.
 function changedPaths(pathspecs) {
-  const scopeArgs = pathspecs ? ` -- ${pathspecs.map(quotePathspec).join(' ')}` : '';
-  const tracked = execSync(`git diff --name-only HEAD${scopeArgs}`, { encoding: 'utf8' });
-  const untracked = execSync(
-    `git ls-files --others --exclude-standard${scopeArgs}`,
+  const scopeArgs = pathspecArgs(pathspecs);
+  const tracked = execFileSync('git', ['diff', '--name-only', 'HEAD', ...scopeArgs], {
+    encoding: 'utf8',
+  });
+  const untracked = execFileSync(
+    'git',
+    ['ls-files', '--others', '--exclude-standard', ...scopeArgs],
     { encoding: 'utf8' },
   );
   const paths = new Set(
@@ -246,8 +259,7 @@ function runVerifyCommand(command) {
 // per path: anything ls-tree reports already existed in HEAD.
 function classifyArtifacts(paths) {
   if (paths.length === 0) return new Map();
-  const quoted = paths.map(quotePathspec).join(' ');
-  const output = execSync(`git ls-tree -r --name-only HEAD -- ${quoted}`, {
+  const output = execFileSync('git', ['ls-tree', '-r', '--name-only', 'HEAD', '--', ...paths], {
     encoding: 'utf8',
   });
   const existing = new Set(output.split('\n').map((p) => p.trim()).filter(Boolean));
@@ -266,10 +278,9 @@ function classifyArtifacts(paths) {
 // this function makes is the task's final commit; nothing amends it
 // afterward.
 function commitTouchedPaths(paths, commitMessage) {
-  const quoted = paths.map(quotePathspec).join(' ');
-  execSync(`git add -- ${quoted}`, { stdio: 'pipe' });
-  execSync(`git commit -m ${JSON.stringify(commitMessage)}`, { stdio: 'pipe' });
-  return execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+  execFileSync('git', ['add', '--', ...paths], { stdio: 'pipe' });
+  execFileSync('git', ['commit', '-m', commitMessage], { stdio: 'pipe' });
+  return execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
 }
 
 // Phase 0: reap expired leases, load `taskId`, assert it's `building` and


### PR DESCRIPTION
Fixes #15.

`src/db/verify.mjs` built git command strings by interpolation and ran them through `execSync`, i.e. `/bin/sh`. The quoting helper was `JSON.stringify`, which escapes `"` and `\` but not `$` or backticks — and the result landed inside double quotes, where the shell interprets both. The interpolated values are file names read from the working tree and fields from the project's `core.yaml`.

## What changed

`execFileSync('git', [...])` at all four call sites, so git receives an argv array directly and no shell is involved:

- `git diff --name-only HEAD` + `git ls-files --others` (scope globs from `core.yaml`)
- `git ls-tree -r --name-only HEAD --` (file names)
- `git add --` (file names)
- `git commit -m` (the layer's `commit` message)

`scopeArgs` is now built by a `pathspecArgs()` helper returning `['--', ...pathspecs]`, preserving the degenerate empty-list case exactly. `git rev-parse HEAD` in the same function was converted too — a static string with zero behaviour change, but it removes the last needless shell from that path. `quotePathspec` is deleted.

`execSync` is retained for exactly one call site: `runVerifyCommand`, which runs the layer's own `verify` command. That one is a shell command by design and must stay one.

## It is also an integrity bug, not only an RCE

This was not in the original report and is worth stating plainly. Because the shell rewrites the pathspec, a payload-named file **silently evades `git add`**. Pre-fix, the verify commit contained only the innocent siblings; the file with the payload name stayed untracked while the task was marked `complete`.

So the gate certified a commit that did not contain the work it was gating. That is a failure of the property the whole discipline rests on, reachable without any intent to attack — any file whose name happens to contain shell metacharacters would do it.

The file-name vector also reaches **two** call sites, not one: the reproduction records four payload executions per malicious file name.

## Evidence

`repro/shell-injection.mjs` drives the real CLI (`db init` → `intent add` → `plan` → `claim` → `verify`) in a throwaway `mkdtemp` per scenario. Payloads only `touch`/`printf` a relative marker inside that temp dir.

**Before — 0/5 checks passed:**

```
Scenario A — scope glob        [FAIL] marker present
Scenario B — commit message    [FAIL] marker present
                               [FAIL] subject expected "feat(demo): layer $(touch ../pwn-commit)"
                                             actual   "feat(demo): layer"
Scenario C — file name         payload executions recorded: 4
                               files in the verify commit: src/evil.ts, src/tick.ts
                               [FAIL] marker present
                               [FAIL] payload-named files staged: expected 2, actual []
```

**After — 5/5:** zero executions, the subject recorded verbatim, and every in-scope file staged under its real name, payload-named ones included.

## No regression

`repro/normal-verify.mjs` — 23 assertions across 5 end-to-end scenarios: happy path (multi-glob scope, `:(glob)` pathspec semantics, created-vs-modified artifact rows read back from the DB, exact commit subject, exactly the in-scope files staged, clean tree afterwards); shell-awkward-but-legal file names (space, `;`, `&`, `()`, `'`, leading dash); a scope violation; a failing `verify_command` (`echo boom && exit 3`, which pins that `verify_command` is still interpreted by a shell); and an empty change set.

**23/23 on both the unfixed and the fixed code.** That is the load-bearing claim — the suite passes identically before and after, so it pins existing behaviour rather than describing the new one.

`node scripts/check.mjs` passes.

## Two things found along the way, deliberately not fixed here

- **Pre-existing and unrelated:** a file name containing `"` breaks verify entirely, before and after this change. `git ls-files --others` C-quotes such paths, so verify reads back the literal `"src/has\"quote.ts"` including the outer quotes, and the following `git add` fails with `pathspec ... did not match any files`. That is a path-decoding bug needing its own fix; it is documented in a comment in `repro/normal-verify.mjs`.
- **`src/golden-cores/full-stack-app/tools/phase-gate.cjs:19`** — `execSync(\`git log --format=%s ${range}\`)`, where `range` derives from `PHASE_GATE_BASE` / `GITHUB_BASE_REF` / `'origin/main'`. Same class, lower severity: git refnames legally permit `$`, backticks, `;`, `&`, `(` and `)`, so a branch name is a viable payload, though creating one in the base repo needs push access. It is also entirely unquoted — a space in `base` splits into two arguments — and lacks a `--` separator, so a crafted value could inject git options too. This file ships into every full-stack-app project's CI. The fix is the same shape: `execFileSync('git', ['log', '--format=%s', range])`. Left out of this PR to keep it to one concern; happy to add it here if you would rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
