### PR TITLE
feat(packet): carry the intent goal to every builder, restate it when the intent closes, and let tasks declare debt

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -821,6 +821,27 @@ async function verifyCommand(args) {
   if (result.intentComplete) {
     console.log(`  ${green('intent complete')}  ${dim('every task for this intent is done')}`);
   }
+
+  // The one comparison in the circuit. Each layer's verify_command runs
+  // the tests that layer itself wrote, so it measures internal
+  // consistency and never coverage of what was asked — a layer that
+  // builds half an intent and tests that half exhaustively is green.
+  // Closing the last layer is the moment the intent is claimed done, so
+  // that is where what was requested gets printed back to be read against
+  // what was built. It is not a machine-checkable gate; it cannot be. Its
+  // value is that the comparison happens at all, once.
+  if (result.completedIntent) {
+    const { id, goal, outcome } = result.completedIntent;
+    console.log('');
+    console.log(`${bold('INTENT CHECK')}  ${bold(id)}  ${dim('— this closed the last layer of this intent.')}`);
+    console.log(`  ${dim('GOAL')}     ${goal}`);
+    console.log(`  ${dim('OUTCOME')}  ${outcome}`);
+    console.log('');
+    console.log(dim('  Confirm the work built across this intent\'s layers covers the above.'));
+    console.log(dim('  Anything asked for and not built is a Correction Protocol case now,'));
+    console.log(dim('  not a later discovery. Nothing else in the build checks this.'));
+    console.log('');
+  }
 }
 
 // `hedgehog claim --owner <owner> [--count <n>]` — atomically claims up to

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -21,7 +21,7 @@ import { dbInit, DB_PATH, openDb } from '../src/db/init.mjs';
 import { loadCore } from '../src/db/core.mjs';
 import { planTasks } from '../src/db/plan.mjs';
 import { addIntent, INTENTS_DIR } from '../src/db/intent.mjs';
-import { nextTask, formatNext, stalledTasks } from '../src/db/next.mjs';
+import { nextTask, formatNext, stalledTasks, assemblePacket } from '../src/db/next.mjs';
 import { verifyTask } from '../src/db/verify.mjs';
 import { claimTasks, releaseTask, renewLease } from '../src/db/claim.mjs';
 import { readyTasks, formatReady } from '../src/db/ready.mjs';
@@ -825,8 +825,14 @@ async function verifyCommand(args) {
 
 // `hedgehog claim --owner <owner> [--count <n>]` — atomically claims up to
 // `count` mutually non-conflicting ready tasks (claimTasks's fan-out, item
-// 13) and prints each one's packet-level summary, plus which owner now
-// holds them.
+// 13) and prints each one's FULL packet, plus which owner now holds them.
+//
+// The full packet, not a summary: `claim` is the surface the loop skills
+// dispatch from ("returns up to N task packets ... each"), so an agent
+// handed only a task id and a lease expiry never sees the intent's goal,
+// its rules, its scope, or its verification — it sees a layer name and
+// builds whatever that name suggests. `hedgehog next` prints the same
+// thing for the read-only case; the two now agree.
 async function claimCommand(args) {
   await ensureDb();
 
@@ -848,8 +854,13 @@ async function claimCommand(args) {
 
   const db = openDb();
   let claimed;
+  let packets = [];
   try {
     claimed = claimTasks(db, { owner, count });
+    // Assembled on the same open handle, right after the claim: the
+    // packet is what the caller dispatches, so it has to come back from
+    // the same call that handed out the lease.
+    packets = claimed.map((task) => assemblePacket(db, task));
   } finally {
     db.close();
   }
@@ -867,6 +878,12 @@ async function claimCommand(args) {
   for (const task of claimed) {
     if (claimed.length > 1) console.log(`  ${bold(task.id)}`);
     console.log(`  ${dim('expires')}  ${task.lease_expires_at}`);
+  }
+
+  for (const packet of packets) {
+    console.log('');
+    console.log(dim('─'.repeat(60)));
+    console.log(formatNext(packet));
   }
 }
 

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -28,6 +28,7 @@ import { readyTasks, formatReady } from '../src/db/ready.mjs';
 import { graphStatus, formatStatus } from '../src/db/status.mjs';
 import { whyPath, formatWhy } from '../src/db/why.mjs';
 import { addFriction, listFriction } from '../src/db/friction.mjs';
+import { addDebt, listDebt } from '../src/db/debt.mjs';
 import { rebuildDb } from '../src/db/rebuild.mjs';
 import { HOSTS, HOST_FLAGS, DEFAULT_HOST, availableHosts } from '../src/hosts/index.mjs';
 import { recordHosts, installedHosts } from '../src/hosts/installed.mjs';
@@ -322,6 +323,8 @@ ${bold('Usage')}
   npx @skyf0xx/hedgehog why <path>                provenance chain for a file
   npx @skyf0xx/hedgehog friction add "<note>"     log a friction note [--task <task-id>]
   npx @skyf0xx/hedgehog friction list             list logged friction, oldest first
+  npx @skyf0xx/hedgehog debt add <task-id> "<note>"   declare debt that lands in dependent tasks' packets
+  npx @skyf0xx/hedgehog debt list [<task-id>]     list declared debt, oldest first
   npx @skyf0xx/hedgehog --help
 
 Available cores: ${cores.join(', ')}
@@ -1291,6 +1294,74 @@ async function frictionCommand(args) {
   process.exitCode = 1;
 }
 
+// `hedgehog debt add <task-id> "<note>"` / `hedgehog debt list [<task-id>]`
+// — declared debt between tasks. A note recorded against a task is
+// rendered into the INHERITED DEBT section of the packet of every task
+// that depends on it (see src/db/debt.mjs and src/db/next.mjs).
+async function debtCommand(args) {
+  await ensureDb();
+
+  const sub = args[0];
+
+  if (!(await exists(DB_PATH))) {
+    console.error(`${red('No build graph found.')} Run ${bold('hedgehog db init')} first.\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (sub === 'add') {
+    const taskId = args[1];
+    const note = args.slice(2).join(' ');
+    if (!taskId || !note) {
+      console.error(`${red('Usage:')} hedgehog debt add <task-id> "<note>"\n`);
+      process.exitCode = 1;
+      return;
+    }
+
+    const db = openDb();
+    let entry;
+    try {
+      entry = addDebt(db, { taskId, note });
+    } catch (err) {
+      console.error(`${red('Failed to declare debt:')} ${err.message}\n`);
+      process.exitCode = 1;
+      return;
+    } finally {
+      db.close();
+    }
+
+    console.log(`  ${green('declared')}  #${entry.id} ${bold(entry.taskId)}`);
+    console.log(`  ${dim('reaches the packet of every task depending on it')}`);
+    return;
+  }
+
+  if (sub === 'list') {
+    const taskId = args[1];
+    const db = openDb();
+    let entries;
+    try {
+      entries = listDebt(db, taskId);
+    } finally {
+      db.close();
+    }
+
+    if (entries.length === 0) {
+      console.log(`${dim('No debt declared.')}\n`);
+      return;
+    }
+    for (const entry of entries) {
+      console.log(`#${entry.id}  ${dim(entry.loggedAt)}  ${bold(entry.taskId)}`);
+      console.log(`  ${entry.note}\n`);
+    }
+    return;
+  }
+
+  console.error(
+    `${red('Unknown debt subcommand:')} ${sub ?? '(none)'}\n\nUsage: hedgehog debt add <task-id> "<note>"\n   or: hedgehog debt list [<task-id>]\n`,
+  );
+  process.exitCode = 1;
+}
+
 async function main() {
   const args = process.argv.slice(2);
   if (args.includes('--help') || args.includes('-h') || args.length === 0) {
@@ -1421,6 +1492,11 @@ async function main() {
 
   if (cmd === 'friction') {
     await frictionCommand(args.slice(1));
+    return;
+  }
+
+  if (cmd === 'debt') {
+    await debtCommand(args.slice(1));
     return;
   }
 

--- a/repro/debt-reaches-inheriting-packet.mjs
+++ b/repro/debt-reaches-inheriting-packet.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// Repro: a task must be able to leave declared debt for the tasks that
+// inherit from it, and that debt must land in the inheriting task's
+// packet.
+//
+// Before the fix there was no mechanism at all: a layer that discovered a
+// real limitation could only write a "KNOWN LIMITATION" comment into a
+// source file, and the task that inherited the problem was never told —
+// its packet said nothing.
+
+import { execFileSync } from 'node:child_process';
+import { makeFixture, writeInScope, assertIncludes, report } from './lib.mjs';
+
+const NOTE =
+  'Card.updatedAt is set by the caller, not the model — the service layer must stamp it';
+
+const fx = makeFixture();
+try {
+  // Build and close layer 1, declaring debt against it on the way out.
+  fx.run(['claim', '--owner', 'repro']);
+  writeInScope(fx.dir, 'src/card/model/card.js', 'export const Card = {};\n');
+
+  let added;
+  try {
+    added = fx.run(['debt', 'add', 'CARD-DOMAIN-MODEL', NOTE]);
+  } catch (err) {
+    console.error('  FAIL  `hedgehog debt add` is not a command');
+    console.error(`    expected: a command that records a note against a task`);
+    console.error(`    actual  : ${(err.stdout ?? '') + (err.stderr ?? '') || err.message}`);
+    process.exit(1);
+  }
+  console.log('--- hedgehog debt add ---');
+  console.log(added);
+
+  fx.run(['verify', 'CARD-DOMAIN-MODEL', '--owner', 'repro']);
+
+  // Layer 2 depends on layer 1 — its packet must carry layer 1's debt.
+  const next = fx.run(['next']);
+  console.log('--- hedgehog next (inheriting task) ---');
+  console.log(next);
+
+  assertIncludes(next, 'INHERITED DEBT', 'the inheriting packet has a debt section');
+  assertIncludes(next, NOTE, 'the inheriting packet carries the declared note');
+  assertIncludes(next, 'CARD-DOMAIN-MODEL', 'the debt names the task that declared it');
+
+  // The same debt must reach the packet `hedgehog claim` emits, since
+  // that is the surface the loop actually dispatches from.
+  const claimed = fx.run(['claim', '--owner', 'repro']);
+  console.log('--- hedgehog claim (inheriting task) ---');
+  console.log(claimed);
+  assertIncludes(claimed, NOTE, 'claim: the inheriting packet carries the declared note');
+} finally {
+  fx.cleanup();
+}
+
+report('debt-reaches-inheriting-packet');

--- a/repro/intent-close-restates-goal.mjs
+++ b/repro/intent-close-restates-goal.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// Repro: when `hedgehog verify` closes the LAST layer of an intent, it
+// must print the intent's goal and outcome back out, framed as a check —
+// the one point in the circuit where what was built can be compared
+// against what was asked for.
+//
+// Before the fix, closing the last layer printed only:
+//   intent complete   every task for this intent is done
+// — no restatement, so nothing anywhere compared the built work against
+// the intent.
+
+import { makeFixture, writeInScope, GOAL, OUTCOME, assertIncludes, report } from './lib.mjs';
+
+const fx = makeFixture();
+try {
+  // Layer 1 of 2 — closing it must NOT print the check.
+  fx.run(['claim', '--owner', 'repro']);
+  writeInScope(fx.dir, 'src/card/model/card.js', 'export const Card = {};\n');
+  const first = fx.run(['verify', 'CARD-DOMAIN-MODEL', '--owner', 'repro']);
+  console.log('--- verify (first layer, intent still open) ---');
+  console.log(first);
+  if (first.includes('INTENT CHECK')) {
+    console.error('  FAIL  the check printed while the intent was still open');
+    process.exit(1);
+  }
+  console.log('  ok    no intent check while the intent is still open');
+
+  // Layer 2 of 2 — closing it completes the intent.
+  fx.run(['claim', '--owner', 'repro']);
+  writeInScope(fx.dir, 'src/card/service/card-service.js', 'export const createCard = () => {};\n');
+  const last = fx.run(['verify', 'CARD-DOMAIN-SERVICE', '--owner', 'repro']);
+  console.log('--- verify (last layer, intent completes) ---');
+  console.log(last);
+
+  assertIncludes(last, 'INTENT CHECK', 'closing the last layer frames the restatement as a check');
+  assertIncludes(last, GOAL, 'closing the last layer restates the intent goal');
+  assertIncludes(last, OUTCOME, 'closing the last layer restates the intent outcome');
+} finally {
+  fx.cleanup();
+}
+
+report('intent-close-restates-goal');

--- a/repro/lib.mjs
+++ b/repro/lib.mjs
@@ -1,0 +1,126 @@
+// Shared fixture harness for the repro scripts in this directory.
+//
+// Each repro builds a throwaway git repo in a temp dir, gives it a
+// two-layer authored core, and drives the REAL CLI (bin/cli.mjs) against
+// it as a subprocess — no test framework, no `sqlite3` binary, nothing
+// mocked. Assertions are plain: on failure the script prints expected vs
+// actual and exits non-zero.
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = resolve(__dirname, '..');
+export const CLI = join(REPO_ROOT, 'bin/cli.mjs');
+
+// The fixture core: two layers in a chain, both with a verify command
+// that trivially passes, so the repro exercises the packet/verify
+// plumbing rather than a real toolchain.
+const CORE_YAML = `id: reprocore
+layers:
+  - id: domain-model
+    scope: ["src/{module}/model/**"]
+    verify: node --version
+    commit: "feat({module}): domain model"
+  - id: domain-service
+    depends_on: domain-model
+    scope: ["src/{module}/service/**"]
+    verify: node --version
+    commit: "feat({module}): domain service"
+`;
+
+// The goal/outcome under test — deliberately the shape from the report:
+// a goal naming three operations, of which a layer could build two.
+export const GOAL =
+  'allow creating, editing and moving Cards between Lists';
+export const OUTCOME =
+  'a Card can be created, its scalar fields updated, and moved between Lists';
+
+export function makeFixture({ goal = GOAL, outcome = OUTCOME } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'hedgehog-repro-'));
+  const run = (args, opts = {}) =>
+    execFileSync('node', [CLI, ...args], {
+      cwd: dir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, NODE_NO_WARNINGS: '1' },
+      ...opts,
+    });
+
+  mkdirSync(join(dir, '.hedgehog'), { recursive: true });
+  writeFileSync(join(dir, '.hedgehog/core.yaml'), CORE_YAML);
+  writeFileSync(join(dir, '.gitignore'), '.hedgehog/hedgehog.db*\n.hedgehog/commit.lock\n.hedgehog/graph-server.json\n');
+
+  const git = (cmd) => execFileSync('git', cmd, { cwd: dir, encoding: 'utf8', stdio: 'pipe' });
+  git(['init', '-q', '.']);
+  git(['config', 'user.email', 'repro@example.com']);
+  git(['config', 'user.name', 'repro']);
+  git(['add', '-A']);
+  git(['commit', '-qm', 'chore: fixture']);
+
+  run(['db', 'init']);
+  run([
+    'intent', 'add',
+    '--id', 'card',
+    '--goal', goal,
+    '--outcome', outcome,
+    '--rule', 'moving a Card between Lists restarts the time-in-list clock',
+  ]);
+  run(['plan']);
+
+  // `intent add` writes .hedgehog/intents/<id>.json into the working
+  // tree; left uncommitted it sits outside every task's scope and trips
+  // verify's scope gate before any of this repro's own assertions run.
+  git(['add', '-A']);
+  git(['commit', '-qm', 'chore: intents']);
+
+  const cleanup = () => {
+    // `hedgehog plan` detaches a graph server; kill it so the temp dir
+    // can go away and the repro process can exit.
+    try {
+      const { pid } = JSON.parse(readFileSync(join(dir, '.hedgehog/graph-server.json'), 'utf8'));
+      process.kill(pid);
+    } catch {
+      // No server running, or already gone.
+    }
+    rmSync(dir, { recursive: true, force: true });
+  };
+
+  return { dir, run, git, cleanup };
+}
+
+// Writes a file inside a task's allowed scope so `hedgehog verify` has
+// something in-scope to commit.
+export function writeInScope(dir, relPath, contents) {
+  const full = join(dir, relPath);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, contents);
+}
+
+const failures = [];
+
+export function assertIncludes(haystack, needle, what) {
+  if (haystack.includes(needle)) {
+    console.log(`  ok    ${what}`);
+    return;
+  }
+  failures.push({ what, expected: needle, actual: haystack });
+  console.log(`  FAIL  ${what}`);
+}
+
+export function report(title) {
+  if (failures.length === 0) {
+    console.log(`\n${title}: PASS\n`);
+    return;
+  }
+  console.error(`\n${title}: FAIL — ${failures.length} assertion(s)\n`);
+  for (const f of failures) {
+    console.error(`  ✗ ${f.what}`);
+    console.error(`    expected output to contain:\n      ${JSON.stringify(f.expected)}`);
+    console.error(`    actual output was:\n${f.actual.split('\n').map((l) => `      | ${l}`).join('\n')}\n`);
+  }
+  process.exit(1);
+}

--- a/repro/packet-carries-intent-goal.mjs
+++ b/repro/packet-carries-intent-goal.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// Repro: the task packet an agent actually receives must carry the
+// intent's GOAL and OUTCOME.
+//
+// Two surfaces emit a packet:
+//   * `hedgehog next` — prints the formatted packet.
+//   * `hedgehog claim` — the surface the loop skills and CLAUDE.md tell
+//     agents to use ("returns up to N task packets, STATUS/INTENT/
+//     RELEVANT RULES/WHY NOW/BLOCKED DOWNSTREAM/ALLOWED SCOPE/
+//     VERIFICATION each").
+//
+// Before the fix: `next` printed the goal and outcome as two unlabeled
+// lines under INTENT, and `claim` printed no packet at all — only the
+// task id and the lease expiry. An agent following the documented loop
+// therefore never saw what the intent asked for.
+
+import { makeFixture, GOAL, OUTCOME, assertIncludes, report } from './lib.mjs';
+
+const fx = makeFixture();
+try {
+  const next = fx.run(['next']);
+  console.log('--- hedgehog next ---');
+  console.log(next);
+
+  assertIncludes(next, GOAL, 'next: packet carries the intent goal');
+  assertIncludes(next, OUTCOME, 'next: packet carries the intent outcome');
+  assertIncludes(next, 'GOAL', 'next: the goal is labelled, not a bare line');
+  assertIncludes(next, 'OUTCOME', 'next: the outcome is labelled, not a bare line');
+
+  const claimed = fx.run(['claim', '--owner', 'repro']);
+  console.log('--- hedgehog claim ---');
+  console.log(claimed);
+
+  assertIncludes(claimed, GOAL, 'claim: packet carries the intent goal');
+  assertIncludes(claimed, OUTCOME, 'claim: packet carries the intent outcome');
+  assertIncludes(claimed, 'ALLOWED SCOPE', 'claim: emits the full packet, not just a lease line');
+  assertIncludes(claimed, 'VERIFICATION', 'claim: emits the packet VERIFICATION section');
+} finally {
+  fx.cleanup();
+}
+
+report('packet-carries-intent-goal');

--- a/repro/run-all.mjs
+++ b/repro/run-all.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// Runs every repro in this directory, serially, and exits non-zero if any
+// of them does.
+
+import { readdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scripts = readdirSync(here)
+  .filter((f) => f.endsWith('.mjs') && f !== 'lib.mjs' && f !== 'run-all.mjs')
+  .sort();
+
+let failed = 0;
+for (const script of scripts) {
+  const { status } = spawnSync('node', [join(here, script)], { stdio: 'inherit' });
+  if (status !== 0) failed++;
+}
+
+console.log(`\n${scripts.length - failed}/${scripts.length} repro(s) passed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/src/agents/backend-eng.md
+++ b/src/agents/backend-eng.md
@@ -63,7 +63,14 @@ needed.
 ## Workflow
 
 1. Read the claimed task packet: its ALLOWED SCOPE is what to
-   build, not a step name you infer independently. Its WHY NOW section
+   build, not a step name you infer independently. Its INTENT block is
+   the goal and outcome of the whole intent this layer belongs to — build
+   this layer's share of it, and report anything the goal asks for that
+   the packet's scope and rules don't account for; your own tests prove
+   internal consistency, never coverage of what was asked. INHERITED DEBT
+   is what the layers you depend on declared they left for you; declare
+   your own with `hedgehog debt add <task-id> "<note>"` rather than a
+   code comment nothing reads. Its WHY NOW section
    already confirms the module is in scope and every dependency is
    `complete` — no need to re-derive that by hand. Cross-module FK
    targets should already have their own schema landed (the packet's

--- a/src/agents/front-end-eng.md
+++ b/src/agents/front-end-eng.md
@@ -68,7 +68,14 @@ don't reach for a second one.
 
 ## Workflow
 
-1. Read the claimed task packet: its WHY NOW section already
+1. Read the claimed task packet: its INTENT block is the goal and outcome
+   of the whole intent this layer belongs to — build this layer's share
+   of it, and report anything the goal asks for that the packet's scope
+   and rules don't account for; your own tests prove internal
+   consistency, never coverage of what was asked. INHERITED DEBT is what
+   the layers you depend on declared they left for you; declare your own
+   with `hedgehog debt add <task-id> "<note>"` rather than a code comment
+   nothing reads. Its WHY NOW section already
    confirms Phase A is closed for this module (the `hook`/`screen`
    layer's dependencies wouldn't be `complete` otherwise) — no need to
    re-derive that by hand. If you're handed a step outside a packet with

--- a/src/agents/layer-eng.md
+++ b/src/agents/layer-eng.md
@@ -25,9 +25,12 @@ live in the project, not in this file:
   stack (language, package manager, frameworks, test runner), and a line
   per layer on what it owns and why it sits where it does. This is what
   tells you *what belongs in* the layer you're building.
-- **The task packet** — INTENT and RELEVANT RULES carry the domain
-  requirements mined from the PRD; ALLOWED SCOPE and VERIFICATION are the
-  gate you'll be checked against.
+- **The task packet** — INTENT carries the goal and outcome of the
+  *whole* intent this layer belongs to (not your layer's objective, which
+  only names what kind of thing to build); RELEVANT RULES carry the
+  domain requirements mined from the PRD; INHERITED DEBT carries what the
+  layers you depend on declared they left undone; ALLOWED SCOPE and
+  VERIFICATION are the gate you'll be checked against.
 
 Read all three before writing anything. `core-design.md`'s line for your
 layer is the closest thing to a spec you get — a layer described as
@@ -43,6 +46,20 @@ parsing and typing, and the layer after it consumes the result.
 - Write the tests the layer's `verify` command runs. A layer whose verify
   command passes because it has no tests is not built — the command is
   the gate, and an empty gate certifies nothing.
+- Build this layer's share of the packet's INTENT goal, not just
+  something plausible for the layer's name. Your `verify` command runs
+  the tests you wrote, so it proves internal consistency and nothing
+  about coverage: half the goal, exhaustively tested, is green. Report
+  anything the goal asks for that ALLOWED SCOPE and RELEVANT RULES don't
+  account for — silently building the part you can is the failure mode
+  this section exists for.
+- Read INHERITED DEBT before you start. A layer you depend on declared
+  those limitations knowing you'd inherit them.
+- Declare your own, with `hedgehog debt add <task-id> "<note>"`, whenever
+  you leave something the next layer has to compensate for. It lands in
+  the packet of every task that depends on yours. A "KNOWN LIMITATION"
+  comment in a source file reaches nobody — the next packet is assembled
+  from the build graph, not from your file's comments.
 - Match the conventions already in the workspace: the generated
   toolchain's idioms, the file naming already on disk, the import style
   the earlier layers established.

--- a/src/db/debt.mjs
+++ b/src/db/debt.mjs
@@ -1,0 +1,65 @@
+// `hedgehog debt add` / `hedgehog debt list` — declared debt between
+// tasks. See schema.mjs's `debt` table and next.mjs's INHERITED DEBT
+// packet section.
+//
+// A layer that discovers a real limitation while building — something the
+// next layer down the chain has to compensate for — has no way to tell
+// that layer. A "KNOWN LIMITATION" comment in a source file is not a
+// mechanism: the inheriting task's packet is assembled from the graph,
+// not from reading its dependencies' comments, so the note never
+// arrives. `debt add` records the note against the declaring task, and
+// next.mjs renders it into the packet of every task that depends on it.
+//
+// Unlike friction.mjs, nothing is written to a committed markdown log.
+// Debt is in-build traffic between two tasks, and a file under
+// `.hedgehog/` written mid-task sits outside every task's scope globs —
+// it would trip verify's scope gate on the very task that declared it.
+// The consequence is that debt does not survive `hedgehog db rebuild`
+// (which replays only `.hedgehog/intents/*.json`); by then the
+// inheriting task has usually already consumed it.
+
+import { applySchema } from './schema.mjs';
+
+const insertDebt = (db) =>
+  db.prepare(`
+    INSERT INTO debt (task_id, note)
+    VALUES (?, ?)
+  `);
+
+function taskExists(db, taskId) {
+  return db.prepare('SELECT 1 FROM tasks WHERE id = ?').get(taskId) !== undefined;
+}
+
+// Writes one debt row against `taskId`. The task must exist — debt
+// addressed to nobody reaches nobody, and the schema's foreign key would
+// reject it anyway, less legibly.
+export function addDebt(db, { taskId, note }) {
+  // Idempotent, and the migration path for a build graph created before
+  // the `debt` table existed: dbInit only applies the schema to a DB it
+  // just created, so an in-flight project's DB would otherwise have no
+  // table to insert into.
+  applySchema(db);
+
+  if (!taskId) throw new Error('debt requires a task id');
+  if (!note) throw new Error('debt requires a note');
+  if (!taskExists(db, taskId)) throw new Error(`no such task: ${taskId}`);
+
+  const result = insertDebt(db).run(taskId, note);
+  return { id: Number(result.lastInsertRowid), taskId, note };
+}
+
+// Every debt row, oldest first, optionally narrowed to one task.
+export function listDebt(db, taskId) {
+  const where = taskId ? 'WHERE task_id = ?' : '';
+  const params = taskId ? [taskId] : [];
+  try {
+    return db
+      .prepare(
+        `SELECT id, task_id AS taskId, note, logged_at AS loggedAt FROM debt ${where} ORDER BY id ASC`,
+      )
+      .all(...params);
+  } catch {
+    // No `debt` table yet (a build graph from before this table existed).
+    return [];
+  }
+}

--- a/src/db/init.mjs
+++ b/src/db/init.mjs
@@ -71,7 +71,13 @@ export async function dbInit(dbPath = DB_PATH) {
   const db = new DatabaseSync(dbPath);
   try {
     db.exec('PRAGMA foreign_keys = ON;');
-    if (!already) applySchema(db);
+    // Applied unconditionally, not only on creation: the schema is all
+    // `CREATE TABLE IF NOT EXISTS`, so re-running it against an existing
+    // graph is a no-op for tables that are already there and the
+    // migration path for ones added since that graph was created (the
+    // `debt` table, for instance). `created` still reports whether the
+    // file itself is new.
+    applySchema(db);
   } finally {
     db.close();
   }

--- a/src/db/next.mjs
+++ b/src/db/next.mjs
@@ -88,7 +88,7 @@ function loadBlockedDownstream(db, taskId) {
 // intent, requirements, and blocked downstream chain. Returns null fields
 // never — every field here is NOT NULL on tasks, or defaults to an empty
 // list.
-function assemblePacket(db, task) {
+export function assemblePacket(db, task) {
   const intent = loadIntent(db, task.intent_id);
   const requirements = loadTaskRequirements(db, task.id);
   const dependents = loadBlockedDownstream(db, task.id);
@@ -143,9 +143,15 @@ export function formatNext(packet) {
   lines.push('');
   lines.push('STATUS   READY');
   lines.push('');
+  // The intent's goal and outcome are what this task's layer is a part
+  // of — labelled rather than left as two bare lines, because the
+  // layer's own `objective` ("domain-service for card") says what to
+  // build a layer of, and only these say what the work is *for*. A layer
+  // can otherwise pass its own verify green while covering half of what
+  // the intent asked for.
   lines.push('INTENT');
-  lines.push(`  ${intent.goal}`);
-  lines.push(`  ${intent.outcome}`);
+  lines.push(`  GOAL     ${intent.goal}`);
+  lines.push(`  OUTCOME  ${intent.outcome}`);
   lines.push('');
   lines.push('RELEVANT RULES');
   if (requirements.length === 0) {

--- a/src/db/next.mjs
+++ b/src/db/next.mjs
@@ -47,6 +47,50 @@ function loadTaskRequirements(db, taskId) {
     .all(taskId);
 }
 
+// The full transitive closure of tasks this one depends on — its whole
+// upstream chain, not just its direct dependencies. Debt declared three
+// layers up doesn't stop applying one layer later, so the packet has to
+// see the same distance the dependency edge actually reaches.
+function loadUpstreamTaskIds(db, taskId) {
+  const directDeps = db.prepare(
+    'SELECT depends_on_task_id AS id FROM dependencies WHERE task_id = ?',
+  );
+  const seen = new Set([taskId]);
+  const upstream = [];
+  let frontier = [taskId];
+  while (frontier.length > 0) {
+    const next = [];
+    for (const id of frontier) {
+      for (const row of directDeps.all(id)) {
+        if (seen.has(row.id)) continue;
+        seen.add(row.id);
+        upstream.push(row.id);
+        next.push(row.id);
+      }
+    }
+    frontier = next;
+  }
+  return upstream;
+}
+
+// Debt declared by anything this task inherits from (see debt.mjs).
+// Tolerates a `debt` table that doesn't exist yet — a build graph created
+// before the table was added must still be able to emit a packet.
+function loadInheritedDebt(db, taskId) {
+  const upstream = loadUpstreamTaskIds(db, taskId);
+  if (upstream.length === 0) return [];
+  const placeholders = upstream.map(() => '?').join(',');
+  try {
+    return db
+      .prepare(
+        `SELECT task_id AS taskId, note FROM debt WHERE task_id IN (${placeholders}) ORDER BY id ASC`,
+      )
+      .all(...upstream);
+  } catch {
+    return [];
+  }
+}
+
 function loadDirectDependents(db, taskId) {
   return db
     .prepare(
@@ -92,12 +136,14 @@ export function assemblePacket(db, task) {
   const intent = loadIntent(db, task.intent_id);
   const requirements = loadTaskRequirements(db, task.id);
   const dependents = loadBlockedDownstream(db, task.id);
+  const inheritedDebt = loadInheritedDebt(db, task.id);
 
   return {
     task,
     intent,
     requirements,
     dependents,
+    inheritedDebt,
   };
 }
 
@@ -127,14 +173,15 @@ export function stalledTasks(db) {
     .all();
 }
 
-// Renders a packet into the STATUS / INTENT / RELEVANT RULES / WHY NOW /
-// BLOCKED DOWNSTREAM / ALLOWED SCOPE / VERIFICATION format. The spec
+// Renders a packet into the STATUS / INTENT / RELEVANT RULES /
+// INHERITED DEBT / WHY NOW / BLOCKED DOWNSTREAM / ALLOWED SCOPE /
+// VERIFICATION format. The spec
 // splits this across two examples — the `hedgehog next` display and "The
 // task packet" (which carries the intent and its rules) — but an agent
 // receives one thing, so the packet is one thing: everything the worker
 // needs to build the task without reading the plan.
 export function formatNext(packet) {
-  const { task, intent, requirements, dependents } = packet;
+  const { task, intent, requirements, dependents, inheritedDebt = [] } = packet;
   const scopeGlobs = JSON.parse(task.scope_globs);
 
   const lines = [];
@@ -159,6 +206,15 @@ export function formatNext(packet) {
   } else {
     for (const req of requirements) {
       lines.push(`  - ${req.statement}`);
+    }
+  }
+  lines.push('');
+  lines.push('INHERITED DEBT');
+  if (inheritedDebt.length === 0) {
+    lines.push('  (none declared)');
+  } else {
+    for (const entry of inheritedDebt) {
+      lines.push(`  ! ${entry.taskId}  ${entry.note}`);
     }
   }
   lines.push('');

--- a/src/db/schema.mjs
+++ b/src/db/schema.mjs
@@ -87,6 +87,20 @@ CREATE TABLE IF NOT EXISTS verifications (
   ran_at     TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- Declared debt: a note one task leaves for the tasks that inherit from
+-- it. A layer that discovers a real limitation has nowhere else to put
+-- it — a "KNOWN LIMITATION" comment in a source file is not a mechanism,
+-- because the task that inherits the problem never reads that file's
+-- comments before building. Rows here are rendered into the packet of
+-- every task that (transitively) depends on task_id, so the limitation
+-- travels down the chain the same way the dependency does.
+CREATE TABLE IF NOT EXISTS debt (
+  id        INTEGER PRIMARY KEY,
+  task_id   TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  note      TEXT NOT NULL,
+  logged_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 CREATE TABLE IF NOT EXISTS friction (
   id        INTEGER PRIMARY KEY,
   task_id   TEXT REFERENCES tasks(id) ON DELETE SET NULL,

--- a/src/db/verify.mjs
+++ b/src/db/verify.mjs
@@ -223,9 +223,14 @@ function completeIntentIfDone(db, intentId) {
       "SELECT 1 FROM tasks WHERE intent_id = ? AND status <> 'complete'",
     )
     .get(intentId);
-  if (openTask !== undefined) return false;
+  if (openTask !== undefined) return null;
   db.prepare("UPDATE intents SET status = 'complete' WHERE id = ?").run(intentId);
-  return true;
+  // Returns the intent row rather than a bare `true`: this is the one
+  // moment the engine can put what was asked for back in front of whoever
+  // is closing it, and the CLI prints goal/outcome here as an INTENT
+  // CHECK. Nothing else in the circuit compares built work to requested
+  // work.
+  return db.prepare('SELECT id, goal, outcome FROM intents WHERE id = ?').get(intentId);
 }
 
 // Runs `command` via the shell, capturing combined stdout+stderr and exit
@@ -314,7 +319,11 @@ function claimForVerify(db, taskId, owner) {
 // Returns a result object describing what happened:
 //   { outcome: 'scope_violation', offending: [...] }
 //   { outcome: 'failed', exitCode, output }
-//   { outcome: 'complete', exitCode, output, commitSha, unlocked: [...] }
+//   { outcome: 'complete', exitCode, output, commitSha, unlocked: [...],
+//     intentComplete, completedIntent }
+// `completedIntent` is the intent row (id/goal/outcome) when this task
+// was the last one of its intent, else null — the CLI prints it back as
+// an INTENT CHECK.
 export function verifyTask(db, taskId, owner) {
   const task = claimForVerify(db, taskId, owner);
 
@@ -390,7 +399,7 @@ export function verifyTask(db, taskId, owner) {
   });
 
   let unlocked;
-  let intentComplete;
+  let completedIntent;
   db.exec('BEGIN IMMEDIATE');
   try {
     insertVerification(db).run(task.id, task.verify_command, exitCode, output, 'passed');
@@ -402,7 +411,7 @@ export function verifyTask(db, taskId, owner) {
 
     setTaskStatus(db, task.id, 'complete');
     unlocked = unlockReadyDependents(db, task.id);
-    intentComplete = completeIntentIfDone(db, task.intent_id);
+    completedIntent = completeIntentIfDone(db, task.intent_id);
 
     db.exec('COMMIT');
   } catch (err) {
@@ -414,5 +423,13 @@ export function verifyTask(db, taskId, owner) {
     throw err;
   }
 
-  return { outcome: 'complete', exitCode, output, commitSha, unlocked, intentComplete };
+  return {
+    outcome: 'complete',
+    exitCode,
+    output,
+    commitSha,
+    unlocked,
+    intentComplete: completedIntent !== null,
+    completedIntent: completedIntent ?? null,
+  };
 }

--- a/src/hosts/routing.mjs
+++ b/src/hosts/routing.mjs
@@ -84,8 +84,11 @@ intake first.
 
 ## The loop
 
-1. \`hedgehog next\` emits one task packet — STATUS, WHY NOW, BLOCKED
-   DOWNSTREAM, ALLOWED SCOPE, VERIFICATION. Trust it: a task is never
+1. \`hedgehog next\` emits one task packet — STATUS, INTENT (the goal and
+   outcome of the whole intent, not just this layer), RELEVANT RULES,
+   INHERITED DEBT, WHY NOW, BLOCKED DOWNSTREAM, ALLOWED SCOPE,
+   VERIFICATION. \`hedgehog claim\` emits the same packet and reserves the
+   task with a lease. Trust it: a task is never
    emitted unless every dependency is \`complete\`.
 2. Delegate the **full packet** to the agent that owns that layer (see
    the table below). Don't summarize it, and don't pass just a step name.

--- a/src/skills/hedgehog-authored-loop/SKILL.md
+++ b/src/skills/hedgehog-authored-loop/SKILL.md
@@ -58,7 +58,7 @@ runtime detail.
 
 1. **Run `hedgehog claim --count N --owner <owner>`.** `<owner>` is this
    session. Claim is atomic and lease-based, and returns up to N task
-   packets (STATUS/INTENT/RELEVANT RULES/WHY NOW/BLOCKED
+   packets (STATUS/INTENT/RELEVANT RULES/INHERITED DEBT/WHY NOW/BLOCKED
    DOWNSTREAM/ALLOWED SCOPE/VERIFICATION each) that the scheduler has
    already verified are safe to run together — trust it: a packet is
    never handed out unless its dependencies are `complete` and it
@@ -94,6 +94,46 @@ runtime detail.
 Each `hedgehog verify` call commits exactly one layer, built right for
 what's known now; a wrong layer is fixed forward later via the Correction
 Protocol.
+
+## The packet's INTENT is the whole intent
+
+The packet's **INTENT** block carries the goal and outcome of the intent
+this layer belongs to — not a restatement of the layer's own objective
+("domain-service for card"), which says what kind of thing to build and
+nothing about what it's for. This matters because a layer's `verify`
+command runs the tests that layer itself wrote: it measures internal
+consistency, never coverage of what was asked. A layer that builds half
+the intent's goal and tests that half exhaustively is green.
+
+So: build the layer's share of the goal, and report anything the goal
+asks for that the packet's scope and rules don't account for — that's a
+`planner` or Correction Protocol call, not something to quietly drop.
+
+When `hedgehog verify` closes the **last** layer of an intent, it prints
+the goal and outcome back out as an **INTENT CHECK**. Read the work built
+across that intent's layers against it before moving on. It isn't a gate
+and can't be one — it's the only point in the circuit where what was
+built is compared to what was requested.
+
+## Declared debt between layers
+
+A layer that hits a real limitation the next layer has to compensate for
+declares it:
+
+```
+hedgehog debt add <task-id> "<note>"
+```
+
+The note lands in the **INHERITED DEBT** section of the packet of every
+task that depends on that one, so it reaches the layer that inherits the
+problem. A "KNOWN LIMITATION" comment in a source file is not a
+mechanism — the inheriting task's packet is assembled from the graph, and
+nothing reads that comment. `hedgehog debt list [<task-id>]` reads them
+back.
+
+Debt lives in the build graph only (not a committed log), so it does not
+survive `hedgehog db rebuild` — declare it while the chain is live, which
+is when it's needed.
 
 ## Intra-layer conventions
 

--- a/src/skills/hedgehog-landing-loop/SKILL.md
+++ b/src/skills/hedgehog-landing-loop/SKILL.md
@@ -139,8 +139,9 @@ paragraph algorithm, and their self-tests.
 
 1. **Run `hedgehog claim --owner <owner> --count <n>`.** `<owner>` is
    this session (a stable id — session id or equivalent). It emits the
-   task packet for one ready compiled layer (STATUS/WHY NOW/BLOCKED
-   DOWNSTREAM/ALLOWED SCOPE/VERIFICATION) — trust it: `hedgehog claim`
+   task packet for one ready compiled layer (STATUS/INTENT/RELEVANT
+   RULES/INHERITED DEBT/WHY NOW/BLOCKED DOWNSTREAM/ALLOWED
+   SCOPE/VERIFICATION) — trust it: `hedgehog claim`
    never hands out a layer whose dependency isn't `complete`, so there's
    no separate gate check to run by hand. This core's chain is linear, so
    `--count N` always returns 1 task, never more — see Rules below.

--- a/src/skills/hedgehog-loop/SKILL.md
+++ b/src/skills/hedgehog-loop/SKILL.md
@@ -166,6 +166,22 @@ writes `docs/design/<module>.md`, not its own compiled layer — the
 5. **Repeat** — `hedgehog claim --count N --owner <owner>` again for the
    next batch.
 
+Each claimed packet is the full packet — STATUS/INTENT/RELEVANT
+RULES/INHERITED DEBT/WHY NOW/BLOCKED DOWNSTREAM/ALLOWED
+SCOPE/VERIFICATION — and its **INTENT** block carries the goal and
+outcome of the whole intent, not just this layer's objective. A layer's
+verify command runs the tests that layer wrote, so it measures internal
+consistency, never coverage of what was asked; build the layer's share of
+the goal and say so when the packet doesn't account for something the
+goal asks for. When `hedgehog verify` closes the **last** layer of an
+intent it prints the goal and outcome back as an **INTENT CHECK** — read
+the built work against it there, because nothing else in the build does.
+
+A layer that hits a limitation the next layer must compensate for
+declares it with `hedgehog debt add <task-id> "<note>"`; the note lands
+in the **INHERITED DEBT** section of every packet that depends on that
+task. A comment in a source file is not a mechanism — nothing reads it.
+
 Each `hedgehog verify` call commits exactly one layer, built right for
 what's known now; a wrong layer is fixed forward later via the
 Correction Protocol. Valid task statuses are `planned`, `ready`,

--- a/src/templates/CLAUDE.md
+++ b/src/templates/CLAUDE.md
@@ -68,8 +68,9 @@ context** below).
 re-derive build state from prose. To work from it:
 
 1. Run `hedgehog claim --count N --owner <owner>`. It's atomic and
-   lease-based, and returns up to N tasks (each with its own STATUS/WHY
-   NOW/BLOCKED DOWNSTREAM/ALLOWED SCOPE/VERIFICATION packet) that the
+   lease-based, and returns up to N tasks (each with its own full
+   STATUS/INTENT/RELEVANT RULES/INHERITED DEBT/WHY NOW/BLOCKED
+   DOWNSTREAM/ALLOWED SCOPE/VERIFICATION packet) that the
    scheduler has already verified are safe to run together right now —
    scope and verify-radius disjoint. `--count` is a maximum, not a
    promise: a call may return fewer than N, or zero. `hedgehog ready` is
@@ -89,6 +90,21 @@ re-derive build state from prose. To work from it:
 
 `hedgehog claim` hands out only tasks safe to run together. Never run
 two tasks it didn't hand you together.
+
+The packet's **INTENT** block names the goal and outcome of the *whole*
+intent, not just this layer. A layer's own verify command runs the tests
+that layer wrote, so it measures internal consistency and never coverage
+of what was asked — a layer that builds half the intent and tests that
+half exhaustively is green. Build the layer's share of the goal, and say
+so when the packet doesn't account for something the goal asks for.
+When `hedgehog verify` closes the **last** layer of an intent it prints
+that goal and outcome back as an **INTENT CHECK**: read the built work
+against it there, because nothing else in the build does.
+
+A layer that discovers a limitation the next layer has to compensate for
+records it with `hedgehog debt add <task-id> "<note>"` — it lands in the
+**INHERITED DEBT** section of every packet that depends on that task. A
+comment in a source file is not a mechanism; nothing reads it.
 
 `planner` owns writing intents (`hedgehog intent add`) at planning
 intake; `hedgehog plan` compiles them into the task graph the loop


### PR DESCRIPTION
A layer can pass its own verify without building what the intent asked for. On the build where this surfaced, an intent whose `goal` began *"allow creating, editing and moving Cards between Lists"* compiled into a `domain-service` task. The agent built `create`, `moveToList` and `reorderWithinList` — and no `update` of the Card's scalar fields. It passed with **117 green tests** and was committed. The gap was caught two layers later, by a human, not by any gate.

## ⚠️ Overlap with #12 — please read first

One commit here (`feat(packet)`) makes `hedgehog claim` emit the full packet. **#12 does the same thing**, as part of its recovery-commands work. The two were written independently and will conflict textually.

If #12 lands first, `feat(packet)`'s claim change becomes redundant and I will rebase this branch to drop it — the rest of this PR (the `GOAL`/`OUTCOME` labels, the intent check, the debt table) is independent and still applies. Happy to do that pre-emptively if you would rather review them in a fixed order.

## A correction to my own diagnosis

I opened this expecting the packet not to carry the intent's goal. **That was wrong**, and the reproduction says so explicitly: `formatNext` in `src/db/next.mjs` already printed it —

```js
lines.push('INTENT');
lines.push(`  ${intent.goal}`);
lines.push(`  ${intent.outcome}`);
```

The real hole is one surface over. `hedgehog claim` — which `templates/CLAUDE.md` and every loop skill tell agents to dispatch from — printed **no packet at all**. Against unmodified master, the entire output is:

```
Claimed. Task CARD-DOMAIN-MODEL leased to sess1.
  expires 2026-08-08 21:38:07
```

No goal, no rules, no scope, no verification. Meanwhile `src/skills/hedgehog-authored-loop/SKILL.md:61` and `src/templates/CLAUDE.md:72` both assert that claim "returns up to N task packets (STATUS/INTENT/RELEVANT RULES/WHY NOW/… each)". **The documentation described a packet the CLI never emitted**, and that is the whole explanation for the observed bug: the agent building that layer genuinely never saw the goal, because the command it was dispatched from never printed one.

## What this adds

- **`feat(packet)`** — labels the two INTENT lines `GOAL`/`OUTCOME`, and makes `claim` emit the full packet per claimed task (via an exported `assemblePacket`). *(This is the commit that overlaps #12.)*
- **`feat(verify)`** — `completeIntentIfDone` now returns the intent row rather than a bare boolean, and when the **last** layer of an intent closes, the CLI prints an `INTENT CHECK` block restating the goal and outcome. The point is not automation — it cannot be automated — but that the comparison between *what was asked* and *what was built* exists **at least once**, at the moment the intent is claimed to be done. The change to `verify.mjs` is 23 added / 6 removed, confined to that one function and the return object.
- **`feat(debt)`** — a `debt` table, `hedgehog debt add <task-id> "<note>"` / `debt list [<task-id>]`, and an `INHERITED DEBT` packet section fed by the declaring task's **transitive** downstream. This addresses the related failure where a layer discovered a real limitation, wrote it into a code comment under a "KNOWN LIMITATION" heading, and the task that inherited the problem was never told. A comment in a file is not a mechanism.

Two deliberate choices in the debt work:

- **No committed markdown log**, unlike `friction`. A file written under `.hedgehog/` mid-task is outside every task's scope globs and would trip verify's scope gate on the very task declaring the debt. The cost is that debt does not survive `hedgehog db rebuild`.
- `dbInit` now applies the schema unconditionally (everything is `IF NOT EXISTS`) so pre-existing graphs pick up the table, and the packet's debt read tolerates the table being absent — verified by dropping it and running `next`.

## Evidence

Repros under `repro/` — a `lib.mjs` harness plus 3 scripts, driving the real CLI against a throwaway git repo in a temp dir.

- **Against exported master:** all 3 exit 1 — `FAIL claim: emits the full packet, not just a lease line`; `FAIL closing the last layer frames the restatement as a check`; `FAIL hedgehog debt add is not a command`. The harness *also* confirms the two `next: packet carries the intent goal/outcome` assertions already passed on master — the correction above, made visible in the reproduction's own output rather than only claimed in prose.
- **Against this branch:** 3/3 pass. `node scripts/check.mjs` passes.

`hedgehog next` output diff on an unchanged fixture — this is the complete change:

```diff
 INTENT
-  allow creating, editing and moving Cards between Lists
-  a Card can be created, its scalar fields updated, and moved between Lists
+  GOAL     allow creating, editing and moving Cards between Lists
+  OUTCOME  a Card can be created, its scalar fields updated, and moved between Lists
 
 RELEVANT RULES
   - moving a Card between Lists restarts the time-in-list clock
 
+INHERITED DEBT
+  (none declared)
+
 WHY NOW
```

One section added; two existing lines gained labels with their text byte-identical. Nothing removed, renamed, reordered or reworded.

Payload docs updated to match: `templates/CLAUDE.md`, `hosts/routing.mjs`, `hedgehog-loop`, `hedgehog-authored-loop`, `hedgehog-landing-loop`, `layer-eng`, `backend-eng`, `front-end-eng`.

## Honest caveats

- The `INTENT CHECK` is text a human has to read. If nobody reads verify's stdout it changes nothing — it is not, and cannot be, a gate.
- Debt is graph-only and lost on `hedgehog db rebuild`. A durable version needs a structured committed file plus a replay path in `rebuild.mjs`, and would need `isEngineStatePath` widened so writing it mid-task does not trip the scope gate. That is more than "a new table plus packet rendering", so I stopped short.
- `formatNext` still hardcodes `STATUS   READY` even when emitted from `claim`, where the task is `building`. Deriving it from `task.status` would change existing `next` output, since `plan.mjs` inserts tasks as `planned`. Left alone deliberately.
- **Incidental finding, not fixed:** `.hedgehog/intents/*.json` (written by `intent add`) and `.hedgehog/friction/log.md` (written by `friction add`) are outside every task's scope globs, so leaving either uncommitted trips verify's scope gate on an unrelated task. Hit while building the repro harness; pre-existing and outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
