### PR TITLE
fix(core): fail the commit gate closed, and make the first commit of a fresh install possible

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -423,8 +423,17 @@ async function init({ force, core, explicitCore, host = DEFAULT_HOST, hostOnly =
   );
   console.log('Next steps:');
   if (explicitCore) {
-    console.log(`  1. ${bold('git add -A && git commit -m "chore: install Hedgehog"')}`);
-    console.log(`  2. ${bold('pnpm install')}`);
+    // `pnpm install` before the first commit, not after it. The core's
+    // commit gate is lefthook, and lefthook's hooks are written by its
+    // own postinstall — so a commit made before the install is a commit
+    // made with no gate at all, and the instruction that put it first
+    // was quietly teaching the project to skip its own discipline on
+    // the one commit that lands the entire workspace. Installing first
+    // means commit #1 is already gated; with no HEAD to diff against it
+    // runs the whole workspace (see lefthook.yml), so expect it to take
+    // as long as a full typecheck/lint/test — that is the gate working.
+    console.log(`  1. ${bold('pnpm install')}`);
+    console.log(`  2. ${bold('git add -A && git commit -m "chore: install Hedgehog"')}`);
     console.log(`  3. Open ${HOSTS[host].label} and describe what you want to build.`);
   } else {
     console.log(`  1. ${bold('git add -A && git commit -m "chore: install Hedgehog"')}`);

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -26,6 +26,7 @@ import { verifyTask } from '../src/db/verify.mjs';
 import { claimTasks, releaseTask, renewLease } from '../src/db/claim.mjs';
 import { readyTasks, formatReady } from '../src/db/ready.mjs';
 import { graphStatus, formatStatus } from '../src/db/status.mjs';
+import { commitGateStatus, formatCommitGate } from '../src/db/gate.mjs';
 import { whyPath, formatWhy } from '../src/db/why.mjs';
 import { addFriction, listFriction } from '../src/db/friction.mjs';
 import { rebuildDb } from '../src/db/rebuild.mjs';
@@ -974,6 +975,18 @@ async function statusCommand() {
   }
 
   console.log(formatStatus(result));
+
+  // Whether the commit gate is actually enforcing. This is reported at
+  // the start of every session because a gate that isn't running looks
+  // exactly like one that is — `.git/hooks` exists, `lefthook.yml` is
+  // committed, and a passing commit prints nothing to tell the two
+  // apart. Nothing else in the discipline would notice.
+  const gate = await commitGateStatus(DEST_ROOT);
+  const gateText = formatCommitGate(gate);
+  if (gateText) {
+    console.log('');
+    console.log(gate.state === 'active' ? dim(gateText) : yellow(gateText));
+  }
 }
 
 // `hedgehog ready` — read-only preview of what a `hedgehog claim` call

--- a/repro/commit-gate-fails-open.mjs
+++ b/repro/commit-gate-fails-open.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// Reproduction: the commit gate must fail CLOSED when the lefthook
+// binary is unavailable.
+//
+// The hooks lefthook writes into .git/hooks call the `lefthook` binary.
+// If node_modules is cleared — a workspace clean, a fresh clone before
+// install, a core switch — the generated hook's lookup chain falls
+// through to `echo "Can't find lefthook in PATH"` and the function
+// returns 0. The hook exits 0 and the commit lands with no typecheck,
+// no lint and no test. Nothing in the output distinguishes that from a
+// commit that passed the gate.
+//
+// This drives the real thing: the real src/golden-cores/full-stack-app/
+// lefthook.yml, the real lefthook release pinned by the core's own
+// package.json, and a real `git commit`. Nothing is stubbed; the commit
+// runs with a PATH cut down to the binaries the generated hook
+// legitimately needs (see minimalBin), which is what makes "lefthook is
+// unavailable" actually true rather than merely hoped for.
+//
+// Requires network on first run (it installs lefthook from the
+// registry). Everything happens inside its own mkdtemp directory, with
+// the git repository one level below it so the harness's own scratch
+// files can never be staged; the surrounding repository is never
+// touched, and every git invocation is pinned with an explicit cwd and
+// an isolated git config.
+//
+// Exits 0 when the gate refuses the commit, non-zero otherwise.
+
+import { mkdtemp, rm, writeFile, mkdir, readFile, symlink, cp } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const CORE = join(ROOT, 'src/golden-cores/full-stack-app');
+
+const failures = [];
+function check(label, expected, actual) {
+  const ok = expected === actual;
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${label}`);
+  if (!ok) {
+    console.log(`          expected: ${JSON.stringify(expected)}`);
+    console.log(`          actual:   ${JSON.stringify(actual)}`);
+    failures.push(label);
+  }
+}
+
+const run = (cmd, args, opts) => spawnSync(cmd, args, { encoding: 'utf8', ...opts });
+
+// A PATH holding only what the generated hook legitimately needs.
+//
+// Without this the reproduction is not hermetic, and the way it leaks is
+// worth knowing: lefthook's generated hook tries `pnpm lefthook -h` as
+// one of its fallbacks, and pnpm v11 installs the missing dependency to
+// satisfy the exec — so on a developer machine with pnpm and a network,
+// a gate with no lefthook can quietly reinstall it mid-commit. That is
+// not the behaviour under test, and it is not something to rely on.
+async function minimalBin(dir) {
+  await mkdir(dir, { recursive: true });
+  for (const tool of ['sh', 'git', 'uname', 'sed', 'tr', 'node']) {
+    const found = spawnSync('sh', ['-c', `command -v ${tool}`], { encoding: 'utf8' }).stdout.trim();
+    if (found) await symlink(found, join(dir, tool)).catch(() => {});
+  }
+  return dir;
+}
+
+const work = await mkdtemp(join(tmpdir(), 'hedgehog-repro-failsopen-'));
+const repo = join(work, 'repo');
+
+// Isolated git: no user hooks, no global core.hooksPath, no signing
+// config leaking in from whoever is running this.
+const gitEnv = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: '/dev/null',
+  GIT_CONFIG_SYSTEM: '/dev/null',
+};
+
+try {
+  console.log('repro: commit gate must fail closed when lefthook is missing');
+  console.log(`  workspace: ${work}\n`);
+
+  await mkdir(repo, { recursive: true });
+  run('git', ['init', '-q', '-b', 'main', '.'], { cwd: repo, env: gitEnv });
+  run('git', ['config', 'user.email', 'repro@example.invalid'], { cwd: repo, env: gitEnv });
+  run('git', ['config', 'user.name', 'repro'], { cwd: repo, env: gitEnv });
+
+  // The payload file under test, verbatim.
+  await cp(join(CORE, 'lefthook.yml'), join(repo, 'lefthook.yml'));
+  // The core's real ignore rules, so what gets staged matches a real project.
+  await cp(join(CORE, 'gitignore.template'), join(repo, '.gitignore'));
+
+  // The lefthook version this core actually pins.
+  const corePkg = JSON.parse(await readFile(join(CORE, 'package.json'), 'utf8'));
+  const lefthookSpec = corePkg.devDependencies?.lefthook;
+  if (!lefthookSpec) {
+    console.error('  ERROR: full-stack-app package.json no longer pins lefthook.');
+    process.exit(1);
+  }
+  await writeFile(
+    join(repo, 'package.json'),
+    JSON.stringify(
+      { name: 'repro', private: true, devDependencies: { lefthook: lefthookSpec } },
+      null,
+      2,
+    ),
+  );
+
+  // LEFTHOOK=1 because lefthook's postinstall skips installing hooks
+  // when CI is set — without it this would "pass" on CI by never
+  // installing a gate in the first place.
+  const install = run('npm', ['install', '--no-audit', '--no-fund', '--prefer-offline'], {
+    cwd: repo,
+    env: { ...gitEnv, LEFTHOOK: '1' },
+  });
+  if (install.status !== 0) {
+    console.error(
+      `  ERROR: could not install lefthook${lefthookSpec} — this reproduction needs the registry.`,
+    );
+    console.error(install.stderr?.slice(-800) ?? '');
+    process.exit(1);
+  }
+  if (!existsSync(join(repo, '.git/hooks/pre-commit'))) {
+    console.error('  ERROR: lefthook did not install a pre-commit hook; nothing to test.');
+    process.exit(1);
+  }
+
+  // The failure this is about: the tooling is gone, the hooks are not.
+  await rm(join(repo, 'node_modules'), { recursive: true, force: true });
+
+  const bin = await minimalBin(join(work, 'bin'));
+
+  await writeFile(join(repo, 'a.ts'), 'export const a: number = 1;\n');
+  run('git', ['add', '-A'], { cwd: repo, env: gitEnv });
+
+  const commit = run('git', ['commit', '-m', 'chore: ungated commit'], {
+    cwd: repo,
+    env: { ...gitEnv, PATH: bin },
+  });
+  const output = `${commit.stdout ?? ''}${commit.stderr ?? ''}`;
+
+  const log = run('git', ['log', '--oneline'], { cwd: repo, env: gitEnv });
+  const commitCount = log.status === 0 ? log.stdout.trim().split('\n').filter(Boolean).length : 0;
+
+  console.log('  --- hook output ---');
+  for (const line of output.trim().split('\n')) console.log(`  | ${line}`);
+  console.log('  -------------------\n');
+
+  check('git commit is refused (non-zero exit)', true, commit.status !== 0);
+  check('no commit was created', 0, commitCount);
+  check('the refusal names the --no-verify escape hatch', true, /--no-verify/.test(output));
+
+  if (failures.length) {
+    console.log(
+      `\nFAILED (${failures.length}): the commit gate fails OPEN — a commit landed with no typecheck, no lint and no test.`,
+    );
+    process.exit(1);
+  }
+  console.log('\nOK: the commit gate failed closed.');
+} finally {
+  if (!process.env.KEEP_REPRO) await rm(work, { recursive: true, force: true });
+}

--- a/repro/first-commit-rejected.mjs
+++ b/repro/first-commit-rejected.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// Reproduction: the first commit of a fresh install must succeed
+// through the documented path.
+//
+// `hedgehog init --ts-full-stack-app` prints `git add -A && git commit`
+// as a next step, but the pre-commit hook ran `npx nx affected -t
+// typecheck --base=HEAD`, and in a repository with no commits `HEAD`
+// does not resolve. Every command died with `fatal: ambiguous argument
+// 'HEAD': unknown revision`, the commit was rejected, and `git commit
+// --no-verify` was the only way through — teaching the project to skip
+// its own gate on the one commit that lands the entire codebase.
+//
+// This drives the real thing: the real src/golden-cores/full-stack-app/
+// lefthook.yml, the real pinned lefthook, and a real `git commit` into
+// a repository with no history.
+//
+// `npx` is stubbed, because standing up Nx 23 and the whole workspace
+// to exercise a base-ref bug is not viable here. The stub models
+// exactly one behaviour of the real thing and no more: nx resolves
+// `--base` against git, so the stub rejects a base ref git cannot
+// resolve, using git's own message. That is the mechanism under test,
+// and it was checked against real lefthook — the unfixed lefthook.yml
+// produces the identical `fatal: ambiguous argument 'HEAD'` failure.
+//
+// The stub also records every invocation, so this asserts the gate
+// actually RAN rather than merely that the commit was allowed through:
+// a "fix" that skipped the checks on the first commit would fail here.
+//
+// Requires network on first run (it installs lefthook from the
+// registry). Everything happens inside its own mkdtemp directory, with
+// the git repository one level below it so the harness's own scratch
+// files can never be staged; the surrounding repository is never
+// touched.
+//
+// Exits 0 when the first commit succeeds with the gate running.
+
+import { mkdtemp, rm, writeFile, mkdir, readFile, chmod, symlink, cp } from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const CORE = join(ROOT, 'src/golden-cores/full-stack-app');
+
+const failures = [];
+function check(label, expected, actual) {
+  const ok = expected === actual;
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${label}`);
+  if (!ok) {
+    console.log(`          expected: ${JSON.stringify(expected)}`);
+    console.log(`          actual:   ${JSON.stringify(actual)}`);
+    failures.push(label);
+  }
+}
+
+const run = (cmd, args, opts) => spawnSync(cmd, args, { encoding: 'utf8', ...opts });
+
+// A PATH holding only what the generated hook legitimately needs, plus
+// the stub npx written below. Keeping the real npm/pnpm/npx off it is
+// what stops the hook reaching the registry mid-commit and makes the
+// run deterministic — lefthook itself still resolves, via the absolute
+// node_modules path it baked into the hook at install time.
+async function minimalBin(dir) {
+  await mkdir(dir, { recursive: true });
+  for (const tool of ['sh', 'git', 'uname', 'sed', 'tr', 'node']) {
+    const found = spawnSync('sh', ['-c', `command -v ${tool}`], { encoding: 'utf8' }).stdout.trim();
+    if (found) await symlink(found, join(dir, tool)).catch(() => {});
+  }
+  return dir;
+}
+
+const work = await mkdtemp(join(tmpdir(), 'hedgehog-repro-firstcommit-'));
+const repo = join(work, 'repo');
+
+const gitEnv = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: '/dev/null',
+  GIT_CONFIG_SYSTEM: '/dev/null',
+};
+
+try {
+  console.log('repro: the first commit of a fresh install must pass the gate');
+  console.log(`  workspace: ${work}\n`);
+
+  await mkdir(repo, { recursive: true });
+  run('git', ['init', '-q', '-b', 'main', '.'], { cwd: repo, env: gitEnv });
+  run('git', ['config', 'user.email', 'repro@example.invalid'], { cwd: repo, env: gitEnv });
+  run('git', ['config', 'user.name', 'repro'], { cwd: repo, env: gitEnv });
+
+  await cp(join(CORE, 'lefthook.yml'), join(repo, 'lefthook.yml'));
+  // The core's real ignore rules, so what gets staged matches a real project.
+  await cp(join(CORE, 'gitignore.template'), join(repo, '.gitignore'));
+
+  const corePkg = JSON.parse(await readFile(join(CORE, 'package.json'), 'utf8'));
+  const lefthookSpec = corePkg.devDependencies?.lefthook;
+  if (!lefthookSpec) {
+    console.error('  ERROR: full-stack-app package.json no longer pins lefthook.');
+    process.exit(1);
+  }
+  await writeFile(
+    join(repo, 'package.json'),
+    JSON.stringify(
+      { name: 'repro', private: true, devDependencies: { lefthook: lefthookSpec } },
+      null,
+      2,
+    ),
+  );
+
+  const install = run('npm', ['install', '--no-audit', '--no-fund', '--prefer-offline'], {
+    cwd: repo,
+    env: { ...gitEnv, LEFTHOOK: '1' },
+  });
+  if (install.status !== 0) {
+    console.error(
+      `  ERROR: could not install lefthook${lefthookSpec} — this reproduction needs the registry.`,
+    );
+    console.error(install.stderr?.slice(-800) ?? '');
+    process.exit(1);
+  }
+  if (!existsSync(join(repo, '.git/hooks/pre-commit'))) {
+    console.error('  ERROR: lefthook did not install a pre-commit hook; nothing to test.');
+    process.exit(1);
+  }
+
+  // Stub `npx`: records the call, then mimics the one behaviour of nx
+  // this bug is about — resolving `--base` against git. The log lives
+  // outside the repo so it is never staged by `git add -A`.
+  const bin = await minimalBin(join(work, 'bin'));
+  const calls = join(work, 'nx-calls.log');
+  await writeFile(
+    join(bin, 'npx'),
+    [
+      '#!/bin/sh',
+      `echo "$*" >> ${JSON.stringify(calls)}`,
+      'for a in "$@"; do',
+      '  case "$a" in',
+      '    --base=*)',
+      '      b=${a#--base=}',
+      '      if ! git rev-parse --verify --quiet "$b^{commit}" >/dev/null 2>&1; then',
+      `        echo "fatal: ambiguous argument '$b': unknown revision" >&2`,
+      '        exit 128',
+      '      fi;;',
+      '  esac',
+      'done',
+      'exit 0',
+      '',
+    ].join('\n'),
+  );
+  await chmod(join(bin, 'npx'), 0o755);
+
+  await writeFile(join(repo, 'a.ts'), 'export const a: number = 1;\n');
+  run('git', ['add', '-A'], { cwd: repo, env: gitEnv });
+
+  // The documented path, verbatim.
+  const commit = run('git', ['commit', '-m', 'chore: install Hedgehog'], {
+    cwd: repo,
+    env: { ...gitEnv, PATH: bin },
+  });
+  const output = `${commit.stdout ?? ''}${commit.stderr ?? ''}`;
+
+  const log = run('git', ['log', '--oneline'], { cwd: repo, env: gitEnv });
+  const commitCount = log.status === 0 ? log.stdout.trim().split('\n').filter(Boolean).length : 0;
+
+  const invocations = existsSync(calls)
+    ? readFileSync(calls, 'utf8').trim().split('\n').filter(Boolean)
+    : [];
+  const nxCalls = invocations.filter((l) => l.startsWith('nx '));
+
+  console.log('  --- hook output ---');
+  for (const line of output.trim().split('\n')) console.log(`  | ${line}`);
+  console.log('  --- nx invocations ---');
+  for (const line of nxCalls) console.log(`  | ${line}`);
+  console.log('  ----------------------\n');
+
+  check('the first commit succeeds (zero exit)', true, commit.status === 0);
+  check('exactly one commit exists', 1, commitCount);
+  check('no unresolvable base ref reached nx', false, /ambiguous argument/.test(output));
+
+  // The gate must still have run. Skipping the checks would make the
+  // commit succeed too, and would be the wrong fix.
+  for (const target of ['typecheck', 'lint', 'test']) {
+    check(
+      `the ${target} gate actually ran on the first commit`,
+      true,
+      nxCalls.some((l) => l.includes(`-t ${target}`)),
+    );
+  }
+
+  if (failures.length) {
+    console.log(`\nFAILED (${failures.length}): the documented first-commit path does not work.`);
+    process.exit(1);
+  }
+  console.log('\nOK: the first commit passed a gate that actually ran.');
+} finally {
+  if (!process.env.KEEP_REPRO) await rm(work, { recursive: true, force: true });
+}

--- a/src/db/gate.mjs
+++ b/src/db/gate.mjs
@@ -1,0 +1,149 @@
+// Is the commit gate actually enforcing? — the second line of defence
+// behind `lefthook.yml`'s own `assert_lefthook_installed`.
+//
+// The gate's whole promise is that it can't be worked around, and its
+// worst failure mode is not a broken hook but an absent one: `.git/hooks`
+// is present, `lefthook.yml` is committed, and nothing in a commit's
+// output distinguishes "passed the gate" from "there was no gate". Every
+// signal a person would look at says gated. So the check has to be
+// explicit, and it belongs somewhere read at the start of every session
+// — which is `hedgehog status`.
+//
+// Read-only and never throws: a status command that fails because it
+// couldn't stat a hook would be worse than the thing it reports on.
+
+import { readFile, access } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { join, isAbsolute, delimiter } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const exists = (p) =>
+  access(p, constants.F_OK).then(
+    () => true,
+    () => false,
+  );
+
+// The string `lefthook install` writes into the generated hook when
+// `assert_lefthook_installed: true` is set. Its presence is the only
+// way to tell a fail-closed hook from a fail-open one, since both are
+// otherwise the same generated script — and the distinction matters,
+// because the flag is baked in at install time, so a hook generated
+// before the flag was set keeps failing open until it's regenerated.
+const ASSERT_MARKER = 'Operation is aborted due to lefthook settings';
+
+// Resolves the repo's hooks directory the way git itself does, so a
+// project that has moved it with `core.hooksPath`, or is running from a
+// worktree, isn't reported as ungated on the strength of an empty
+// `.git/hooks`. Falls back to the conventional location if git can't be
+// run at all — guessing the usual path is a better failure than
+// announcing "no gate installed" because we couldn't spawn a process.
+function hooksDir(projectRoot) {
+  try {
+    const out = execFileSync('git', ['rev-parse', '--git-path', 'hooks'], {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    if (out) return isAbsolute(out) ? out : join(projectRoot, out);
+  } catch {
+    // fall through
+  }
+  return join(projectRoot, '.git/hooks');
+}
+
+// The subset of the generated hook's own lookup chain that can be
+// checked without running anything: the binary on PATH, and the two
+// node_modules layouts lefthook's npm package produces. Deliberately
+// not exhaustive — the hook also tries bundler/go/mise/etc. paths — so
+// this only ever reports "missing" for the JS-toolchain install this
+// core actually uses.
+async function lefthookBinaryPresent(projectRoot) {
+  const dirs = (process.env.PATH ?? '').split(delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    if (await exists(join(dir, 'lefthook'))) return true;
+  }
+  if (await exists(join(projectRoot, 'node_modules/lefthook/bin/index.js'))) return true;
+
+  const osArch = process.platform === 'win32' ? 'windows' : process.platform;
+  const cpuArch = process.arch === 'x64' ? 'x64' : process.arch === 'arm64' ? 'arm64' : process.arch;
+  if (await exists(join(projectRoot, `node_modules/lefthook-${osArch}-${cpuArch}/bin/lefthook`))) {
+    return true;
+  }
+  return false;
+}
+
+// Returns { applicable, state, detail, repair }.
+//
+//   applicable false  this core doesn't gate commits with lefthook —
+//                     nothing to report, and reporting "no gate" would
+//                     be wrong rather than merely noisy
+//   active            hooks installed, fail-closed, binary resolvable
+//   not-installed     lefthook.yml is committed but no hook was written
+//   fails-open        hook predates assert_lefthook_installed
+//   binary-missing    hook would refuse, but the tooling is gone
+export async function commitGateStatus(projectRoot) {
+  if (!(await exists(join(projectRoot, 'lefthook.yml')))) {
+    return { applicable: false };
+  }
+
+  const hook = join(hooksDir(projectRoot), 'pre-commit');
+
+  if (!(await exists(hook))) {
+    return {
+      applicable: true,
+      state: 'not-installed',
+      detail: 'lefthook.yml is committed, but no pre-commit hook is installed.',
+      repair: 'pnpm install   (or: pnpm dlx lefthook install)',
+    };
+  }
+
+  let script = '';
+  try {
+    script = await readFile(hook, 'utf8');
+  } catch {
+    // Unreadable is not the same as absent, and guessing which one it
+    // is would be worse than saying so.
+    return {
+      applicable: true,
+      state: 'unknown',
+      detail: `Could not read ${hook}.`,
+      repair: 'pnpm dlx lefthook install',
+    };
+  }
+
+  if (!script.includes(ASSERT_MARKER)) {
+    return {
+      applicable: true,
+      state: 'fails-open',
+      detail:
+        'The installed hook predates assert_lefthook_installed — it exits 0 ' +
+        'when lefthook is missing, so commits land ungated.',
+      repair: 'pnpm dlx lefthook install   (regenerates the hook fail-closed)',
+    };
+  }
+
+  if (!(await lefthookBinaryPresent(projectRoot))) {
+    return {
+      applicable: true,
+      state: 'binary-missing',
+      detail:
+        'The hook is fail-closed, so it will refuse commits until lefthook ' +
+        'is back — nothing is landing ungated, but nothing can land at all.',
+      repair: 'pnpm install',
+    };
+  }
+
+  return { applicable: true, state: 'active' };
+}
+
+// Plain text, colouring left to the caller — same split as formatStatus.
+// Returns null when there's nothing worth printing.
+export function formatCommitGate(gate) {
+  if (!gate || !gate.applicable) return null;
+  if (gate.state === 'active') return 'COMMIT GATE  active';
+
+  const lines = ['COMMIT GATE  NOT ENFORCING', '', `  ${gate.detail}`, ''];
+  lines.push(`  Restore it with: ${gate.repair}`);
+  lines.push('  To commit anyway, deliberately: git commit --no-verify');
+  return lines.join('\n');
+}

--- a/src/golden-cores/full-stack-app/lefthook.yml
+++ b/src/golden-cores/full-stack-app/lefthook.yml
@@ -1,15 +1,28 @@
+# The `git rev-parse --verify --quiet HEAD` guard on each command is
+# there because `--base=HEAD` cannot resolve in a repo with no commits:
+# on the very first commit of a fresh install every command died with
+# "fatal: ambiguous argument 'HEAD': unknown revision", the commit was
+# rejected, and `git commit --no-verify` became the only way through —
+# which is exactly the habit this gate exists to prevent. (The Nx daemon
+# dying with ECONNRESET behind it made the real cause hard to see.)
+#
+# The fallback is `run-many`, not a skip: with no history there is no
+# diff to narrow by, every project is new, and running the whole
+# workspace is both the honest answer and the strongest one. Silencing
+# the gate on the one commit that introduces the entire codebase would
+# be the worst possible place to do it.
 pre-commit:
   parallel: true
   commands:
     typecheck:
       glob: '*.{ts,tsx}'
-      run: npx nx affected -t typecheck --base=HEAD
+      run: if git rev-parse --verify --quiet HEAD >/dev/null 2>&1; then npx nx affected -t typecheck --base=HEAD; else npx nx run-many -t typecheck; fi
     lint:
       glob: '*.{ts,tsx}'
-      run: npx nx affected -t lint --base=HEAD
+      run: if git rev-parse --verify --quiet HEAD >/dev/null 2>&1; then npx nx affected -t lint --base=HEAD; else npx nx run-many -t lint; fi
     test:
       glob: '*.{ts,tsx}'
-      run: npx nx affected -t test --base=HEAD
+      run: if git rev-parse --verify --quiet HEAD >/dev/null 2>&1; then npx nx affected -t test --base=HEAD; else npx nx run-many -t test; fi
 
 commit-msg:
   commands:

--- a/src/golden-cores/full-stack-app/lefthook.yml
+++ b/src/golden-cores/full-stack-app/lefthook.yml
@@ -1,16 +1,38 @@
+# The commit gate. Two things in here are load-bearing and read like
+# noise if you don't know what they're for — don't "clean them up".
+#
+# `assert_lefthook_installed: true` is what makes the gate fail CLOSED.
+# It is consumed by `lefthook install`, which bakes a refusing branch
+# into the generated .git/hooks/* scripts. Without it, a repo whose
+# node_modules has been cleared — a workspace clean, a fresh clone
+# before install, a core switch — prints "Can't find lefthook in PATH"
+# and exits 0, so the commit lands with no typecheck, no lint and no
+# test while .git/hooks and this file both still look like a gate.
+# There is nothing in the output that distinguishes "passed the gate"
+# from "there was no gate". With it, the hook refuses the commit and
+# names the escape hatch (`git commit --no-verify`, or `LEFTHOOK=0`).
+# Restore enforcement with `pnpm install` — lefthook's own postinstall
+# re-runs `lefthook install -f` — or with `pnpm dlx lefthook install`
+# on its own. `hedgehog status` reports whether the gate is live.
+#
+# Because the assertion is written into the hook at install time, this
+# flag only protects hooks generated after it was set. `pnpm install`
+# regenerates them, so any project that has installed once since is
+# covered.
+#
 # The `git rev-parse --verify --quiet HEAD` guard on each command is
 # there because `--base=HEAD` cannot resolve in a repo with no commits:
-# on the very first commit of a fresh install every command died with
-# "fatal: ambiguous argument 'HEAD': unknown revision", the commit was
-# rejected, and `git commit --no-verify` became the only way through —
-# which is exactly the habit this gate exists to prevent. (The Nx daemon
-# dying with ECONNRESET behind it made the real cause hard to see.)
-#
-# The fallback is `run-many`, not a skip: with no history there is no
-# diff to narrow by, every project is new, and running the whole
-# workspace is both the honest answer and the strongest one. Silencing
-# the gate on the one commit that introduces the entire codebase would
-# be the worst possible place to do it.
+# on the very first commit of a fresh install every command dies with
+# "fatal: ambiguous argument 'HEAD': unknown revision", the commit is
+# rejected, and `git commit --no-verify` becomes the only way through —
+# which is exactly the habit this gate exists to prevent. The fallback
+# is `run-many`, not a skip: with no history there is no diff to narrow
+# by, every project is new, and running the whole workspace is both the
+# honest answer and the strongest one. Silencing the gate on the one
+# commit that introduces the entire codebase would be the worst
+# possible place to do it.
+assert_lefthook_installed: true
+
 pre-commit:
   parallel: true
   commands:

--- a/src/skills/hedgehog-bootstrap-full-stack-app-core/SKILL.md
+++ b/src/skills/hedgehog-bootstrap-full-stack-app-core/SKILL.md
@@ -133,12 +133,28 @@ four separate live generate-and-verify passes — core isn't proven
 correct by trusting the copy, it's proven correct by actually running
 the same gate every other step in this discipline runs.
 
-Run `pnpm dlx lefthook install` once `lefthook.yml` is in place (it
-already is, from the copy) so the commit gate is active before the next
-commit. Verify the hook resolves to the project's pinned local lefthook
-(check `lefthook version` during a commit, or that `.git/hooks/`
-resolves into `node_modules/.bin/lefthook`) rather than a global
-Homebrew-installed shadow.
+The commit gate is already active by this point: `lefthook.yml` came
+with the copy, and lefthook's own postinstall ran `lefthook install -f`
+during step 4's `pnpm install`. Run `pnpm dlx lefthook install` only if
+`.git/hooks/pre-commit` is somehow absent.
+
+Confirm the gate is real rather than assuming it, with:
+
+```bash
+hedgehog status
+```
+
+Its `COMMIT GATE` line reads `active` only when the hooks exist, were
+generated with `lefthook.yml`'s `assert_lefthook_installed: true`, and
+the lefthook binary actually resolves. Anything else is a gate that
+isn't enforcing, and the line names the repair. Two failure modes it
+catches that nothing else does: hooks generated before that flag
+existed (they fail open — regenerate with `pnpm dlx lefthook install`),
+and a `node_modules` that has since been cleared (`pnpm install`).
+
+Also check the hook resolves to the project's pinned local lefthook
+(`lefthook version` during a commit, or that `.git/hooks/` resolves
+into `node_modules/`) rather than a global Homebrew-installed shadow.
 
 ### 6. Commit
 


### PR DESCRIPTION
Two bugs in the `full-stack-app` core's commit gate, both confirmed against the real files and a real lefthook binary.

## Bug 1 — the gate fails OPEN when lefthook is missing

The payload contains no hook file; hooks are generated by `lefthook install`. Reading the `.git/hooks/pre-commit` that lefthook 2.1.10 (the version this core pins) generates, the lookup chain ends:

```sh
    else
      echo "Can't find lefthook in PATH"
    fi
  fi
}
call_lefthook run "pre-commit" "$@"
```

No `exit 1` — the function returns 0 and the hook exits 0. Reproduced live: with `node_modules` removed, `git commit` printed `Can't find lefthook in PATH` and **exited 0 with the commit landed**.

What makes this dangerous is the appearance. `.git/hooks` is present and `lefthook.yml` comes back with bootstrap, so the repo looks gated when it is not, and nothing in the output distinguishes "passed the gate" from "there was no gate". On the build where this surfaced, five commits after a workspace clean produced ten warnings and zero blocks.

## Bug 2 — the first commit of a fresh install cannot pass

`src/golden-cores/full-stack-app/lefthook.yml` at HEAD:

```yaml
    typecheck:
      glob: '*.{ts,tsx}'
      run: npx nx affected -t typecheck --base=HEAD
```

…identically for `lint` and `test`. In a repo with no commits `HEAD` does not resolve, so all three fail with `fatal: ambiguous argument 'HEAD'` and the commit is rejected. The Nx daemon then dies with `ECONNRESET`, masking the cause. The only way through is `git commit --no-verify`.

`bin/cli.mjs` printed `1. git add -A && git commit -m "chore: install Hedgehog"` with `2. pnpm install` *after* it — so the documented first step could not work.

## What changed, and why each choice

**Base ref.** Each command is now guarded with `if git rev-parse --verify --quiet HEAD; then … --base=HEAD; else npx nx run-many -t <target>; fi`.

`run-many` rather than a skip or an empty-tree SHA, deliberately: with no history there is no diff to narrow by and every project is new, so the whole workspace is both the honest answer and the strongest one — and silencing the gate on the commit that introduces the entire codebase is the worst possible place to do it. The empty-tree-SHA route is also fragile, since Nx's `--head` defaults to `HEAD`, which is equally unresolvable there.

**Fail closed.** `assert_lefthook_installed: true` — lefthook's own switch, which bakes a refusing branch into the generated hooks. Chosen over shipping a shim via `core.hooksPath` because lefthook's postinstall runs `lefthook install -f` on **every** install, so a tracked hook file would be clobbered and would dirty the worktree on each `pnpm install`. Verified: the commit is now refused with exit 1, and the message names `--no-verify` and `LEFTHOOK=0`.

The lockout trade-off seems right because the failure is loud, immediate, self-describing, and repaired by one `pnpm install` — whereas fail-open is silent and surfaces later as unreviewed code already in history.

**Installer ordering.** Swapped to `pnpm install` first, then commit. lefthook's postinstall is what writes the hooks, so the old order guaranteed commit #1 was ungated regardless of the base-ref bug.

I did **not** make the installer create the commit itself. `init` can run in a repo that already has history, and a tool committing into someone's repo unasked is a bigger surprise than a wrong ordering.

**`hedgehog status`.** New `src/db/gate.mjs` (~150 lines), wired into `statusCommand`. It distinguishes four states — never installed / hooks predating the flag (i.e. still fail-open) / fail-closed with the binary gone / active — and names the repair for each. Silent on cores without a `lefthook.yml`, so landing-page is unaffected.

## Evidence

| reproduction | before | after |
|---|---|---|
| `repro/commit-gate-fails-open.mjs` | FAILED (3): commit landed, exit 0, `Can't find lefthook in PATH` ×2 | OK — refused, 0 commits, names `--no-verify` |
| `repro/first-commit-rejected.mjs` | FAILED (3): `fatal: ambiguous argument 'HEAD': unknown revision` ×3, 0 commits | OK — 1 commit, `nx run-many -t {typecheck,lint,test}` all ran |

Each uses its own `mkdtemp` with the git repo one level below it, isolated git config, and an explicit `cwd` — the surrounding repo is never touched. `node scripts/check.mjs` passes.

## Caveats, honestly

- **Real Nx was not run.** `first-commit-rejected.mjs` stubs `npx`, modelling one behaviour: nx resolving `--base` against git. The stub was validated to reproduce the exact real symptom against real lefthook before being relied on. `commit-gate-fails-open.mjs` stubs nothing.
- **The refusal message does not name `pnpm install`.** Lefthook's text is fixed and not configurable — it names `--no-verify` and `LEFTHOOK=0` only. The repair command is surfaced through `hedgehog status` and the `lefthook.yml` comments instead; getting it into the hook itself would require the `core.hooksPath` approach rejected above.
- **The flag is baked in at install time**, so hooks generated before this change stay fail-open until regenerated. That is precisely the state `hedgehog status` now detects and names.
- **Incidental finding, worth knowing:** lefthook's fallback chain tries `pnpm lefthook -h`, and pnpm v11 will install the missing dependency to satisfy it — so on a machine with pnpm and network access, a gateless repo can silently reinstall lefthook mid-commit. The first draft of the fail-open reproduction passed for exactly this wrong reason; both reproductions now pin `PATH` to the binaries the hook actually needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
