### PR TITLE
feat(cli): add hedgehog boundary, so the discipline can answer when to clear context

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -26,6 +26,7 @@ import { verifyTask } from '../src/db/verify.mjs';
 import { claimTasks, releaseTask, renewLease } from '../src/db/claim.mjs';
 import { readyTasks, formatReady } from '../src/db/ready.mjs';
 import { graphStatus, formatStatus } from '../src/db/status.mjs';
+import { boundaryState, formatBoundary, formatPosition, formatHandoff } from '../src/db/boundary.mjs';
 import { whyPath, formatWhy } from '../src/db/why.mjs';
 import { addFriction, listFriction } from '../src/db/friction.mjs';
 import { rebuildDb } from '../src/db/rebuild.mjs';
@@ -196,7 +197,11 @@ const exists = (p) =>
 // there's nothing to rebuild from either (a genuinely fresh project, no
 // intents yet), this no-ops and leaves the DB missing — the caller's own
 // existing "No build graph found" guard still fires for that case.
-async function ensureDb() {
+// `log` exists for the one caller whose stdout is a machine-consumable
+// payload (`hedgehog boundary`): the rebuild notice is commentary, and
+// commentary on stdout would corrupt a block meant to be captured or
+// piped. Every other command leaves it at the default.
+async function ensureDb({ log = console.log } = {}) {
   if (await exists(DB_PATH)) return;
 
   let intentFiles = [];
@@ -218,7 +223,7 @@ async function ensureDb() {
   } finally {
     db.close();
   }
-  console.log(
+  log(
     `${dim('DB missing — rebuilt from')} ${bold(INTENTS_DIR)}${dim(':')} ${dim(`${result.intentsReplayed} intent(s) replayed, ${result.tasksMarkedComplete} task(s) marked complete`)}\n`,
   );
 }
@@ -317,6 +322,10 @@ ${bold('Usage')}
   npx @skyf0xx/hedgehog status                    graph overview: counts by status, ready list, in flight
   npx @skyf0xx/hedgehog ready                     preview which ready tasks are claimable now vs held back
   npx @skyf0xx/hedgehog quiesce                   report whether anything is still in flight
+  npx @skyf0xx/hedgehog boundary                  is this a moment to clear context? exits 0 only if it is,
+                                                   and prints what a fresh session picks up next
+  npx @skyf0xx/hedgehog boundary --handoff        print the block a fresh session starts from
+  npx @skyf0xx/hedgehog boundary --quiet          exit code only, for a shell hook
   npx @skyf0xx/hedgehog graph                     start (or reuse) the live graph server and open it
   npx @skyf0xx/hedgehog graph --no-open           start (or reuse) the server; print the URL instead
   npx @skyf0xx/hedgehog why <path>                provenance chain for a file
@@ -1024,6 +1033,62 @@ async function quiesceCommand() {
   process.exitCode = 1;
 }
 
+// `hedgehog boundary [--quiet] [--handoff]` — is this a good moment to
+// clear the conversation, and where would a fresh one pick up?
+//
+// `quiesce` answers one third of that question (nothing in flight).
+// This answers all of it: nothing in flight, a clean working tree, and a
+// last closed task that completed its intent — see boundary.mjs for how
+// each is derived. Exits 0 only when all three hold, so a shell hook can
+// consume it without reading anything.
+//
+// Output is split by consumer, not by importance:
+//   stdout — the payload worth capturing: the NEXT/WHY positioning block,
+//            or with --handoff the full block a fresh session starts from.
+//   stderr — the verdict and the per-condition results, so a non-zero
+//            exit always names which condition failed without that
+//            commentary landing in a captured payload.
+//   --quiet drops the commentary and the default payload, leaving the
+//            exit code (and, if asked for explicitly, --handoff's block).
+//
+// Exit codes: 0 boundary reached; 1 not a boundary; 2 the question can't
+// be answered here (no build graph, no git repository, or a last closed
+// task that isn't identifiable).
+async function boundaryCommand(args) {
+  const quiet = args.includes('--quiet');
+  const handoff = args.includes('--handoff');
+
+  await ensureDb({ log: (msg) => console.error(msg) });
+
+  if (!(await exists(DB_PATH))) {
+    if (!quiet) {
+      console.error(`${red('No build graph found.')} Run ${bold('hedgehog db init')} first.\n`);
+    }
+    process.exitCode = 2;
+    return;
+  }
+
+  const db = openDb();
+  let state;
+  try {
+    state = boundaryState(db);
+  } finally {
+    db.close();
+  }
+
+  if (!quiet) console.error(formatBoundary(state));
+  if (handoff) console.log(formatHandoff(state));
+  else if (!quiet && state.reached) console.log(formatPosition(state));
+
+  if (state.undecidable) {
+    process.exitCode = 2;
+    return;
+  }
+  if (!state.reached) {
+    process.exitCode = 1;
+  }
+}
+
 const GRAPH_PIDFILE_PATH = '.hedgehog/graph-server.json';
 const GRAPH_SERVER_MODULE = join(PKG_ROOT, 'src/db/graph-server.mjs');
 const GRAPH_TEMPLATE_PATH = join(PKG_ROOT, 'src/templates/graph.html');
@@ -1368,6 +1433,11 @@ async function main() {
 
   if (cmd === 'quiesce') {
     await quiesceCommand();
+    return;
+  }
+
+  if (cmd === 'boundary') {
+    await boundaryCommand(args.slice(1));
     return;
   }
 

--- a/repro/boundary-at-boundary.mjs
+++ b/repro/boundary-at-boundary.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Repro: a genuine boundary exits 0 and positions a fresh session.
+//
+// Intent `alpha` is built to completion (both layers claimed, built,
+// verified, committed), nothing is left in flight, and the working tree
+// is clean — the exact moment the discipline says to clear context. The
+// operator has no way to learn that today: `hedgehog quiesce` exits 0
+// here, but it also exits 0 halfway through `alpha`, so its 0 doesn't
+// mean "boundary".
+//
+// Expected: `hedgehog boundary` exits 0, names all three conditions on
+// stderr, and prints the next task and why on stdout.
+
+import {
+  makeProject,
+  completeNextTask,
+  runCliCapturingBoth,
+  cleanup,
+  check,
+  checkExit,
+  checkContains,
+  report,
+} from './lib/fixture.mjs';
+
+const project = makeProject();
+try {
+  completeNextTask(project); // ALPHA-MODEL
+  completeNextTask(project); // ALPHA-VIEW — closes intent alpha
+
+  const result = runCliCapturingBoth(project, ['boundary']);
+  console.log('--- exit', result.status);
+  console.log('--- stdout\n' + result.stdout);
+  console.log('--- stderr\n' + result.stderr);
+
+  checkExit('exits 0 at a genuine boundary', 0, result);
+  checkContains('stderr names the verdict', 'Boundary reached.', result.stderr);
+  checkContains('stderr names condition 1', 'nothing in flight', result.stderr);
+  checkContains('stderr names condition 2', 'working tree clean', result.stderr);
+  checkContains('stderr names condition 3', 'completed intent "alpha"', result.stderr);
+  checkContains('stdout positions the next task', 'BETA-MODEL', result.stdout);
+  checkContains('stdout says why it is next', 'WHY', result.stdout);
+  check('stderr commentary stays off stdout', {
+    expected: false,
+    actual: result.stdout.includes('Boundary reached.'),
+  });
+
+  // Script-friendly: exit code only, nothing on either stream.
+  const quiet = runCliCapturingBoth(project, ['boundary', '--quiet'], {
+    env: { NODE_NO_WARNINGS: '1' },
+  });
+  checkExit('--quiet exits 0 at a boundary', 0, quiet);
+  check('--quiet prints nothing to stdout', { expected: '', actual: quiet.stdout });
+  check('--quiet prints nothing to stderr', { expected: '', actual: quiet.stderr });
+
+  // Usable as a handoff: a block a fresh session can be started with.
+  const handoff = runCliCapturingBoth(project, ['boundary', '--handoff']);
+  console.log('--- handoff stdout\n' + handoff.stdout);
+  checkExit('--handoff exits 0 at a boundary', 0, handoff);
+  checkContains('handoff names itself', 'HEDGEHOG HANDOFF', handoff.stdout);
+  checkContains('handoff says where the build is', 'BUILD', handoff.stdout);
+  checkContains('handoff says what is next', 'BETA-MODEL', handoff.stdout);
+  checkContains('handoff says what is blocked', 'BLOCKED', handoff.stdout);
+  checkContains('handoff reports the boundary verdict', 'BOUNDARY', handoff.stdout);
+} finally {
+  cleanup(project);
+}
+
+report('boundary-at-boundary');

--- a/repro/boundary-dirty-tree.mjs
+++ b/repro/boundary-dirty-tree.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+// Repro: a dirty working tree is not a boundary, and the command says so.
+//
+// Intent `alpha` closes cleanly and nothing is in flight — `hedgehog
+// quiesce` exits 0 here — but an uncommitted file is sitting in the
+// working tree. Clearing context now discards the only knowledge of why
+// that file exists, since it is in no commit and in no task's artifacts.
+//
+// Expected: non-zero exit, and stderr marks the clean-tree condition
+// failed and names the offending path. The engine's own gitignored
+// files must not count as dirt.
+
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  makeProject,
+  completeNextTask,
+  runCliCapturingBoth,
+  cleanup,
+  checkNonZeroExit,
+  checkContains,
+  report,
+} from './lib/fixture.mjs';
+
+const project = makeProject();
+try {
+  completeNextTask(project); // ALPHA-MODEL
+  completeNextTask(project); // ALPHA-VIEW — closes intent alpha
+
+  writeFileSync(join(project, 'stray-note.txt'), 'half-finished work\n');
+
+  const result = runCliCapturingBoth(project, ['boundary']);
+  console.log('--- exit', result.status);
+  console.log('--- stdout\n' + result.stdout);
+  console.log('--- stderr\n' + result.stderr);
+
+  checkNonZeroExit('exits non-zero with a dirty working tree', result);
+  checkContains('stderr names the verdict', 'Not a boundary.', result.stderr);
+  checkContains('stderr marks the clean-tree condition failed', '✗ working tree clean', result.stderr);
+  checkContains('stderr names the uncommitted path', 'stray-note.txt', result.stderr);
+  checkContains('stderr still passes the in-flight condition', '✓ nothing in flight', result.stderr);
+} finally {
+  cleanup(project);
+}
+
+report('boundary-dirty-tree');

--- a/repro/boundary-intent-incomplete.mjs
+++ b/repro/boundary-intent-incomplete.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Repro: mid-intent is not a boundary, and the command says so.
+//
+// This is the condition nothing in the CLI can answer today. One layer
+// of intent `alpha` is committed; the next layer of the same intent is
+// ready. Nothing is in flight and the tree is clean, so `hedgehog
+// quiesce` exits 0 — but the intent is half built, which is exactly the
+// state the discipline does not want a conversation thrown away in.
+// `hedgehog verify` printed "intent complete" when the intent closed;
+// nothing records that it did *not* print it here.
+//
+// Expected: non-zero exit, and stderr marks the intent condition failed,
+// naming the last closed task and what remains.
+
+import {
+  makeProject,
+  completeNextTask,
+  runCli,
+  runCliCapturingBoth,
+  cleanup,
+  checkExit,
+  checkNonZeroExit,
+  checkContains,
+  report,
+} from './lib/fixture.mjs';
+
+const project = makeProject();
+try {
+  const closed = completeNextTask(project); // ALPHA-MODEL only
+  console.log('--- closed', closed);
+
+  // The state `quiesce` calls settled — necessary, but not the boundary.
+  const quiesce = runCliCapturingBoth(project, ['quiesce']);
+  checkExit('quiesce exits 0 mid-intent (the gap being closed)', 0, quiesce);
+
+  const result = runCliCapturingBoth(project, ['boundary']);
+  console.log('--- exit', result.status);
+  console.log('--- stdout\n' + result.stdout);
+  console.log('--- stderr\n' + result.stderr);
+
+  checkNonZeroExit('exits non-zero mid-intent', result);
+  checkContains('stderr names the verdict', 'Not a boundary.', result.stderr);
+  checkContains(
+    'stderr marks the intent condition failed',
+    '✗ last closed task completed an intent',
+    result.stderr,
+  );
+  checkContains('stderr names the last closed task', 'ALPHA-MODEL', result.stderr);
+  checkContains('stderr names what remains of the intent', 'ALPHA-VIEW', result.stderr);
+  checkContains('stderr still passes the in-flight condition', '✓ nothing in flight', result.stderr);
+  checkContains('stderr still passes the clean-tree condition', '✓ working tree clean', result.stderr);
+
+  // The handoff block is still usable when it isn't a boundary — a fresh
+  // session still has to be positioned, it just isn't a free moment to
+  // start one.
+  const handoff = runCliCapturingBoth(project, ['boundary', '--handoff']);
+  checkNonZeroExit('--handoff keeps the non-zero verdict', handoff);
+  checkContains('handoff still positions the next task', 'ALPHA-VIEW', handoff.stdout);
+
+  // Nothing built at all is also not a boundary — there is no closed
+  // intent to sit behind.
+  const fresh = makeProject();
+  try {
+    const freshResult = runCliCapturingBoth(fresh, ['boundary']);
+    checkNonZeroExit('exits non-zero before anything is built', freshResult);
+    checkContains('stderr says no task has completed yet', 'no task has completed yet', freshResult.stderr);
+  } finally {
+    cleanup(fresh);
+  }
+
+  runCli(project, ['status']);
+} finally {
+  cleanup(project);
+}
+
+report('boundary-intent-incomplete');

--- a/repro/boundary-work-in-flight.mjs
+++ b/repro/boundary-work-in-flight.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Repro: work in flight is not a boundary, and the command says so.
+//
+// Intent `alpha` closes cleanly, then BETA-MODEL is claimed — a lease is
+// outstanding. Clearing context now orphans that lease until it expires,
+// which is the one case `hedgehog quiesce` already catches. `boundary`
+// must catch it too, and must name *this* condition rather than a
+// generic failure.
+//
+// Expected: non-zero exit, and stderr marks the in-flight condition
+// failed with the task and its owner.
+
+import {
+  makeProject,
+  completeNextTask,
+  runCli,
+  runCliCapturingBoth,
+  cleanup,
+  checkNonZeroExit,
+  checkContains,
+  report,
+} from './lib/fixture.mjs';
+
+const project = makeProject();
+try {
+  completeNextTask(project); // ALPHA-MODEL
+  completeNextTask(project); // ALPHA-VIEW — closes intent alpha
+
+  const claimed = runCli(project, ['claim', '--owner', 'agent-7']);
+  console.log('--- claim\n' + claimed.stdout);
+
+  const result = runCliCapturingBoth(project, ['boundary']);
+  console.log('--- exit', result.status);
+  console.log('--- stdout\n' + result.stdout);
+  console.log('--- stderr\n' + result.stderr);
+
+  checkNonZeroExit('exits non-zero with a lease outstanding', result);
+  checkContains('stderr names the verdict', 'Not a boundary.', result.stderr);
+  checkContains('stderr marks the in-flight condition failed', '✗ nothing in flight', result.stderr);
+  checkContains('stderr names the in-flight task', 'BETA-MODEL', result.stderr);
+  checkContains('stderr names the lease owner', 'agent-7', result.stderr);
+  checkContains('stderr still passes the clean-tree condition', '✓ working tree clean', result.stderr);
+} finally {
+  cleanup(project);
+}
+
+report('boundary-work-in-flight');

--- a/repro/lib/fixture.mjs
+++ b/repro/lib/fixture.mjs
@@ -1,0 +1,241 @@
+// Shared harness for the `hedgehog boundary` reproductions.
+//
+// Every repro builds a real Hedgehog project in a throwaway temp dir — a
+// git repo, an authored `.hedgehog/core.yaml`, two intents, a compiled
+// build graph — and drives it through the real CLI (`bin/cli.mjs`), the
+// same binary a consuming project runs. Nothing is stubbed: tasks are
+// claimed, files are written, `hedgehog verify` runs the verify command
+// and makes the commit.
+//
+// No test framework and no `sqlite3` binary: assertions are plain
+// functions that print expected vs actual and exit non-zero.
+
+import { execFileSync, execSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = resolve(__dirname, '../..');
+export const CLI = join(REPO_ROOT, 'bin/cli.mjs');
+
+// Two layers, two intents, and a verify command that always passes —
+// the repro is about the boundary question, not about whether a layer's
+// tests are green. `alpha` is priority 10 and `beta` 20, so `hedgehog
+// claim` hands out a deterministic order: ALPHA-MODEL, ALPHA-VIEW,
+// BETA-MODEL, BETA-VIEW.
+const CORE_YAML = `id: repro
+layers:
+  - id: model
+    scope: [src/{module}/model.txt]
+    verify: node -e "process.exit(0)"
+    commit: "feat({module}): model"
+  - id: view
+    depends_on: model
+    scope: [src/{module}/view.txt]
+    verify: node -e "process.exit(0)"
+    commit: "feat({module}): view"
+`;
+
+const GITIGNORE = `.hedgehog/hedgehog.db
+.hedgehog/hedgehog.db-*
+.hedgehog/commit.lock
+.hedgehog/graph-server.json
+`;
+
+export function runCli(project, args, { env = {} } = {}) {
+  try {
+    const stdout = execFileSync(process.execPath, [CLI, ...args], {
+      cwd: project,
+      encoding: 'utf8',
+      env: { ...process.env, NO_COLOR: '1', ...env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    return {
+      status: err.status ?? 1,
+      stdout: err.stdout ?? '',
+      stderr: err.stderr ?? '',
+      signal: err.signal,
+    };
+  }
+}
+
+// execFileSync surfaces stderr only on failure, and the whole point of
+// `hedgehog boundary` is that its two streams carry different things —
+// so the repros read both on every run, via a shell redirect. The
+// capture file lives outside the project: writing it inside would dirty
+// the very working tree the command is being asked about.
+export function runCliCapturingBoth(project, args, { env = {} } = {}) {
+  const errPath = join(mkdtempSync(join(tmpdir(), 'hedgehog-repro-err-')), 'stderr.txt');
+  let status = 0;
+  let stdout = '';
+  try {
+    stdout = execSync(
+      `${JSON.stringify(process.execPath)} ${JSON.stringify(CLI)} ${args
+        .map((a) => JSON.stringify(a))
+        .join(' ')} 2>${JSON.stringify(errPath)}`,
+      { cwd: project, encoding: 'utf8', env: { ...process.env, NO_COLOR: '1', ...env } },
+    );
+  } catch (err) {
+    status = err.status ?? 1;
+    stdout = err.stdout ?? '';
+  }
+  const stderr = existsSync(errPath) ? readFileSync(errPath, 'utf8') : '';
+  rmSync(dirname(errPath), { recursive: true, force: true });
+  return { status, stdout, stderr };
+}
+
+function git(project, command) {
+  return execSync(`git ${command}`, { cwd: project, encoding: 'utf8', stdio: 'pipe' });
+}
+
+// A project with the graph compiled, intents committed, and a clean
+// working tree — the state a build starts from.
+export function makeProject() {
+  const project = mkdtempSync(join(tmpdir(), 'hedgehog-boundary-repro-'));
+
+  execSync('git init -q .', { cwd: project, stdio: 'pipe' });
+  git(project, 'config user.email repro@example.com');
+  git(project, 'config user.name repro');
+  git(project, 'config commit.gpgsign false');
+
+  mkdirSync(join(project, '.hedgehog'), { recursive: true });
+  writeFileSync(join(project, '.gitignore'), GITIGNORE);
+  writeFileSync(join(project, '.hedgehog/core.yaml'), CORE_YAML);
+  git(project, 'add -A');
+  git(project, 'commit -qm "chore: init"');
+
+  runCli(project, ['db', 'init']);
+  runCli(project, ['intent', 'add', '--id', 'alpha', '--goal', 'alpha goal', '--outcome', 'alpha outcome', '--priority', '10']);
+  runCli(project, ['intent', 'add', '--id', 'beta', '--goal', 'beta goal', '--outcome', 'beta outcome', '--priority', '20']);
+
+  // `hedgehog plan` also starts the graph server and hands the URL to the
+  // OS browser opener; neither is part of what's under test here, and on
+  // a headless box the opener may fail after the graph is already
+  // written. The effect is asserted below instead of the exit code.
+  runCli(project, ['plan']);
+  stopGraphServer(project);
+
+  const status = runCli(project, ['status']);
+  if (!status.stdout.includes('ALPHA-MODEL')) {
+    throw new Error(`fixture: plan did not compile the graph\n${status.stdout}${status.stderr}`);
+  }
+
+  // Intents are committed source of truth (`hedgehog db rebuild` replays
+  // them); committing them here is also what leaves the tree clean, the
+  // state a real build has when a task starts.
+  git(project, 'add -A');
+  git(project, 'commit -qm "chore: intents"');
+
+  return project;
+}
+
+// Claims one task, writes the single file its scope allows, and verifies
+// it — one full turn of the loop, through the real CLI. Returns the task
+// id that closed.
+export function completeNextTask(project, { owner = 'repro' } = {}) {
+  const claimed = runCli(project, ['claim', '--owner', owner]);
+  const match = claimed.stdout.match(/Task ([A-Z0-9-]+) leased/);
+  if (!match) {
+    throw new Error(`fixture: nothing claimable\n${claimed.stdout}${claimed.stderr}`);
+  }
+  const taskId = match[1];
+  writeScopeFile(project, taskId);
+
+  const verified = runCli(project, ['verify', taskId, '--owner', owner]);
+  if (verified.status !== 0) {
+    throw new Error(
+      `fixture: verify ${taskId} failed (exit ${verified.status})\n${verified.stdout}${verified.stderr}`,
+    );
+  }
+  return taskId;
+}
+
+// Task ids are `<INTENT>-<LAYER>` (plan.mjs), and this fixture's core
+// gives every layer exactly one scope path, `src/<module>/<layer>.txt`.
+export function writeScopeFile(project, taskId) {
+  const [intentId, layerId] = taskId.toLowerCase().split('-');
+  const dir = join(project, 'src', intentId);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${layerId}.txt`), `${taskId}\n`);
+}
+
+// `hedgehog plan` leaves a detached graph server running; a repro that
+// exits without stopping it leaks a process per run.
+export function stopGraphServer(project) {
+  const pidfile = join(project, '.hedgehog/graph-server.json');
+  if (!existsSync(pidfile)) return;
+  try {
+    const { pid } = JSON.parse(readFileSync(pidfile, 'utf8'));
+    process.kill(pid, 'SIGTERM');
+  } catch {
+    // Already gone, or never started — nothing to stop.
+  }
+}
+
+export function cleanup(project) {
+  stopGraphServer(project);
+  if (process.env.HEDGEHOG_REPRO_KEEP === '1') {
+    console.log(`kept fixture: ${project}`);
+    return;
+  }
+  rmSync(project, { recursive: true, force: true });
+}
+
+// ── assertions ──────────────────────────────────────────────────────────
+const failures = [];
+
+export function check(label, { expected, actual }) {
+  const pass = expected instanceof RegExp ? expected.test(actual) : expected === actual;
+  if (pass) {
+    console.log(`  ok    ${label}`);
+    return true;
+  }
+  failures.push(label);
+  console.log(`  FAIL  ${label}`);
+  console.log(`        expected: ${expected instanceof RegExp ? expected.source : JSON.stringify(expected)}`);
+  console.log(`        actual:   ${JSON.stringify(actual)}`);
+  return false;
+}
+
+export function checkExit(label, expected, result) {
+  return check(label, { expected, actual: result.status });
+}
+
+export function checkNonZeroExit(label, result) {
+  if (result.status !== 0) {
+    console.log(`  ok    ${label} (exit ${result.status})`);
+    return true;
+  }
+  failures.push(label);
+  console.log(`  FAIL  ${label}`);
+  console.log('        expected: a non-zero exit code');
+  console.log('        actual:   0');
+  return false;
+}
+
+export function checkContains(label, needle, haystack) {
+  if (haystack.includes(needle)) {
+    console.log(`  ok    ${label}`);
+    return true;
+  }
+  failures.push(label);
+  console.log(`  FAIL  ${label}`);
+  console.log(`        expected to contain: ${JSON.stringify(needle)}`);
+  console.log(`        actual:              ${JSON.stringify(haystack)}`);
+  return false;
+}
+
+export function report(name) {
+  if (failures.length === 0) {
+    console.log(`\n${name}: PASS\n`);
+    process.exit(0);
+  }
+  console.log(`\n${name}: FAIL — ${failures.length} assertion(s):`);
+  for (const f of failures) console.log(`  - ${f}`);
+  console.log('');
+  process.exit(1);
+}

--- a/repro/run-all.mjs
+++ b/repro/run-all.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+// Runs every `hedgehog boundary` reproduction and summarizes. Each repro
+// is standalone — run one directly to see its full output.
+
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const REPROS = [
+  'boundary-at-boundary.mjs',
+  'boundary-work-in-flight.mjs',
+  'boundary-dirty-tree.mjs',
+  'boundary-intent-incomplete.mjs',
+];
+
+const results = [];
+for (const repro of REPROS) {
+  console.log(`\n======== ${repro} ========`);
+  try {
+    const out = execFileSync(process.execPath, [join(__dirname, repro)], { encoding: 'utf8' });
+    console.log(out);
+    results.push({ repro, ok: true });
+  } catch (err) {
+    console.log(err.stdout ?? '');
+    console.log(err.stderr ?? '');
+    results.push({ repro, ok: false });
+  }
+}
+
+console.log('\n======== summary ========');
+for (const { repro, ok } of results) console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${repro}`);
+const failed = results.filter((r) => !r.ok).length;
+console.log('');
+process.exit(failed === 0 ? 0 : 1);

--- a/src/db/boundary.mjs
+++ b/src/db/boundary.mjs
@@ -1,0 +1,396 @@
+// `hedgehog boundary` — is this a good moment to throw away the
+// conversation?
+//
+// The discipline tells an operator to clear context at a natural
+// boundary (CLAUDE.md, "Managing context"). `hedgehog quiesce` answers
+// only whether anything is in flight — necessary, but not sufficient: a
+// settled graph with half an intent built and a dirty working tree is
+// exactly the moment clearing costs something. This command answers the
+// whole question, from state the engine already holds, so the decision
+// stops living in the operator's head.
+//
+// Three conditions, all derived, none remembered:
+//
+//   1. nothing in flight   — no task `building` or `verifying`
+//                            (status.mjs's inFlight; the same set
+//                            `quiesce` reports).
+//   2. working tree clean  — `git status --porcelain` empty, minus the
+//                            engine's own derived files (the gitignored
+//                            build graph, its sqlite sidecars, the commit
+//                            lock, the graph-server pidfile), which are
+//                            never a reason to keep a conversation.
+//   3. intent closed       — the last closed task completed its intent.
+//                            verify.mjs's completeIntentIfDone already
+//                            detects this and the CLI prints "intent
+//                            complete" — this recomputes it from the same
+//                            predicate rather than depending on anyone
+//                            having read that line.
+//
+// Condition 3's "last closed task" is read from the `verifications`
+// table (the newest `passed` row — the engine's own record of which task
+// closed last), and falls back to git history when there is no such row:
+// `hedgehog db rebuild` reconstructs `tasks.status` from commit subjects
+// without replaying verifications, so a rebuilt graph has complete tasks
+// and an empty verifications table. The fallback matches commit subjects
+// against `tasks.commit_message`, which is exactly what verify.mjs
+// committed and what rebuild.mjs already matches on.
+
+import { execSync } from 'node:child_process';
+import { DB_PATH } from './init.mjs';
+import { LOCK_PATH } from './commitLock.mjs';
+import { graphStatus } from './status.mjs';
+import { nextTask, stalledTasks } from './next.mjs';
+
+const GRAPH_PIDFILE_PATH = '.hedgehog/graph-server.json';
+
+// Engine state, written by this CLI and nobody else, and derived from
+// sources that are themselves committed — the same exclusion verify.mjs
+// applies to its scope diff, for the same reason: the engine's own
+// bookkeeping must never read as the operator's unfinished work. Covers
+// SQLite's journal/WAL/SHM sidecars.
+function isEngineStatePath(path) {
+  return (
+    path === DB_PATH ||
+    path.startsWith(`${DB_PATH}-`) ||
+    path === LOCK_PATH ||
+    path === GRAPH_PIDFILE_PATH
+  );
+}
+
+// One porcelain line is `XY <path>`, or `XY <old> -> <new>` for a rename
+// — the path starts at column 3 in either case. Renames report the
+// destination, the path that actually differs from HEAD.
+function parsePorcelainLine(line) {
+  const path = line.slice(3);
+  const arrow = path.lastIndexOf(' -> ');
+  return arrow === -1 ? path : path.slice(arrow + 4);
+}
+
+// The working tree's uncommitted paths (modified, staged, untracked),
+// minus engine state. Returns { ok: false, error } instead of throwing
+// when git itself can't answer — no repository, no git on PATH — since
+// "the tree is dirty" and "there is no tree" are different answers and
+// the caller reports them differently.
+export function workingTreeState() {
+  let output;
+  try {
+    output = execSync('git status --porcelain', { encoding: 'utf8', stdio: 'pipe' });
+  } catch (err) {
+    const detail = `${err.stderr ?? ''}`.trim() || err.message;
+    return { ok: false, error: detail, dirty: [] };
+  }
+  const dirty = output
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .map(parsePorcelainLine)
+    .filter((path) => !isEngineStatePath(path));
+  return { ok: true, error: null, dirty };
+}
+
+// The task the engine most recently closed, and how that was determined:
+//   'verification' — the newest passed `verifications` row (authoritative;
+//                    the engine wrote it at the instant the task closed).
+//   'commit'       — no verifications row exists (a rebuilt graph), so the
+//                    newest commit subject matching a complete task's
+//                    commit_message stands in.
+// Returns null when nothing has completed yet, and
+// { task: null, reason } when complete tasks exist but none can be
+// identified as the last one — an honest "can't tell", not a verdict.
+export function lastClosedTask(db) {
+  const verified = db
+    .prepare(
+      `
+      SELECT t.*, v.ran_at AS closed_at
+      FROM verifications v
+      JOIN tasks t ON t.id = v.task_id
+      WHERE v.status = 'passed'
+      ORDER BY v.id DESC
+      LIMIT 1
+    `,
+    )
+    .get();
+  if (verified !== undefined) {
+    return { task: verified, source: 'verification', reason: null };
+  }
+
+  const complete = db
+    .prepare("SELECT * FROM tasks WHERE status = 'complete'")
+    .all();
+  if (complete.length === 0) return null;
+
+  let subjects;
+  try {
+    subjects = execSync('git log --format=%s -n 200', { encoding: 'utf8', stdio: 'pipe' })
+      .split('\n')
+      .filter((line) => line !== '');
+  } catch (err) {
+    return {
+      task: null,
+      source: 'commit',
+      reason: `no verification records, and git history is unreadable (${
+        `${err.stderr ?? ''}`.trim() || err.message
+      })`,
+    };
+  }
+
+  const byMessage = new Map();
+  for (const task of complete) {
+    const bucket = byMessage.get(task.commit_message) ?? [];
+    bucket.push(task);
+    byMessage.set(task.commit_message, bucket);
+  }
+
+  for (const subject of subjects) {
+    const matches = byMessage.get(subject);
+    if (matches === undefined) continue;
+    if (matches.length > 1) {
+      return {
+        task: null,
+        source: 'commit',
+        reason: `no verification records, and commit subject "${subject}" matches ${matches.length} complete tasks (${matches
+          .map((t) => t.id)
+          .join(', ')}) — which one closed last is not derivable`,
+      };
+    }
+    return { task: matches[0], source: 'commit', reason: null };
+  }
+
+  return {
+    task: null,
+    source: 'commit',
+    reason: `no verification records, and no commit in the last 200 subjects matches a complete task's commit_message`,
+  };
+}
+
+// The tasks of `intentId` that are not yet complete — the same predicate
+// verify.mjs's completeIntentIfDone uses to decide whether an intent has
+// closed, read here instead of written.
+function remainingIntentTasks(db, intentId) {
+  return db
+    .prepare(
+      "SELECT id, layer FROM tasks WHERE intent_id = ? AND status <> 'complete' ORDER BY priority, id",
+    )
+    .all(intentId);
+}
+
+function loadIntent(db, intentId) {
+  return db.prepare('SELECT * FROM intents WHERE id = ?').get(intentId);
+}
+
+function headCommit() {
+  try {
+    return execSync('git log -1 --format="%h %s"', { encoding: 'utf8', stdio: 'pipe' }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// Evaluates all three conditions and assembles everything the CLI needs
+// to report them, position a fresh session, or both. Reads only — no
+// lease is taken, no status is changed.
+//
+// `undecidable` is separate from `reached`: a condition that can't be
+// evaluated (no git repository, an unidentifiable last closed task) is
+// not the same answer as a condition that evaluated false, and the exit
+// code distinguishes them.
+export function boundaryState(db) {
+  const graph = graphStatus(db);
+  const tree = workingTreeState();
+  const closed = lastClosedTask(db);
+
+  const conditions = [];
+
+  conditions.push({
+    id: 'nothing-in-flight',
+    label: 'nothing in flight',
+    ok: graph.inFlight.length === 0,
+    undecidable: false,
+    detail:
+      graph.inFlight.length === 0
+        ? 'no task building or verifying'
+        : `${graph.inFlight.length} task(s) in flight: ${graph.inFlight
+            .map((t) => `${t.id} (${t.status}, owner: ${t.lease_owner})`)
+            .join(', ')}`,
+  });
+
+  conditions.push({
+    id: 'clean-tree',
+    label: 'working tree clean',
+    ok: tree.ok && tree.dirty.length === 0,
+    undecidable: !tree.ok,
+    detail: !tree.ok
+      ? `working tree state is unreadable: ${tree.error}`
+      : tree.dirty.length === 0
+        ? 'no uncommitted changes'
+        : `${tree.dirty.length} uncommitted path(s): ${tree.dirty.slice(0, 10).join(', ')}${
+            tree.dirty.length > 10 ? `, +${tree.dirty.length - 10} more` : ''
+          }`,
+  });
+
+  let intent = null;
+  let remaining = [];
+  if (closed === null) {
+    conditions.push({
+      id: 'intent-closed',
+      label: 'last closed task completed an intent',
+      ok: false,
+      undecidable: false,
+      detail: 'no task has completed yet — the build has no closed intent to sit behind',
+    });
+  } else if (closed.task === null) {
+    conditions.push({
+      id: 'intent-closed',
+      label: 'last closed task completed an intent',
+      ok: false,
+      undecidable: true,
+      detail: closed.reason,
+    });
+  } else {
+    intent = loadIntent(db, closed.task.intent_id);
+    remaining = remainingIntentTasks(db, closed.task.intent_id);
+    conditions.push({
+      id: 'intent-closed',
+      label: 'last closed task completed an intent',
+      ok: remaining.length === 0,
+      undecidable: false,
+      detail:
+        remaining.length === 0
+          ? `last closed task ${closed.task.id} completed intent "${closed.task.intent_id}"`
+          : `last closed task ${closed.task.id} left intent "${closed.task.intent_id}" open — ${
+              remaining.length
+            } task(s) remain: ${remaining.map((t) => t.id).join(', ')}`,
+    });
+  }
+
+  const undecidable = conditions.some((c) => c.undecidable);
+  const reached = !undecidable && conditions.every((c) => c.ok);
+
+  return {
+    conditions,
+    reached,
+    undecidable,
+    failed: conditions.filter((c) => !c.ok),
+    graph,
+    lastClosed: closed,
+    intent,
+    remaining,
+    next: nextTask(db),
+    stalled: stalledTasks(db),
+    head: headCommit(),
+  };
+}
+
+const MARK = { ok: '✓', no: '✗', unknown: '?' };
+
+function mark(condition) {
+  if (condition.undecidable) return MARK.unknown;
+  return condition.ok ? MARK.ok : MARK.no;
+}
+
+// The human verdict: whether this is a boundary, and every condition with
+// its own result — so a non-zero exit always names which condition
+// failed, rather than leaving the operator to guess between three.
+export function formatBoundary(state) {
+  const lines = [];
+  lines.push(
+    state.undecidable
+      ? 'Boundary undecidable.'
+      : state.reached
+        ? 'Boundary reached.'
+        : 'Not a boundary.',
+  );
+  for (const condition of state.conditions) {
+    lines.push(`  ${mark(condition)} ${condition.label} — ${condition.detail}`);
+  }
+  return lines.join('\n');
+}
+
+// What the next task is and why — the positioning text a fresh session
+// needs, printed on stdout so it can be captured, piped, or pasted
+// without the verdict above riding along.
+export function formatPosition(state) {
+  const lines = [];
+  lines.push('NEXT');
+  if (state.next === null) {
+    const openTasks = state.graph.total - state.graph.counts.complete;
+    lines.push(
+      openTasks === 0
+        ? '  (none — every task in the graph is complete)'
+        : '  (none ready — no task has all dependencies complete)',
+    );
+  } else {
+    const { task, intent } = state.next;
+    lines.push(`  ${task.id}   ${task.layer}   ${task.objective}`);
+    lines.push('');
+    lines.push('WHY');
+    lines.push(`  intent "${intent.id}" — ${intent.goal}`);
+    lines.push(`  outcome: ${intent.outcome}`);
+    lines.push('  no incomplete dependencies');
+    if (state.next.dependents.length > 0) {
+      lines.push(`  ${state.next.dependents.length} task(s) blocked downstream of it`);
+    }
+  }
+  return lines.join('\n');
+}
+
+// A block a fresh session can be started with: where the build is, what
+// is next, what is blocked. Every line is read from the graph, git
+// history, or the working tree — nothing here is advice or inference.
+export function formatHandoff(state) {
+  const { graph } = state;
+  const lines = [];
+  lines.push('HEDGEHOG HANDOFF');
+  lines.push('');
+  lines.push('BUILD');
+  lines.push(`  ${graph.counts.complete} of ${graph.total} task(s) complete`);
+  if (state.head) lines.push(`  HEAD  ${state.head}`);
+  lines.push('');
+  lines.push('BOUNDARY');
+  lines.push(
+    state.undecidable
+      ? '  undecidable'
+      : state.reached
+        ? '  reached'
+        : '  not reached',
+  );
+  for (const condition of state.conditions) {
+    lines.push(`  ${mark(condition)} ${condition.label} — ${condition.detail}`);
+  }
+  lines.push('');
+  lines.push(formatPosition(state));
+  if (state.next !== null) {
+    const scopeGlobs = JSON.parse(state.next.task.scope_globs);
+    lines.push('');
+    lines.push('ALLOWED SCOPE');
+    for (const glob of scopeGlobs) lines.push(`  ${glob}`);
+    lines.push('');
+    lines.push('VERIFICATION');
+    lines.push(`  ${state.next.task.verify_command}`);
+  }
+  lines.push('');
+  lines.push('IN FLIGHT');
+  if (graph.inFlight.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const task of graph.inFlight) {
+      lines.push(`  ${task.id}   ${task.layer}   ${task.status}   owner: ${task.lease_owner}`);
+    }
+  }
+  lines.push('');
+  lines.push('BLOCKED');
+  if (state.stalled.length === 0) {
+    lines.push('  (none)');
+  } else {
+    for (const task of state.stalled) {
+      lines.push(`  ${task.id}   ${task.layer}   ${task.blocked_reason}`);
+    }
+  }
+  if (state.next !== null && state.next.dependents.length > 0) {
+    lines.push('');
+    lines.push(`BLOCKED DOWNSTREAM OF ${state.next.task.id}`);
+    for (const dep of state.next.dependents) {
+      lines.push(`  ${dep.id}   ${dep.layer}`);
+    }
+  }
+  return lines.join('\n');
+}

--- a/src/hosts/claude/DISPATCH.md
+++ b/src/hosts/claude/DISPATCH.md
@@ -6,4 +6,6 @@ context with its own tool grant. The skills in `.claude/skills/` are
 available the same way; invoke one by name rather than reimplementing what
 it describes.
 
-Clear context with `/clear` at the unit boundaries described above.
+Clear context with `/clear` at the unit boundaries described above —
+`hedgehog boundary` tells you whether you're at one (exit 0), and
+`hedgehog boundary --handoff` is what the next session starts from.

--- a/src/hosts/cursor/DISPATCH.md
+++ b/src/hosts/cursor/DISPATCH.md
@@ -13,4 +13,6 @@ gates the commit either way.
 The skills in `.cursor/skills/` are procedures to follow — read the one
 whose situation applies rather than improvising the steps.
 
-Clear the conversation at the unit boundaries described above.
+Clear the conversation at the unit boundaries described above —
+`hedgehog boundary` tells you whether you're at one (exit 0), and
+`hedgehog boundary --handoff` is what the next session starts from.

--- a/src/hosts/gemini/DISPATCH.md
+++ b/src/hosts/gemini/DISPATCH.md
@@ -22,6 +22,8 @@ commit lands.
 The skills in `.gemini/skills/` are procedures to follow — read the one
 whose situation applies rather than improvising the steps.
 
-Clear the conversation at the unit boundaries described above.
+Clear the conversation at the unit boundaries described above —
+`hedgehog boundary` tells you whether you're at one (exit 0), and
+`hedgehog boundary --handoff` is what the next session starts from.
 
 @./AGENTS.md

--- a/src/skills/hedgehog-authored-loop/SKILL.md
+++ b/src/skills/hedgehog-authored-loop/SKILL.md
@@ -192,14 +192,22 @@ the ones that were designed.
 ## Stop Condition
 
 Same fresh-context handoff as `hedgehog-loop`'s Stop Condition (offer it
-once every task is `complete`, nothing is still in flight — check
-`hedgehog status`'s IN FLIGHT section or run `hedgehog quiesce` — and
+once every task is `complete`, `hedgehog boundary` exits 0, and
 scope isn't genuinely ambiguous; the permanent record is the committed
 intents, friction log, and `core.yaml`, not `.hedgehog/hedgehog.db`,
 which is gitignored and derived; a `tweaker` session in a *new* chat
 window handles adjustments, using the same paste-in prompt that skill's
 Stop Condition gives). On a module axis, "every task complete" means
 every intent through every layer, not the last layer completed once.
+
+Mid-build, the layer boundary this core clears context at is the same
+question: run `hedgehog boundary` before `/clear` rather than judging it.
+It exits 0 only when nothing is in flight, the working tree is clean, and
+the last closed task completed its intent — every layer of it, on a
+module axis — and names which of the three failed otherwise. `hedgehog
+quiesce` answers only the in-flight third, which is why it's the check
+the Correction Protocol above uses and not the one for clearing. The next
+session opens on `hedgehog boundary --handoff`.
 
 **New scope** — a new intent on the module axis, anything beyond
 adjusting what exists — goes to `planner`, which runs

--- a/src/skills/hedgehog-landing-loop/SKILL.md
+++ b/src/skills/hedgehog-landing-loop/SKILL.md
@@ -412,6 +412,15 @@ the friction log, and the git commit history itself, including every
 `.hedgehog/hedgehog.db` is gitignored: a derived index, rebuildable at
 any time via `hedgehog db rebuild`.
 
+Confirm it with `hedgehog boundary` before offering the handoff: it exits
+0 only when nothing is in flight, the working tree is clean, and the last
+closed task completed its intent, and names which of the three failed
+otherwise. `hedgehog quiesce` answers only the in-flight third — the
+right check while waiting out a correction, not the one for clearing
+context. The same command is what decides any mid-chain `/clear` too, and
+`hedgehog boundary --handoff` prints the block the next session opens
+with: where the build is, what's next and why, and what's blocked.
+
 Tell the user plainly that the build (including the polish pass) is
 complete, and that clearing context now costs nothing — the chain
 artifacts, the build graph, and the commit log hold everything a fresh

--- a/src/skills/hedgehog-loop/SKILL.md
+++ b/src/skills/hedgehog-loop/SKILL.md
@@ -329,12 +329,21 @@ and the commit history itself — not `.hedgehog/hedgehog.db`, which is
 gitignored and derived, rebuildable at any time via `hedgehog db
 rebuild`. That's what makes the next session cheap.
 
-Before offering that handoff, confirm nothing is still in flight — every
-task showing `complete` is not sufficient on its own, since a lease can
-be outstanding without a visible status change. Check `hedgehog
-status`'s IN FLIGHT section (or run `hedgehog quiesce`, which exits
-non-zero if anything is still claimed) and only declare the Stop
-Condition met once it's empty.
+Before offering that handoff, run `hedgehog boundary` and only declare
+the Stop Condition met once it exits 0. Every task showing `complete` is
+not sufficient on its own: a lease can be outstanding without a visible
+status change, and the working tree can still hold uncommitted work.
+`boundary` checks all three — nothing in flight, clean tree, last closed
+task completed its intent — and names which one failed when it exits
+non-zero. `hedgehog quiesce` covers only the first of the three; it is
+the right check mid-correction, not the right check for a handoff.
+
+The same command answers the mid-build question the project instructions
+file's **Managing context** section depends on: whether *this* moment,
+not just the end of the build, is one to clear the conversation at. Run
+it at any point you're considering `/clear`, and start the next session
+from `hedgehog boundary --handoff`, which prints where the build is,
+what's next and why, and what's blocked, straight from the graph.
 
 Name **both** ways forward, because which one applies depends on what the
 user wants next:

--- a/src/templates/CLAUDE.md
+++ b/src/templates/CLAUDE.md
@@ -96,8 +96,9 @@ consumes. Nothing checks a box — there is no checklist, only queryable
 state.
 
 **When the build is done:** once `hedgehog status` shows every task
-`complete` and nothing in flight (see `hedgehog quiesce` below), the
-build session is complete. The permanent record is the committed
+`complete` and `hedgehog boundary` exits 0 (see **Managing context**
+below — it checks nothing-in-flight, a clean tree, and a closed intent
+together), the build session is complete. The permanent record is the committed
 intents (`.hedgehog/intents/*.json`), the friction log
 (`.hedgehog/friction/*.md`), `core.yaml`, and the git commit history
 itself — not the database. `.hedgehog/hedgehog.db` is gitignored: a
@@ -151,15 +152,30 @@ context small:
 
 - **Clear context at natural boundaries** — a module's Phase A, a
   landing page section, whatever this core's own unit boundary is — once
-  that unit is done and committed. Clear the conversation and start
-  fresh, then run `hedgehog status`/`hedgehog claim` and continue. Nothing
-  is lost, because the build graph, commits, and code hold all the state.
-  Prefer this over letting one session accumulate the entire project.
-  Before clearing, run `hedgehog quiesce` and confirm it exits 0 —
-  nothing in flight — first. Clearing context while a lease is
-  outstanding orphans that lease until it expires.
+  that unit is done and committed. Ask `hedgehog boundary` rather than
+  judging it: it exits 0 only when all three of nothing-in-flight, a
+  clean working tree, and a last closed task that completed its intent
+  hold, and names which one failed otherwise. Clear the conversation and
+  start fresh, then run `hedgehog status`/`hedgehog claim` and continue.
+  Nothing is lost, because the build graph, commits, and code hold all
+  the state. Prefer this over letting one session accumulate the entire
+  project.
+- **`hedgehog quiesce` and `hedgehog boundary` answer different
+  questions.** `quiesce` reports whether anything is still in flight —
+  necessary before clearing (clearing while a lease is outstanding
+  orphans that lease until it expires), but not sufficient: a graph can
+  be perfectly settled halfway through an intent, with a dirty working
+  tree. `boundary` is the whole question — is this a moment to throw the
+  conversation away — and it includes the `quiesce` check as its first
+  condition. Use `quiesce` when you're waiting for dispatched work to
+  land (the Correction Protocol), `boundary` when you're deciding whether
+  to clear.
 - **A cleared or new session recovers by running `hedgehog status` and
   reading the commit log**, never by needing the prior conversation.
+  `hedgehog boundary --handoff` prints that recovery block directly —
+  where the build is, what's next and why, what's in flight, what's
+  blocked — derived from the graph, so no session hands a summary to the
+  next one.
 - **Delegate heavy work to agents.** Planning intake, scaffolding, and
   every build step each run in their own isolated context — so that work
   doesn't pile up in the main thread.


### PR DESCRIPTION
The discipline's central claim is that the conversation is disposable — clear context at a natural boundary and recover from the graph. The template says exactly that, and tells the operator to run `hedgehog quiesce` first. But `quiesce` answers only whether anything is in flight, which is a **necessary condition, not a sufficient one**, so nothing in the tool can actually answer the question the discipline asks.

## What was missing

A boundary needs three things the tool already knows separately:

1. nothing is in flight,
2. the working tree is clean,
3. the last closed task completed an intent.

`hedgehog verify` already prints `intent complete` when (3) happens — `completeIntentIfDone` in `verify.mjs` — and then discards it. Nothing stores or re-derives it. So the boundary decision lives in the operator's head, which is precisely the kind of state the discipline says it does not want anyone holding.

The second half is positioning: when a fresh session starts, nothing tells it where the build is. On the project where this surfaced, a hand-maintained handoff file was the only thing doing that job.

## Interface

```
hedgehog boundary [--quiet] [--handoff]
```

- **Exit 0** — boundary reached. **1** — not a boundary. **2** — unanswerable (no build graph, no git repo, or complete tasks exist but the last-closed one cannot be identified).
- **stdout** is the capturable payload: the `NEXT`/`WHY` block on success, or `--handoff`'s full block (BUILD + HEAD, boundary verdict, NEXT/WHY, ALLOWED SCOPE, VERIFICATION, IN FLIGHT, BLOCKED, BLOCKED DOWNSTREAM).
- **stderr** is the human verdict: all three conditions with ✓/✗/? and a detail line each.
- `--quiet` gives the exit code only, for a shell hook. `--handoff` prints its block regardless of verdict — a fresh session needs positioning either way — while keeping the exit code honest.

`ensureDb` gained a `log` sink so its rebuild notice goes to stderr for this one command; every other command is unchanged. `quiesce` is untouched.

At a genuine boundary:

```
stderr: Boundary reached.
          ✓ nothing in flight — no task building or verifying
          ✓ working tree clean — no uncommitted changes
          ✓ last closed task completed an intent — last closed task ALPHA-VIEW completed intent "alpha"
stdout: NEXT
          BETA-MODEL   model   model for beta
        WHY
          intent "beta" — beta goal ... 1 task(s) blocked downstream of it
```

Mid-intent, `quiesce` exits 0 while `boundary` exits 1 with:

```
✗ last closed task completed an intent — last closed task ALPHA-MODEL left intent "alpha" open — 1 task(s) remain: ALPHA-VIEW
```

That contrast is the whole point of the command.

## One correction to the premise

There is no `completed_at` column and no verify timestamp, so "the last closed task" is not directly stored. It is derived from the newest `passed` row in `verifications`, with a fallback that matches git commit subjects against `tasks.commit_message`.

The fallback is necessary because `hedgehog db rebuild` reconstructs `tasks.status` from commit subjects and writes **no** verification rows and **no** `intents.status`. For the same reason, intent closure is tested with `completeIntentIfDone`'s own predicate rather than by reading `intents.status`, which is simply wrong on a rebuilt graph. Both paths are covered.

## Evidence

`node repro/run-all.mjs` — four scripts, each building a real temp project (git repo, authored `core.yaml`, two intents, real claim/verify/commit cycles) and driving `bin/cli.mjs`.

- **Before** (`bin/cli.mjs` stashed to pristine master): all four fail — e.g. `expected to contain: "✗ last closed task completed an intent"` / `actual: "Unknown command: boundary"`.
- **After:** all four pass.

Worth noting how the reproductions are written: the exit-code assertions alone would pass *vacuously* against master, because an unknown command also exits 1. So each reproduction additionally asserts that the failing condition is **named**. A test that passes for the wrong reason is worse than no test.

`node scripts/check.mjs` passes. `src/db/verify.mjs`, `plan.mjs` and `next.mjs` are untouched — `boundary.mjs` imports `nextTask`/`stalledTasks`/`graphStatus` read-only.

## Documentation

`src/templates/CLAUDE.md`, `src/skills/hedgehog-loop/SKILL.md` and `hedgehog-authored-loop/SKILL.md` told the operator to use `quiesce` for this. They now point at `boundary` and explain the difference between "nothing in flight" and "this is a boundary".

## Honest caveats

- Condition 3 is fully reliable on a live graph. On a **rebuilt** graph it depends on commit subjects being unique per task — and a core whose `commit:` template omits `{module}` can make two complete tasks share a subject. In that case the command reports the ambiguity and exits 2 rather than guessing.
- A task whose verify touched no in-scope files makes no commit at all, so on a rebuilt graph it is invisible to the fallback. The fallback scans up to 200 subjects and says plainly when none match. (That underlying gap is the subject of a separate PR.)
- Working-tree cleanliness excludes the engine's own derived files (`.hedgehog/hedgehog.db*`, `commit.lock`, `graph-server.json`), mirroring `verify.mjs`'s `isEngineStatePath`.
- `README`/`ARCHITECTURE` were left alone — neither enumerates these graph commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
