### PR TITLE
feat(plan): reconcile compiled tasks with core.yaml, and surface drift instead of hiding it

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -26,6 +26,7 @@ import { verifyTask } from '../src/db/verify.mjs';
 import { claimTasks, releaseTask, renewLease } from '../src/db/claim.mjs';
 import { readyTasks, formatReady } from '../src/db/ready.mjs';
 import { graphStatus, formatStatus } from '../src/db/status.mjs';
+import { detectDrift, recompileTasks, formatRecompile } from '../src/db/drift.mjs';
 import { whyPath, formatWhy } from '../src/db/why.mjs';
 import { addFriction, listFriction } from '../src/db/friction.mjs';
 import { rebuildDb } from '../src/db/rebuild.mjs';
@@ -221,6 +222,22 @@ async function ensureDb() {
   console.log(
     `${dim('DB missing — rebuilt from')} ${bold(INTENTS_DIR)}${dim(':')} ${dim(`${result.intentsReplayed} intent(s) replayed, ${result.tasksMarkedComplete} task(s) marked complete`)}\n`,
   );
+  warnRebuildDrift(result, corePath);
+}
+
+// A rebuild re-derives every task from the current core.yaml and the
+// committed intents. Nothing else is committed — a task row someone
+// patched by hand has no source to replay from — so say plainly what a
+// rebuild can and cannot carry, and surface any task that ends up
+// disagreeing with core.yaml.
+function warnRebuildDrift({ drift }, corePath) {
+  if (!drift || drift.length === 0) return;
+  console.log(
+    `${yellow(bold('Core drift after rebuild.'))} ${drift.length} task(s) do not match ${bold(corePath)}.\n` +
+      `A rebuild replays ${bold(INTENTS_DIR)} and re-derives tasks from core.yaml; task rows\n` +
+      'edited by hand have no committed source and are not replayed. Run\n' +
+      `${bold('hedgehog status')} for the divergence, ${bold('hedgehog plan --recompile')} to reconcile.\n`,
+  );
 }
 
 // Writes one planned file to disk — a straight copy, or for a `merge`
@@ -307,6 +324,8 @@ ${bold('Usage')}
   npx @skyf0xx/hedgehog db rebuild                re-derive the build graph from committed intents + git history
   npx @skyf0xx/hedgehog plan                      compile pending intents into tasks + dependencies,
                                                    then open the build graph if anything compiled
+  npx @skyf0xx/hedgehog plan --recompile          rewrite core.yaml-derived fields on not-started tasks
+                                                   [--dry-run] [--include-blocked] [--strict]
   npx @skyf0xx/hedgehog intent add [flags]        add an intent (rules/requirements/dependencies)
   npx @skyf0xx/hedgehog intent add --file <path>  add an intent from a JSON file
   npx @skyf0xx/hedgehog next                      print the task packet for one ready task
@@ -314,7 +333,8 @@ ${bold('Usage')}
   npx @skyf0xx/hedgehog release <task-id> --owner <owner>   hand a claimed task back to ready
   npx @skyf0xx/hedgehog renew <task-id> --owner <owner> [--minutes <n>]   extend a held lease
   npx @skyf0xx/hedgehog verify <task-id> --owner <owner>   run scope + verify checks, commit on pass
-  npx @skyf0xx/hedgehog status                    graph overview: counts by status, ready list, in flight
+  npx @skyf0xx/hedgehog status                    graph overview: counts by status, ready list, in flight,
+                                                   and any drift from core.yaml
   npx @skyf0xx/hedgehog ready                     preview which ready tasks are claimable now vs held back
   npx @skyf0xx/hedgehog quiesce                   report whether anything is still in flight
   npx @skyf0xx/hedgehog graph                     start (or reuse) the live graph server and open it
@@ -532,6 +552,7 @@ async function dbRebuildCommand() {
   console.log(
     `${green('rebuilt')}  ${dim(`${result.intentsReplayed} intent(s) replayed, ${result.tasksMarkedComplete} task(s) marked complete`)}\n`,
   );
+  warnRebuildDrift(result, corePath);
 }
 
 async function dbCommand(args) {
@@ -570,7 +591,56 @@ async function resolveCorePath() {
   return null;
 }
 
-async function planCommand() {
+// `hedgehog plan --recompile` — the reconciliation path for a core.yaml
+// edited after `plan` already compiled it.
+//
+// `plan` copies each layer's scope globs, verify command, commit message,
+// exclusivity and verify radius onto every task row, and from then on the
+// row is what `next`/`claim`/`verify` read. A plain re-run can't fix a
+// later core.yaml correction — compiling an intent flips it to `active`,
+// and `plan` only ever looks at `proposed`/`planned` ones — so before this
+// existed the only remedy was an UPDATE in SQLite by hand.
+//
+// Deliberately not a fresh compile: it rewrites fields on tasks nothing
+// has acted on yet and refuses the rest, so ids, dependencies, statuses
+// and history are untouched.
+async function planRecompileCommand(args, { core, corePath }) {
+  const includeBlocked = args.includes('--include-blocked');
+  const dryRun = args.includes('--dry-run');
+  const strict = args.includes('--strict');
+
+  const db = openDb();
+  let result;
+  try {
+    result = recompileTasks(db, core, { includeBlocked, dryRun });
+  } finally {
+    db.close();
+  }
+
+  if (dryRun) console.log(dim('  (--dry-run — nothing was written)'));
+  console.log(formatRecompile(result));
+
+  if (result.updated.length === 0 && result.skipped.length === 0) {
+    console.log(`\n${green(bold('In sync.'))} Every task matches ${bold(corePath)}.\n`);
+    return;
+  }
+
+  if (result.skipped.length > 0) {
+    console.log(
+      `\n${yellow(bold('Some drift remains.'))} Each skipped task above names why it kept its compiled\n` +
+        'fields. A task already built, leased, or committed is a Correction Protocol\n' +
+        'case (fix the layer at its source, re-run that layer), not a field rewrite;\n' +
+        'a changed depends_on or a layer dropped from core.yaml is a graph-shape\n' +
+        'change, which --recompile deliberately does not make.\n',
+    );
+  } else {
+    console.log(`\n${green(bold('Recompiled.'))}\n`);
+  }
+
+  if (strict && result.skipped.length > 0) process.exitCode = 1;
+}
+
+async function planCommand(args = []) {
   await ensureDb();
 
   const corePath = await resolveCorePath();
@@ -589,6 +659,12 @@ async function planCommand() {
   }
 
   const core = await loadCore(corePath);
+
+  if (args.includes('--recompile')) {
+    await planRecompileCommand(args, { core, corePath });
+    return;
+  }
+
   const db = openDb();
   let result;
   try {
@@ -602,6 +678,25 @@ async function planCommand() {
   console.log(
     `\n${green(bold('Plan complete.'))} ${dim(`${result.compiled.length} intent(s) compiled, ${result.skipped.length} skipped`)}\n`,
   );
+
+  // A plain `plan` is where someone lands after editing core.yaml,
+  // expecting the edit to take. It won't — already-compiled tasks carry
+  // their own copy of the layer's fields — so say so here rather than
+  // letting the run report "0 compiled" and look like a no-op.
+  const driftDb = openDb({ readOnly: true });
+  let drifted;
+  try {
+    drifted = detectDrift(driftDb, core);
+  } finally {
+    driftDb.close();
+  }
+  if (drifted.length > 0) {
+    console.log(
+      `${yellow(bold('Core drift.'))} ${drifted.length} already-compiled task(s) no longer match ${bold(corePath)}.\n` +
+        `Compiling does not revisit them. Run ${bold('hedgehog status')} to see the divergence,\n` +
+        `or ${bold('hedgehog plan --recompile')} to rewrite the not-started ones.\n`,
+    );
+  }
 
   // Only worth opening when this run actually changed the graph's shape
   // — a plan run that compiled nothing (every intent already had tasks)
@@ -956,10 +1051,27 @@ async function statusCommand() {
     return;
   }
 
+  // Drift needs the core definition to compare against. A project
+  // without one yet (deferred install, pre-bootstrap) simply gets the
+  // status it always got; an unparseable one is reported but never
+  // allowed to take `status` down — it's the command every session
+  // starts with.
+  let core = null;
+  const corePath = await resolveCorePath();
+  if (corePath) {
+    try {
+      core = await loadCore(corePath);
+    } catch (err) {
+      console.error(
+        `${yellow('Core definition unreadable:')} ${corePath} — ${err.message}\n${dim('Drift against core.yaml cannot be checked.')}\n`,
+      );
+    }
+  }
+
   const db = openDb();
   let result;
   try {
-    result = graphStatus(db);
+    result = graphStatus(db, { core });
   } finally {
     db.close();
   }
@@ -1322,7 +1434,7 @@ async function main() {
   }
 
   if (cmd === 'plan') {
-    await planCommand();
+    await planCommand(args.slice(1));
     return;
   }
 

--- a/repro/lib.mjs
+++ b/repro/lib.mjs
@@ -1,0 +1,224 @@
+// Shared fixture for the `repro/` scripts: builds a throwaway Hedgehog
+// project in a temp dir and drives the real CLI against it.
+//
+// No test framework and no `sqlite3` binary — assertions are plain
+// throws, and the DB is read through node:sqlite (built in since Node
+// 22.5; older builds need `node --experimental-sqlite`).
+
+import { DatabaseSync } from 'node:sqlite';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, existsSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = resolve(__dirname, '..');
+export const CLI = join(REPO_ROOT, 'bin/cli.mjs');
+
+// Two layers, module axis — the shape a real authored core has. The
+// `foundation` layer's verify command is the one the scripts edit, since
+// that mirrors the reported bug (a PATH fix on an infra layer's verify).
+export const CORE_YAML_BEFORE = `id: repro-core
+layers:
+  - id: foundation
+    scope: ["infra/{module}/**"]
+    verify: node --test infra/{module}
+    commit: "feat({module}): foundation"
+  - id: api
+    depends_on: foundation
+    scope: ["apps/api/src/{module}/**"]
+    verify: node --test apps/api/src/{module}
+    commit: "feat({module}): api"
+`;
+
+// The correction: `foundation`'s verify gains the PATH prefix, and its
+// scope widens to include the module's generated manifest.
+export const VERIFY_BEFORE = 'node --test infra/billing';
+export const VERIFY_AFTER = 'PATH=/usr/local/bin:$PATH node --test infra/billing';
+
+export const CORE_YAML_AFTER = `id: repro-core
+layers:
+  - id: foundation
+    scope: ["infra/{module}/**", "infra/{module}.manifest.json"]
+    verify: PATH=/usr/local/bin:$PATH node --test infra/{module}
+    commit: "feat({module}): foundation"
+  - id: api
+    depends_on: foundation
+    scope: ["apps/api/src/{module}/**"]
+    verify: node --test apps/api/src/{module}
+    commit: "feat({module}): api"
+`;
+
+const projects = [];
+
+// `hedgehog plan` starts a detached graph server and shells out to the
+// OS "open" handler when it compiles anything. Neither belongs in a
+// repro run, so each project gets a bin dir on PATH that shadows
+// xdg-open/open/start with a no-op, and killGraphServer() reaps the
+// server on cleanup.
+function writeFakeOpeners(binDir) {
+  mkdirSync(binDir, { recursive: true });
+  for (const name of ['xdg-open', 'open', 'start']) {
+    const path = join(binDir, name);
+    writeFileSync(path, '#!/bin/sh\nexit 0\n');
+    chmodSync(path, 0o755);
+  }
+}
+
+function killGraphServer(dir) {
+  const pidfile = join(dir, '.hedgehog/graph-server.json');
+  if (!existsSync(pidfile)) return;
+  try {
+    const { pid } = JSON.parse(readFileSync(pidfile, 'utf8'));
+    process.kill(pid, 'SIGTERM');
+  } catch {
+    // Already gone, or never started — nothing to reap.
+  }
+}
+
+export function makeProject(coreYaml = CORE_YAML_BEFORE) {
+  const dir = mkdtempSync(join(tmpdir(), 'hedgehog-repro-'));
+  const binDir = join(dir, '.fake-bin');
+  writeFakeOpeners(binDir);
+  mkdirSync(join(dir, '.hedgehog'), { recursive: true });
+  writeFileSync(join(dir, '.hedgehog/core.yaml'), coreYaml);
+
+  const env = {
+    ...process.env,
+    PATH: `${binDir}:${process.env.PATH}`,
+    NO_COLOR: '1',
+  };
+
+  const project = {
+    dir,
+    writeCore(text) {
+      writeFileSync(join(dir, '.hedgehog/core.yaml'), text);
+    },
+    run(...args) {
+      const r = spawnSync(process.execPath, [CLI, ...args], {
+        cwd: dir,
+        env,
+        encoding: 'utf8',
+      });
+      return {
+        code: r.status,
+        stdout: r.stdout ?? '',
+        stderr: r.stderr ?? '',
+        out: `${r.stdout ?? ''}${r.stderr ?? ''}`,
+      };
+    },
+    git(...args) {
+      return spawnSync('git', args, { cwd: dir, encoding: 'utf8' });
+    },
+    openDb() {
+      return new DatabaseSync(join(dir, '.hedgehog/hedgehog.db'));
+    },
+    // Reads one task row. Used only to observe what `plan` wrote — the
+    // scripts never patch layer-derived fields by hand, which is the
+    // whole point.
+    task(id) {
+      const db = project.openDb();
+      try {
+        return db.prepare('SELECT * FROM tasks WHERE id = ?').get(id);
+      } finally {
+        db.close();
+      }
+    },
+    // Moves a task into a lifecycle state the CLI would otherwise only
+    // reach by running a real build + verify (which needs a toolchain
+    // this repro deliberately doesn't have). Only `status`/lease columns
+    // are touched, never the layer-derived fields under test.
+    setStatus(id, status, owner = null) {
+      const db = project.openDb();
+      try {
+        db.prepare(
+          'UPDATE tasks SET status = ?, lease_owner = ?, lease_expires_at = ? WHERE id = ?',
+        ).run(status, owner, owner ? '2999-01-01T00:00:00Z' : null, id);
+      } finally {
+        db.close();
+      }
+    },
+    cleanup() {
+      killGraphServer(dir);
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+
+  projects.push(project);
+  return project;
+}
+
+// A project with the "before" core.yaml, one intent, and `plan` already
+// run — the state every scenario starts from.
+export function plannedProject(intentId = 'billing') {
+  const p = makeProject();
+  p.git('init', '-q');
+  mustSucceed(p.run('db', 'init'), 'hedgehog db init');
+  mustSucceed(
+    p.run('intent', 'add', '--id', intentId, '--goal', 'g', '--outcome', 'o'),
+    'hedgehog intent add',
+  );
+  mustSucceed(p.run('plan'), 'hedgehog plan');
+  return p;
+}
+
+export function cleanupAll() {
+  for (const p of projects) p.cleanup();
+}
+
+// ── assertions ─────────────────────────────────────────────────────────
+export class ReproFailure extends Error {}
+
+export function mustSucceed(result, label) {
+  if (result.code !== 0) {
+    throw new ReproFailure(
+      `${label} exited ${result.code}\n--- output ---\n${result.out}`,
+    );
+  }
+  return result;
+}
+
+export function assertEqual(actual, expected, label) {
+  if (actual !== expected) {
+    throw new ReproFailure(
+      `${label}\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+export function assertIncludes(haystack, needle, label) {
+  if (!haystack.includes(needle)) {
+    throw new ReproFailure(
+      `${label}\n  expected output to contain: ${JSON.stringify(needle)}\n  actual output:\n${indent(haystack)}`,
+    );
+  }
+}
+
+export function assertNotIncludes(haystack, needle, label) {
+  if (haystack.includes(needle)) {
+    throw new ReproFailure(
+      `${label}\n  expected output NOT to contain: ${JSON.stringify(needle)}\n  actual output:\n${indent(haystack)}`,
+    );
+  }
+}
+
+function indent(text) {
+  return text
+    .split('\n')
+    .map((l) => `    ${l}`)
+    .join('\n');
+}
+
+// Runs one named scenario, printing pass/fail and returning a boolean.
+export function scenario(name, fn) {
+  try {
+    fn();
+    console.log(`  PASS  ${name}`);
+    return true;
+  } catch (err) {
+    console.log(`  FAIL  ${name}`);
+    console.log(indent(err.message));
+    return false;
+  }
+}

--- a/repro/recompile-reaches-not-started-tasks.mjs
+++ b/repro/recompile-reaches-not-started-tasks.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Repro 1 — a core.yaml correction must reach tasks that have not
+// started, via `hedgehog plan --recompile`.
+//
+// Against v4.0.3 this fails twice over: `--recompile` is not a flag
+// `plan` knows, and plain `plan` recompiles nothing because the intent
+// went `active` the first time round.
+
+import {
+  plannedProject,
+  cleanupAll,
+  scenario,
+  mustSucceed,
+  assertEqual,
+  assertIncludes,
+  CORE_YAML_AFTER,
+  VERIFY_BEFORE,
+  VERIFY_AFTER,
+} from './lib.mjs';
+
+let ok = true;
+
+ok =
+  scenario('plan --recompile rewrites layer-derived fields on not-started tasks', () => {
+    const p = plannedProject('billing');
+
+    const before = p.task('BILLING-FOUNDATION');
+    assertEqual(before.verify_command, VERIFY_BEFORE, 'baseline verify_command from `hedgehog plan`');
+    assertEqual(before.status, 'planned', 'baseline task status');
+
+    // The correction the operator makes to core.yaml.
+    p.writeCore(CORE_YAML_AFTER);
+
+    // Today's only "reconcile" path — re-running plan — is a no-op, and
+    // says so. This assertion documents the bug rather than the fix.
+    const replan = p.run('plan');
+    assertIncludes(replan.out, '0 intent(s) compiled', 'plain `plan` after a core.yaml edit compiles nothing');
+
+    const recompile = mustSucceed(p.run('plan', '--recompile'), 'hedgehog plan --recompile');
+
+    const after = p.task('BILLING-FOUNDATION');
+    assertEqual(after.verify_command, VERIFY_AFTER, 'verify_command after --recompile');
+    assertEqual(
+      after.scope_globs,
+      JSON.stringify(['infra/billing/**', 'infra/billing.manifest.json']),
+      'scope_globs after --recompile',
+    );
+
+    // The untouched layer must stay untouched.
+    const api = p.task('BILLING-API');
+    assertEqual(api.verify_command, 'node --test apps/api/src/billing', 'unrelated layer left alone');
+
+    assertIncludes(recompile.out, 'BILLING-FOUNDATION', '--recompile names the task it changed');
+    assertIncludes(recompile.out, 'verify_command', '--recompile names the field it changed');
+  }) && ok;
+
+ok =
+  scenario('a second --recompile is a no-op once the graph matches core.yaml', () => {
+    const p = plannedProject('billing');
+    p.writeCore(CORE_YAML_AFTER);
+    mustSucceed(p.run('plan', '--recompile'), 'first --recompile');
+    const second = mustSucceed(p.run('plan', '--recompile'), 'second --recompile');
+    assertIncludes(second.out, '0 task(s) updated', 'second --recompile reports nothing to do');
+  }) && ok;
+
+cleanupAll();
+process.exit(ok ? 0 : 1);

--- a/repro/recompile-refuses-started-tasks.mjs
+++ b/repro/recompile-refuses-started-tasks.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+// Repro 2 — `plan --recompile` must refuse to rewrite a task that has
+// already been acted upon (building, verifying, complete), and must say
+// which ones it skipped and why. A task already committed under its old
+// commit_message can't have that message retro-changed; a task an agent
+// is mid-build on can't have its ALLOWED SCOPE moved underneath it.
+
+import {
+  plannedProject,
+  cleanupAll,
+  scenario,
+  mustSucceed,
+  assertEqual,
+  assertIncludes,
+  CORE_YAML_AFTER,
+  VERIFY_BEFORE,
+  VERIFY_AFTER,
+} from './lib.mjs';
+
+let ok = true;
+
+for (const [status, owner] of [
+  ['building', 'agent-a'],
+  ['verifying', 'agent-a'],
+  ['complete', null],
+]) {
+  ok =
+    scenario(`plan --recompile refuses a '${status}' task and says why`, () => {
+      const p = plannedProject('billing');
+      p.setStatus('BILLING-FOUNDATION', status, owner);
+      p.writeCore(CORE_YAML_AFTER);
+
+      const r = mustSucceed(p.run('plan', '--recompile'), 'hedgehog plan --recompile');
+
+      const after = p.task('BILLING-FOUNDATION');
+      assertEqual(after.verify_command, VERIFY_BEFORE, `verify_command on a '${status}' task is untouched`);
+      assertEqual(after.status, status, 'status is untouched');
+
+      assertIncludes(r.out, 'BILLING-FOUNDATION', '--recompile names the task it skipped');
+      assertIncludes(r.out, status, '--recompile names the status that made it refuse');
+      assertIncludes(r.out, 'skipped', '--recompile labels it as skipped');
+    }) && ok;
+}
+
+ok =
+  scenario('a not-started sibling still recompiles when another task is refused', () => {
+    // Two intents through the same layer chain: one whose foundation
+    // task is already complete (must be refused) and one still planned
+    // (must be updated). One run, both outcomes.
+    const p = plannedProject('billing');
+    mustSucceed(
+      p.run('intent', 'add', '--id', 'ledger', '--goal', 'g', '--outcome', 'o'),
+      'hedgehog intent add ledger',
+    );
+    mustSucceed(p.run('plan'), 'hedgehog plan (ledger)');
+
+    p.setStatus('BILLING-FOUNDATION', 'complete');
+    p.writeCore(CORE_YAML_AFTER);
+
+    const r = mustSucceed(p.run('plan', '--recompile'), 'hedgehog plan --recompile');
+
+    assertEqual(
+      p.task('BILLING-FOUNDATION').verify_command,
+      VERIFY_BEFORE,
+      'complete task refused',
+    );
+    assertEqual(
+      p.task('LEDGER-FOUNDATION').verify_command,
+      'PATH=/usr/local/bin:$PATH node --test infra/ledger',
+      'not-started sibling of another intent is updated',
+    );
+    assertIncludes(r.out, 'updated', 'the run reports an update');
+    assertIncludes(r.out, 'skipped', 'the same run reports a refusal');
+  }) && ok;
+
+ok =
+  scenario('--recompile exits non-zero if asked to touch only refused tasks with --strict', () => {
+    const p = plannedProject('billing');
+    p.setStatus('BILLING-FOUNDATION', 'complete');
+    p.writeCore(CORE_YAML_AFTER);
+    const r = p.run('plan', '--recompile', '--strict');
+    assertEqual(r.code, 1, '--strict exit code when drift remains unreconciled');
+    assertIncludes(r.out, VERIFY_AFTER, '--strict run still reports what core.yaml now says');
+  }) && ok;
+
+cleanupAll();
+process.exit(ok ? 0 : 1);

--- a/repro/run-all.mjs
+++ b/repro/run-all.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// Runs every repro script in this directory, serially, and exits
+// non-zero if any of them fails.
+//
+//   node repro/run-all.mjs
+//
+// Each script builds a throwaway project in a temp dir and drives the
+// real `bin/cli.mjs`. Nothing here touches the repo working tree.
+
+import { spawnSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scripts = readdirSync(here)
+  .filter((f) => f.endsWith('.mjs') && f !== 'run-all.mjs' && f !== 'lib.mjs')
+  .sort();
+
+let failed = 0;
+for (const script of scripts) {
+  console.log(`\n${script}`);
+  const r = spawnSync(process.execPath, [join(here, script)], {
+    stdio: 'inherit',
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+  if (r.status !== 0) failed++;
+}
+
+console.log(
+  `\n${scripts.length - failed}/${scripts.length} repro script(s) passed`,
+);
+process.exit(failed === 0 ? 0 : 1);

--- a/repro/status-reports-drift.mjs
+++ b/repro/status-reports-drift.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Repro 3 — drift must be visible before anyone recompiles. `hedgehog
+// status` is the command every session already starts with, so a
+// core.yaml that no longer matches the compiled tasks has to show up
+// there, naming the tasks and fields that diverged.
+//
+// Against v4.0.3 `status` prints counts + ready list only, and a
+// divergent core.yaml is completely silent.
+
+import {
+  plannedProject,
+  cleanupAll,
+  scenario,
+  mustSucceed,
+  assertIncludes,
+  assertNotIncludes,
+  CORE_YAML_AFTER,
+} from './lib.mjs';
+
+let ok = true;
+
+ok =
+  scenario('status is quiet when the graph matches core.yaml', () => {
+    const p = plannedProject('billing');
+    const r = mustSucceed(p.run('status'), 'hedgehog status');
+    assertNotIncludes(r.out, 'DRIFT', 'no drift section on a graph that matches its core');
+  }) && ok;
+
+ok =
+  scenario('status reports drift after a core.yaml edit, before any recompile', () => {
+    const p = plannedProject('billing');
+    p.writeCore(CORE_YAML_AFTER);
+
+    const r = mustSucceed(p.run('status'), 'hedgehog status');
+    assertIncludes(r.out, 'DRIFT', 'status names the drift section');
+    assertIncludes(r.out, 'BILLING-FOUNDATION', 'status names the drifted task');
+    assertIncludes(r.out, 'verify_command', 'status names the drifted field');
+    assertIncludes(r.out, 'scope_globs', 'status names the other drifted field');
+    assertIncludes(r.out, 'plan --recompile', 'status points at the reconciliation command');
+  }) && ok;
+
+ok =
+  scenario('status stops reporting drift once --recompile has run', () => {
+    const p = plannedProject('billing');
+    p.writeCore(CORE_YAML_AFTER);
+    mustSucceed(p.run('plan', '--recompile'), 'hedgehog plan --recompile');
+    const r = mustSucceed(p.run('status'), 'hedgehog status');
+    assertNotIncludes(r.out, 'DRIFT', 'drift section gone after reconciling');
+  }) && ok;
+
+ok =
+  scenario('drift on a task that cannot be recompiled is still reported', () => {
+    const p = plannedProject('billing');
+    p.setStatus('BILLING-FOUNDATION', 'complete');
+    p.writeCore(CORE_YAML_AFTER);
+    mustSucceed(p.run('plan', '--recompile'), 'hedgehog plan --recompile');
+    const r = mustSucceed(p.run('status'), 'hedgehog status');
+    assertIncludes(r.out, 'DRIFT', 'drift on a complete task keeps showing');
+    assertIncludes(r.out, 'BILLING-FOUNDATION', 'the complete task is named');
+  }) && ok;
+
+cleanupAll();
+process.exit(ok ? 0 : 1);

--- a/src/agents/layer-eng.md
+++ b/src/agents/layer-eng.md
@@ -19,8 +19,13 @@ An authored core's stack varies by project, so the specifics you need
 live in the project, not in this file:
 
 - **`.hedgehog/core.yaml`** — the layer sequence, each layer's `scope`
-  globs, `verify` command, and commit message. The compiled authority:
-  the packet you receive is generated from it.
+  globs, `verify` command, and commit message. The design authority: the
+  packet you receive was compiled from it, but it is a *copy* taken at
+  compile time. If the packet and `core.yaml` disagree, the packet is
+  what `hedgehog verify` will gate you against — build to the packet, and
+  report the disagreement rather than silently following the YAML. (The
+  fix is `hedgehog plan --recompile`, run by whoever is driving the loop,
+  not by you mid-task.)
 - **`.hedgehog/core-design.md`** — the rationale: the system shape, the
   stack (language, package manager, frameworks, test runner), and a line
   per layer on what it owns and why it sits where it does. This is what

--- a/src/db/drift.mjs
+++ b/src/db/drift.mjs
@@ -1,0 +1,282 @@
+// Core-definition drift: what `hedgehog plan` copied onto a task row
+// versus what `core.yaml` says today.
+//
+// `plan` compiles intents × layers into `tasks` rows, copying each
+// layer's scope globs, verify command, commit message, exclusivity and
+// verify radius onto every row (plan.mjs#layerTaskFields). From that
+// moment the row — not core.yaml — is what `hedgehog next`, `claim` and
+// `verify` actually read. An edit to core.yaml after the fact therefore
+// changes nothing about already-compiled work, and `plan` won't revisit
+// it: it only reads intents still `proposed`/`planned`, and compiling an
+// intent flips it to `active`.
+//
+// That silence is the bug this module exists to end. It provides:
+//
+//   detectDrift(db, core)     — every task whose layer-derived fields no
+//                               longer match core.yaml, plus the two
+//                               kinds of divergence a field rewrite
+//                               can't fix (a layer that left core.yaml,
+//                               and a changed `depends_on` edge).
+//   recompileTasks(db, core)  — rewrites those fields on tasks nothing
+//                               has acted on yet, and refuses the rest.
+//
+// The split mirrors status.mjs's: a pure data function, and a formatter
+// the CLI prints.
+
+import { LAYER_DERIVED_FIELDS, layerTaskFields, taskId } from './plan.mjs';
+
+// Statuses a field rewrite is safe on: nothing has been built, leased,
+// committed, or failed against these rows yet, so moving their ALLOWED
+// SCOPE / verify command / commit message changes only what a future
+// agent will be handed.
+export const RECOMPILABLE_STATUSES = ['proposed', 'planned', 'ready'];
+
+// `blocked` is the one judgement call. The row carries no lease and no
+// commit, so writing it is mechanically safe — and a blocked task is
+// exactly where a broken verify command lands, which is the case that
+// motivated this command. But an agent's work for it is already sitting
+// in the working tree against the old scope, so it is opt-in
+// (`--include-blocked`) rather than part of the default sweep.
+export const OPT_IN_STATUSES = ['blocked'];
+
+const SKIP_REASONS = {
+  building: 'an agent holds a lease and is building against these fields',
+  verifying: 'a verification run is in flight against these fields',
+  complete: 'already built and committed under the old commit message',
+  blocked: 'work already exists against the old fields — pass --include-blocked to rewrite anyway',
+};
+
+function normalize(value) {
+  // node:sqlite hands back INTEGER columns as BigInt on some builds;
+  // compare as strings so 0 and 0n don't read as drift.
+  if (value === null || value === undefined) return null;
+  return String(value);
+}
+
+function loadTasks(db) {
+  return db.prepare('SELECT * FROM tasks ORDER BY priority, id').all();
+}
+
+// The intra-intent dependency edges recorded for `taskId`. Cross-intent
+// edges (planTasks writes one per depends_on intent, same layer) are
+// excluded by joining back to tasks and keeping only parents in the same
+// intent — so this compares like with like against `layer.depends_on`.
+function intraIntentParents(db, task) {
+  return db
+    .prepare(
+      `SELECT d.depends_on_task_id AS id FROM dependencies d
+         JOIN tasks p ON p.id = d.depends_on_task_id
+        WHERE d.task_id = ? AND p.intent_id = ?
+        ORDER BY d.depends_on_task_id`,
+    )
+    .all(task.id, task.intent_id)
+    .map((r) => r.id);
+}
+
+// Drift for one task. Returns null when the row matches core.yaml.
+//
+// Three shapes of divergence, deliberately kept apart because only the
+// first is something `--recompile` can fix:
+//   fields          — a layer-derived column differs (rewritable)
+//   missingLayer    — the task's layer is no longer in core.yaml
+//   dependencyDrift — the layer's `depends_on` changed, so the graph's
+//                     edges are wrong (a shape change, not a field one)
+export function taskDrift(db, task, core) {
+  const layer = core.layers.find((l) => l.id === task.layer);
+  if (!layer) {
+    return {
+      id: task.id,
+      layer: task.layer,
+      status: task.status,
+      fields: [],
+      missingLayer: true,
+      dependencyDrift: null,
+    };
+  }
+
+  const expected = layerTaskFields(layer, task.module);
+  const fields = [];
+  for (const field of LAYER_DERIVED_FIELDS) {
+    const want = normalize(expected[field]);
+    const have = normalize(task[field]);
+    if (want !== have) fields.push({ field, expected: expected[field], actual: task[field] });
+  }
+
+  const expectedParents = layer.depends_on ? [taskId(task.intent_id, layer.depends_on)] : [];
+  const actualParents = intraIntentParents(db, task);
+  const dependencyDrift =
+    expectedParents.join(',') === actualParents.join(',')
+      ? null
+      : { expected: expectedParents, actual: actualParents };
+
+  if (fields.length === 0 && !dependencyDrift) return null;
+
+  return {
+    id: task.id,
+    layer: task.layer,
+    status: task.status,
+    fields,
+    missingLayer: false,
+    dependencyDrift,
+  };
+}
+
+// True when `--recompile` may rewrite this task's fields.
+export function isRecompilable(status, { includeBlocked = false } = {}) {
+  if (RECOMPILABLE_STATUSES.includes(status)) return true;
+  return includeBlocked && OPT_IN_STATUSES.includes(status);
+}
+
+// Every drifted task, in `priority, id` order. Read-only.
+export function detectDrift(db, core, { includeBlocked = false } = {}) {
+  const drifted = [];
+  for (const task of loadTasks(db)) {
+    const drift = taskDrift(db, task, core);
+    if (!drift) continue;
+    drift.recompilable =
+      drift.fields.length > 0 && !drift.missingLayer && isRecompilable(task.status, { includeBlocked });
+    drift.skipReason = drift.recompilable
+      ? null
+      : drift.missingLayer
+        ? `layer "${task.layer}" is no longer in core.yaml`
+        : drift.fields.length === 0
+          ? 'only the dependency edges drifted, which --recompile does not rewrite'
+          : (SKIP_REASONS[task.status] ?? `status "${task.status}" is not recompilable`);
+    drifted.push(drift);
+  }
+  return drifted;
+}
+
+const UPDATE_SQL = `
+  UPDATE tasks
+     SET objective = ?, scope_globs = ?, verify_command = ?,
+         commit_message = ?, exclusive = ?, verify_radius = ?
+   WHERE id = ?
+`;
+
+// Rewrites the layer-derived fields of every drifted, not-yet-started
+// task from the current core.yaml, and refuses the rest. One
+// transaction: either the whole reconciliation lands or none of it does,
+// so a half-recompiled graph is never a state anyone has to reason
+// about.
+//
+// Returns { updated, skipped } — `updated` the tasks rewritten (with the
+// field list), `skipped` the drifted tasks left alone (with the reason
+// and the fields that stay stale). `dryRun` computes both without
+// writing.
+export function recompileTasks(db, core, { includeBlocked = false, dryRun = false } = {}) {
+  const drifted = detectDrift(db, core, { includeBlocked });
+  const updated = drifted.filter((d) => d.recompilable);
+  const skipped = drifted.filter((d) => !d.recompilable);
+
+  if (dryRun || updated.length === 0) return { updated, skipped };
+
+  const run = db.prepare(UPDATE_SQL);
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    for (const drift of updated) {
+      const task = db.prepare('SELECT * FROM tasks WHERE id = ?').get(drift.id);
+      // Re-read the status inside the write transaction: a concurrent
+      // `claim` could have leased the task between detectDrift and here,
+      // and a rewrite under a live lease is exactly what this refuses.
+      if (!isRecompilable(task.status, { includeBlocked })) {
+        drift.recompilable = false;
+        drift.skipReason = SKIP_REASONS[task.status] ?? `status "${task.status}" is not recompilable`;
+        continue;
+      }
+      const layer = core.layers.find((l) => l.id === task.layer);
+      const fields = layerTaskFields(layer, task.module);
+      run.run(
+        fields.objective,
+        fields.scope_globs,
+        fields.verify_command,
+        fields.commit_message,
+        fields.exclusive,
+        fields.verify_radius,
+        task.id,
+      );
+    }
+    db.exec('COMMIT');
+  } catch (err) {
+    try {
+      db.exec('ROLLBACK');
+    } catch {
+      // Rollback failing must not mask the original error.
+    }
+    throw err;
+  }
+
+  return {
+    updated: updated.filter((d) => d.recompilable),
+    skipped: [...skipped, ...updated.filter((d) => !d.recompilable)],
+  };
+}
+
+function shorten(value) {
+  if (value === null || value === undefined) return '(none)';
+  const s = String(value);
+  return s.length > 120 ? `${s.slice(0, 117)}...` : s;
+}
+
+// The per-field detail block both `status` and `plan --recompile` print
+// under a drifted task — core.yaml's value against the compiled one, so
+// the divergence is legible without opening SQLite.
+function driftDetailLines(drift, indent = '    ') {
+  const lines = [];
+  if (drift.missingLayer) {
+    lines.push(`${indent}layer "${drift.layer}" is no longer defined in core.yaml`);
+  }
+  for (const { field, expected, actual } of drift.fields) {
+    lines.push(`${indent}${field}`);
+    lines.push(`${indent}  core.yaml: ${shorten(expected)}`);
+    lines.push(`${indent}  task:      ${shorten(actual)}`);
+  }
+  if (drift.dependencyDrift) {
+    const { expected, actual } = drift.dependencyDrift;
+    lines.push(`${indent}depends_on (graph edges — not rewritten by --recompile)`);
+    lines.push(`${indent}  core.yaml: ${expected.length ? expected.join(', ') : '(none)'}`);
+    lines.push(`${indent}  graph:     ${actual.length ? actual.join(', ') : '(none)'}`);
+  }
+  return lines;
+}
+
+// The DRIFT block `hedgehog status` appends. Empty string when the graph
+// matches core.yaml, so the section only ever appears when it matters.
+export function formatDrift(drifted) {
+  if (drifted.length === 0) return '';
+  const lines = [];
+  lines.push('DRIFT');
+  lines.push(
+    `  ${drifted.length} task(s) no longer match .hedgehog/core.yaml — the compiled task is what`,
+  );
+  lines.push('  `hedgehog next`/`claim`/`verify` actually use, not core.yaml.');
+  lines.push('');
+  for (const drift of drifted) {
+    const fieldList = drift.fields.map((f) => f.field).join(', ');
+    const suffix = drift.recompilable ? '' : ` — ${drift.skipReason}`;
+    lines.push(`  ${drift.id}   ${drift.status}   ${fieldList || '(structure)'}${suffix}`);
+    lines.push(...driftDetailLines(drift));
+  }
+  lines.push('');
+  lines.push('  Reconcile the not-started ones with: hedgehog plan --recompile');
+  return lines.join('\n');
+}
+
+// The report `hedgehog plan --recompile` prints.
+export function formatRecompile({ updated, skipped }) {
+  const lines = [];
+  for (const drift of updated) {
+    lines.push(
+      `  updated  ${drift.id}   ${drift.status}   ${drift.fields.map((f) => f.field).join(', ')}`,
+    );
+  }
+  for (const drift of skipped) {
+    lines.push(`  skipped  ${drift.id}   ${drift.status}   ${drift.skipReason}`);
+    lines.push(...driftDetailLines(drift, '             '));
+  }
+  lines.push('');
+  lines.push(
+    `${updated.length} task(s) updated, ${skipped.length} task(s) skipped`,
+  );
+  return lines.join('\n');
+}

--- a/src/db/plan.mjs
+++ b/src/db/plan.mjs
@@ -10,14 +10,46 @@
 // chain is the degenerate case of the layer graph (spec: MVP scope
 // item 5).
 
-function fillModule(template, module) {
+export function fillModule(template, module) {
   return template.replaceAll('{module}', module);
 }
 
 // Deterministic, human-legible task id: <INTENT>-<LAYER>, upper-cased.
 // Stable across repeated `hedgehog plan` runs on the same intent/layer.
-function taskId(intentId, layerId) {
+export function taskId(intentId, layerId) {
   return `${intentId}-${layerId}`.toUpperCase();
+}
+
+// The `tasks` columns whose value is derived purely from the core
+// definition's layer (plus the module it's being instantiated for) —
+// i.e. everything `plan` copies out of core.yaml and that a later
+// core.yaml edit therefore leaves stale. Named once here so drift.mjs
+// checks exactly the set layerTaskFields() writes, and the two can't
+// silently diverge. `priority` is deliberately absent: it comes from the
+// intent, not the layer.
+export const LAYER_DERIVED_FIELDS = [
+  'objective',
+  'scope_globs',
+  'verify_command',
+  'commit_message',
+  'exclusive',
+  'verify_radius',
+];
+
+// The single definition of "what a layer contributes to a task row",
+// shared by the compiler (below) and the drift check (drift.mjs).
+export function layerTaskFields(layer, module) {
+  return {
+    objective: `${layer.id} for ${module}`,
+    scope_globs: JSON.stringify(layer.scope.map((g) => fillModule(g, module))),
+    verify_command: fillModule(layer.verify, module),
+    commit_message: fillModule(layer.commit, module),
+    exclusive: layer.exclusive ? 1 : 0,
+    verify_radius:
+      layer.verify_radius === null
+        ? null
+        : JSON.stringify(layer.verify_radius.map((g) => fillModule(g, module))),
+  };
 }
 
 // Compiles one intent's tasks + intra-intent dependencies (mirroring the
@@ -29,16 +61,8 @@ function compileIntentTasks(intent, core) {
     intent_id: intent.id,
     module,
     layer: layer.id,
-    objective: `${layer.id} for ${module}`,
-    scope_globs: JSON.stringify(layer.scope.map((g) => fillModule(g, module))),
-    verify_command: fillModule(layer.verify, module),
-    commit_message: fillModule(layer.commit, module),
     priority: intent.priority,
-    exclusive: layer.exclusive ? 1 : 0,
-    verify_radius:
-      layer.verify_radius === null
-        ? null
-        : JSON.stringify(layer.verify_radius.map((g) => fillModule(g, module))),
+    ...layerTaskFields(layer, module),
   }));
 
   const dependencies = [];

--- a/src/db/rebuild.mjs
+++ b/src/db/rebuild.mjs
@@ -14,6 +14,7 @@ import { applySchema } from './schema.mjs';
 import { addIntent, INTENTS_DIR } from './intent.mjs';
 import { planTasks } from './plan.mjs';
 import { loadCore } from './core.mjs';
+import { detectDrift } from './drift.mjs';
 
 // Alphabetical by filename so replay order is deterministic across
 // machines and runs — intents have no other natural ordering (priority
@@ -85,6 +86,18 @@ function markCompletedTasks(db, commitSubjects) {
 // replayed through addIntent, then planTasks to re-derive tasks +
 // dependencies, then git history to reconcile which tasks already
 // completed. Returns a summary for the CLI to print.
+//
+// `drift` in the return is the honest disclosure this rebuild owes its
+// caller. A rebuild re-derives every task's layer-derived fields from
+// the *current* core.yaml, and the intent files it replays carry no
+// task-level detail at all — so any hand-edit made directly to a task
+// row (the widened scope glob, the patched verify command) has no
+// committed source to replay from and does not survive. Rows that
+// predate this rebuild are left as they are, which is the other half of
+// the same problem: they can be stale against core.yaml and nothing
+// would otherwise say so. Reporting the divergence is what turns both
+// into something the operator sees instead of something they discover
+// three layers later.
 export async function rebuildDb(db, { corePath, intentsDir = INTENTS_DIR } = {}) {
   applySchema(db);
 
@@ -96,5 +109,7 @@ export async function rebuildDb(db, { corePath, intentsDir = INTENTS_DIR } = {})
   const commitSubjects = loadCommitSubjects();
   const tasksMarkedComplete = markCompletedTasks(db, commitSubjects);
 
-  return { intentsReplayed, tasksMarkedComplete };
+  const drift = detectDrift(db, core);
+
+  return { intentsReplayed, tasksMarkedComplete, drift };
 }

--- a/src/db/status.mjs
+++ b/src/db/status.mjs
@@ -11,6 +11,8 @@
 // every task meeting that condition, not just the one `hedgehog next`
 // would pick.
 
+import { detectDrift, formatDrift } from './drift.mjs';
+
 // The task lifecycle in order, matching the tasks CHECK constraint in
 // schema.mjs exactly — every status the engine can write, and no others.
 const TASK_STATUSES = [
@@ -75,18 +77,25 @@ function loadAttentionTasks(db) {
   return db.prepare(ATTENTION_TASKS_SQL).all();
 }
 
-// Returns { counts, ready, inFlight, attention, total } — counts keyed by
-// every status in the tasks CHECK constraint (present even at zero),
-// ready the full list of currently-pickable tasks, inFlight the tasks
-// currently leased (building or verifying), attention the stalled tasks
-// needing a fix, total the sum across all statuses.
-export function graphStatus(db) {
+// Returns { counts, ready, inFlight, attention, drift, total } — counts
+// keyed by every status in the tasks CHECK constraint (present even at
+// zero), ready the full list of currently-pickable tasks, inFlight the
+// tasks currently leased (building or verifying), attention the stalled
+// tasks needing a fix, total the sum across all statuses.
+//
+// `core` is optional and, when given, adds `drift`: the tasks whose
+// layer-derived fields no longer match core.yaml (drift.mjs). It's a
+// parameter rather than a lookup because status.mjs has no business
+// resolving the project's core path — the CLI already does that, and
+// a project mid-install may not have a core definition at all.
+export function graphStatus(db, { core = null } = {}) {
   const counts = countTasksByStatus(db);
   const ready = loadReadyTasks(db);
   const inFlight = loadInFlightTasks(db);
   const attention = loadAttentionTasks(db);
+  const drift = core ? detectDrift(db, core) : [];
   const total = Object.values(counts).reduce((a, b) => a + b, 0);
-  return { counts, ready, inFlight, attention, total };
+  return { counts, ready, inFlight, attention, drift, total };
 }
 
 const BLOCKED_REASON_LABELS = {
@@ -98,7 +107,7 @@ const BLOCKED_REASON_LABELS = {
 // Renders a graphStatus() result into a plain-text overview: counts by
 // status (only non-zero ones, in lifecycle order), the ready list, tasks
 // currently in flight, and anything needing attention.
-export function formatStatus({ counts, ready, inFlight, attention, total }) {
+export function formatStatus({ counts, ready, inFlight, attention, drift, total }) {
   const lines = [];
   lines.push(`TASKS  ${total}`);
   lines.push('');
@@ -133,6 +142,14 @@ export function formatStatus({ counts, ready, inFlight, attention, total }) {
     }
     lines.push('');
     lines.push('  Fix the work, then re-run: hedgehog verify <task-id>');
+  }
+
+  // Last, because it's a condition of the graph as a whole rather than
+  // of any one task, and because an operator reading top-down should
+  // reach it after knowing what's ready and what's stuck.
+  if (drift && drift.length > 0) {
+    lines.push('');
+    lines.push(formatDrift(drift));
   }
 
   return lines.join('\n');

--- a/src/skills/hedgehog-authored-loop/SKILL.md
+++ b/src/skills/hedgehog-authored-loop/SKILL.md
@@ -17,16 +17,51 @@ An authored core's layer sequence and stack were designed for this
 project by `hedgehog-core-design`. Two files carry them, and both are
 locked:
 
-- **`.hedgehog/core.yaml`** — the compiled authority: layer order, each
+- **`.hedgehog/core.yaml`** — the design authority: layer order, each
   layer's `scope` globs, `verify` command, commit message. `hedgehog
-  plan` compiled the graph from it; every packet is generated from it.
+  plan` compiled the graph from it.
 - **`.hedgehog/core-design.md`** — the rationale: system shape, stack,
   what each layer owns and why it sits where it does, and the module-axis
   decision.
 
 Read `core-design.md` at the start of a session to know what this project
-is; trust `core.yaml` and the packet as authoritative if the two ever
-seem to disagree.
+is.
+
+### core.yaml vs. the packet
+
+`hedgehog plan` **copies** each layer's scope globs, verify command and
+commit message onto every task row when it compiles. From that moment
+the row — which is what the packet shows — is what `hedgehog claim` hands
+out and what `hedgehog verify` gates against. `core.yaml` is no longer
+consulted for a task that already exists.
+
+So an edit to `core.yaml` after `plan` has run does **not** reach
+already-compiled tasks, and re-running `hedgehog plan` won't apply it
+either: compiling an intent flips it to `active`, and `plan` only reads
+`proposed`/`planned` intents, so it reports "0 intent(s) compiled" and
+changes nothing.
+
+If the packet and `core.yaml` disagree, the packet is what your work will
+actually be judged by. Reconcile, don't pick a winner:
+
+1. `hedgehog status` prints a **DRIFT** section: every task whose
+   compiled fields no longer match `core.yaml`, field by field, with
+   `core.yaml`'s value against the task's.
+2. `hedgehog plan --recompile` rewrites those fields from the current
+   `core.yaml` on tasks nothing has acted on yet (`proposed`, `planned`,
+   `ready`), and refuses `building`, `verifying`, `complete` and
+   `blocked` tasks, naming each and why. `--dry-run` previews it;
+   `--include-blocked` opts in the blocked ones (their working-tree work
+   was done against the old scope, so check it after);  `--strict` exits
+   non-zero when drift remains.
+3. Drift `--recompile` won't touch — a task already built or committed, a
+   layer dropped from `core.yaml`, a changed `depends_on` — is a
+   Correction Protocol case (below), not a field rewrite.
+
+Never patch a task row in SQLite by hand to work around this. The DB is
+derived and gitignored; `hedgehog db rebuild` re-derives every task from
+`core.yaml` and the committed intents, so a hand-patched row silently
+disappears on the next rebuild or fresh clone.
 
 ## Module axis
 
@@ -147,6 +182,12 @@ wrong place, a missing layer, a scope glob that never fits — that's a
 `.hedgehog/core-design.md` are locked, and changing them re-shapes every
 task the graph compiles. Stop, say what the design got wrong, and hand to
 `planner`.
+
+Once `planner` has changed `core.yaml`, the edit still has to be pushed
+into the already-compiled graph — run `hedgehog plan --recompile` (see
+"core.yaml vs. the packet" above) and read what it reports. Tasks it
+refuses are the ones this Correction Protocol has to fix forward in
+commits instead.
 
 ### Post-build entry
 

--- a/src/skills/hedgehog-loop/SKILL.md
+++ b/src/skills/hedgehog-loop/SKILL.md
@@ -10,11 +10,23 @@ reserves the packet(s) for ready layers, build them, `hedgehog verify`
 gates and commits each. The build graph (`.hedgehog/hedgehog.db`) is the
 live list — query it via `hedgehog status`/`hedgehog ready`, never
 re-derive state from prose. The step tables below mirror
-`src/golden-cores/full-stack-app/core.yaml`, already the source of truth
+`src/golden-cores/full-stack-app/core.yaml`, the design source of truth
 for layer order, scope, and verify command per layer — read the tables
-for the human-readable shape, trust the YAML (and the packet `hedgehog
-claim` emits from it) as the authoritative one if they ever seem to
-disagree.
+for the human-readable shape, and the YAML when they seem to disagree.
+
+The packet, though, is what actually runs. `hedgehog plan` copies each
+layer's scope globs, verify command and commit message onto every task
+row at compile time; from then on the row — not `core.yaml` — is what
+`hedgehog claim` hands out and `hedgehog verify` gates against, and
+editing `core.yaml` afterwards does not reach tasks already compiled (a
+plain `hedgehog plan` re-run won't apply it either — it only reads
+intents still pending). `hedgehog status` prints a **DRIFT** section
+whenever the two have diverged, and `hedgehog plan --recompile` rewrites
+the layer-derived fields on not-yet-started tasks from the current
+`core.yaml`, refusing — and naming — every task already building,
+verifying, complete, or blocked. Never patch a task row in SQLite by
+hand: the DB is derived and gitignored, so `hedgehog db rebuild` drops
+the patch.
 
 ## Determine phase
 

--- a/src/templates/CLAUDE.core.authored.md
+++ b/src/templates/CLAUDE.core.authored.md
@@ -5,22 +5,41 @@ planning intake, rather than taken from a shipped Golden Core. The layer
 sequence, the stack, and each layer's file scope and verification live in
 two files, and both are locked:
 
-- **`.hedgehog/core.yaml`** — the compiled authority: `id`, the layer
+- **`.hedgehog/core.yaml`** — the design authority: `id`, the layer
   order, and per layer its `scope` globs, `verify` command, and commit
-  message. `hedgehog plan` compiled the build graph from this; every task
-  packet is generated from it.
+  message. `hedgehog plan` compiled the build graph from this.
 - **`.hedgehog/core-design.md`** — the rationale: the system shape (what
   this project fundamentally is), the stack and why it was chosen, a line
   per layer on what it owns and why it sits where it does, and the
   module-axis decision.
 
 Read `core-design.md` to know what this project is and what each layer
-owns. Trust `core.yaml` and the packet `hedgehog next` emits as
-authoritative if the two ever seem to disagree.
+owns.
 
-Changing either file re-shapes every task the graph compiles. Both are
-locked at `hedgehog-core-design`'s Confirm & Lock — a layer boundary that
-turns out wrong is a `planner` decision through the Correction Protocol.
+**The packet is what actually runs.** `hedgehog plan` *copies* each
+layer's scope globs, verify command and commit message onto every task
+row at compile time, and from then on the row — surfaced as the packet
+`hedgehog next`/`claim` emits — is what the engine reads. Editing
+`core.yaml` afterwards does not reach tasks already compiled, and a plain
+`hedgehog plan` re-run won't either (compiling an intent marks it
+`active`, and `plan` only looks at pending ones). So if the packet and
+`core.yaml` disagree, the packet is what your work will be gated
+against — reconcile them rather than picking a winner:
+
+- `hedgehog status` reports a **DRIFT** section naming every task whose
+  compiled fields no longer match `core.yaml`, and what differs.
+- `hedgehog plan --recompile` rewrites those fields from the current
+  `core.yaml` on tasks that haven't started, and refuses (naming each
+  one) tasks that are `building`, `verifying`, `complete` or `blocked`.
+  `--dry-run` previews; `--include-blocked` opts blocked tasks in.
+- A task already built or committed can't be reconciled this way at all
+  — that's the Correction Protocol: fix the layer at its source and
+  re-run it.
+
+Changing either file re-shapes every task the graph compiles *from then
+on*. Both are locked at `hedgehog-core-design`'s Confirm & Lock — a layer
+boundary that turns out wrong is a `planner` decision through the
+Correction Protocol.
 
 ### The skills — invoke these, don't improvise
 


### PR DESCRIPTION
Editing `.hedgehog/core.yaml` after `hedgehog plan` has no effect on already-compiled tasks, and nothing warns. This adds a reconciliation path and, more importantly, makes the divergence visible.

## Confirmed in the code

`plan.mjs` copies the layer straight onto each task row:

```js
scope_globs: JSON.stringify(layer.scope.map((g) => fillModule(g, module))),
verify_command: fillModule(layer.verify, module),
commit_message: fillModule(layer.commit, module),
```

`schema.mjs` makes those real columns, and `plan` only ever INSERTs — `insertTask` is the only statement touching them, with no UPDATE path anywhere. `planTasks` skips an intent whose first task exists, and it only loads `PENDING_INTENT_STATUSES = ['proposed', 'planned']` while compiling flips the intent to `active`. So re-running `plan` after a `core.yaml` edit prints `0 intent(s) compiled` and the task keeps the stale command — reproduced literally.

On the build where this surfaced, a PATH fix to one layer's `verify` left **0 of 36 tasks** carrying the corrected version, and the only remedy was a direct `UPDATE` in SQLite.

## What this adds

- **`src/db/drift.mjs`** (new) — `detectDrift` / `recompileTasks` / `formatDrift` / `formatRecompile`. It separates three cases deliberately: field drift (rewritable), a layer dropped from `core.yaml`, and a changed `depends_on` edge. The last is graph shape, so it is reported and never silently rewritten.
- **`hedgehog plan --recompile`** — rewrites `objective`, `scope_globs`, `verify_command`, `commit_message`, `exclusive` and `verify_radius` on `proposed`/`planned`/`ready` tasks. It refuses `building`/`verifying`/`complete`/`blocked`, printing each skipped task with its reason and both values. Flags: `--dry-run`, `--include-blocked`, `--strict` (non-zero exit while drift remains). Status is re-checked **inside** the write transaction, so a task claimed mid-run is never rewritten under a live lease.
- **`hedgehog status`** — a new DRIFT section, field by field, pointing at `plan --recompile`. It degrades gracefully when there is no `core.yaml` or it will not parse.
- **Plain `hedgehog plan`** now warns about drift instead of reporting "0 compiled" and looking like a successful no-op.
- **`hedgehog db rebuild`** reports post-rebuild drift, and states that hand-edited task rows have no committed source and are not replayed.
- **`refactor(plan)`** extracts `layerTaskFields()` + `LAYER_DERIVED_FIELDS`, so the drift check compares exactly the columns the compiler writes. No behaviour change.

## A documentation correction

`src/templates/CLAUDE.core.authored.md` told the operator to treat `core.yaml` as authoritative when it and the compiled task disagree — the exact opposite of the real behaviour, which is what made this bug expensive to diagnose. Corrected to describe what actually happens, and to point at `--recompile` as the way to make the two agree.

## Two corrections to the original diagnosis

Worth recording, since both make the picture sharper:

- **`rebuild` is not only a fresh-clone concern.** It calls `planTasks` with the *current* `core.yaml`, so a rebuild does pick up `core.yaml` edits for whatever it compiles fresh — which is precisely why hand-patched task rows vanish. Verified by deleting the DB and rebuilding: the new commit message from the edited `core.yaml` appeared.
- **On a module-axis core, widening a layer is not merely the worse workaround — it is the only representable one.** `validateCore` actively forces uniformity:

  ```js
  if (!layer.scope.join('').includes('{module}')) {
    throw new Error(`layer "${layer.id}" has no {module} in scope, but core "${core.id}" is module-axis ...`);
  }
  ```

## Evidence

`node repro/run-all.mjs` — 3 scripts, 11 scenarios, driving the real CLI in throwaway temp dirs.

- **Before** (master, via a throwaway worktree): 0/3 scripts, 9 of 11 scenarios fail — e.g. `expected: "PATH=/usr/local/bin:$PATH node --test infra/billing"` / `actual: "node --test infra/billing"`, and `expected output to contain: "DRIFT"` against a status output with none.
- **After:** 3/3 scripts, 11/11 scenarios pass.

`node scripts/check.mjs` passes. `src/db/verify.mjs` is untouched.

## On the per-module scope exception — a recommendation, not an implementation

The related half of this problem is that a per-module scope exception is not expressible at all, so real builds patch individual task rows via SQL and the graph diverges from its own committed sources.

A committed record of task-level corrections would fit the existing shape almost exactly, because `.hedgehog/intents/*.json` already establishes the pattern: committed, plain text, replayed by `rebuild` through `planTasks`. Something like `.hedgehog/overrides/*.json` with entries of the form `{ task: "BILLING-FOUNDATION", scope_add: ["infra/shared/registry.ts"], reason: "..." }`, applied by `planTasks` immediately after insert — a fresh compile applies it, `rebuild` reapplies it, a PR can review it, and `hedgehog why` can reach it.

Three constraints seem worth holding firm on: **additive only** (`scope_add`, never `scope_replace`, so an override can never shrink a gate); **per task, never per layer** (a per-layer override is a layer edit wearing a disguise); and **no `verify` overrides** at all, since weakening a layer's verify is the one thing the discipline forbids outright — that belongs in `core.yaml` plus `--recompile`, which is now a supported path.

This is deliberately **not implemented here**, because it creates a second authority over `scope_globs` — the same class of problem as the bug this PR fixes. Adopting it means `detectDrift` must compare against `core.yaml` *composed with* the overrides, or every overridden task reads as permanently drifted and the new DRIFT section becomes noise. That coupling makes it your design call rather than a patch.

## Honest gaps

- `--include-blocked` is implemented but has **no repro assertion** — the reproduction covers `building`/`verifying`/`complete` only.
- Dependency-edge drift detection and the rebuild drift warning are implemented and manually smoke-tested, **not** covered by an automated reproduction.
- The rebuild warning does not compare against "what it previously held" in the fresh-clone case, because there is nothing to compare against — the DB is gitignored and `planTasks` is additive. It reports post-rebuild disagreement with `core.yaml` instead, which is useful on a populated DB.
- The reproductions drive the real CLI for everything except task lifecycle transitions, which are written directly to the status/lease columns — a real `verify` needs a toolchain the throwaway project does not have. The fields under test are only ever written by the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
