### PR TITLE
docs(core-design): make the author resolve GitOps ordering, and put the framework build in the layer that needs it

### DIFF
--- a/src/skills/hedgehog-core-design/SKILL.md
+++ b/src/skills/hedgehog-core-design/SKILL.md
@@ -224,8 +224,8 @@ For each layer, ask: does this layer's `verify` command only read files
 inside its own `scope`, or does it also read, or typecheck, a wider
 package or project? A test runner scoped by filename or filter token
 usually stays inside `scope`. A typecheck or build step often doesn't —
-`tsc` has no per-module isolation, so a command like `pnpm nx test db
---testPathPattern={module}` typechecks the whole `packages/db` project on
+`tsc` has no per-module isolation, so a command like `pnpm nx test db --
+src/schema/{module}/` typechecks the whole `packages/db` project on
 every run, regardless of which module's tests it filters to.
 
 Where the verify command reads wider than `scope`, declare that wider set
@@ -246,8 +246,8 @@ a flaky verify when a neighboring in-flight task's files get picked up
 mid-run.
 
 Worked example: a Drizzle schema layer scoped to
-`packages/db/src/schema/{module}/**` with `verify: "pnpm nx test db
---testPathPattern={module}"` looks module-scoped by its test filter, but
+`packages/db/src/schema/{module}/**` with `verify: "pnpm nx test db --
+src/schema/{module}/"` looks module-scoped by its test filter, but
 the command typechecks all of `packages/db`, not just that module's
 files. Its true verify radius is the whole package —
 `verify_radius: ["packages/db/**"]` — not just its own scope glob, so two

--- a/src/skills/hedgehog-core-design/SKILL.md
+++ b/src/skills/hedgehog-core-design/SKILL.md
@@ -254,6 +254,55 @@ files. Its true verify radius is the whole package —
 modules' schema tasks correctly serialize against each other on that
 radius even though their scopes don't overlap.
 
+## Step 4c — say where the push happens
+
+Skip this if no layer in the sequence deploys, publishes, or otherwise
+acts on a system outside the working tree. For every layer that does,
+answer one question before Step 5 and record the answer in
+`core-design.md`: **where does the push happen, relative to this layer's
+commit?**
+
+The gate's own ordering forces the question. `hedgehog verify` runs the
+layer's verify command and writes the commit only if it passes, and
+nothing in the tool pushes — so at the moment the command judges the
+world, the files the layer just wrote are in the working tree and nowhere
+else: not committed, not on a remote. A verify that asks a system to read
+those files out of a git repository is asking about files that
+demonstrably do not exist yet.
+
+That makes a deployment model whose source of truth is the committed
+repository — GitOps: ArgoCD, Flux — circular on the first run of any
+layer that introduces manifests, and it fails silently rather than
+loudly. The controller syncs the revision it can see, finds no manifests,
+manages zero resources, and reports healthy; an empty set is trivially
+healthy. A verify that asks "is the application healthy?" gets yes and
+commits a vacuous claim. A continuous-sync policy (ArgoCD's `automated`,
+`selfHeal`) compounds it: it reverts whatever the verify command applied
+out of band — including on revisions moved by later commits that never
+touched the manifests — and a verify that re-applies the controller's own
+Application manifest re-arms that policy on every run.
+
+Two answers are expressible under this discipline:
+
+- **The layer applies directly** — `kubectl apply`, `helm upgrade`, a
+  registry push — and its verify asserts against what it just applied.
+  The repository records what was deployed; it is not what
+  deploys. No reconciliation controller with an automated sync policy
+  belongs in any layer's committed output, since it will revert the layer
+  that applied out of band.
+- **The push is an out-of-band step between two layers** — a person or CI
+  pushes after layer N commits, and layer N+1's verify assumes it
+  happened. The graph cannot represent that step, schedule it, or check
+  it ran, so name it in `core-design.md` as a manual precondition of
+  layer N+1 and expect the first clean run to stop there until someone
+  performs it.
+
+A third answer — the deployed state is reconciled from the committed
+repository, and the verify judges that reconciled state — is not
+expressible: it requires a commit before the verify that gates the
+commit. Choose a model that applies directly rather than designing a
+layer around it.
+
 ## Step 5 — write `.hedgehog/core.yaml`
 
 The loader parses `id` plus a `layers` list of flat maps. Every layer
@@ -302,6 +351,22 @@ if missed:
   of) passes on an empty implementation. Pair typecheck/build commands
   with a test command that exercises the layer's actual output whenever
   the layer produces behavior, not just types.
+- **A layer whose output a framework compiles must run that build in its
+  `verify`.** A typechecker and a test runner are not the framework's
+  build: they are different module resolvers, reading different config,
+  applying different rules. Code can typecheck clean and pass every test
+  and still be unbuildable — a relative import written with an explicit
+  `.js` extension resolves under `NodeNext` and fails under a
+  bundler-style `moduleResolution`, and only the framework's own build
+  says so. The blast radius is what makes this silent rather than slow:
+  these builds are usually all-or-nothing across the app, so one
+  unbuildable file blocks the artifact for every other route too, and it
+  surfaces layers later as "nothing deploys" rather than "this layer is
+  wrong". Put `next build` / `astro build` / `vite build` / `expo export`
+  / whatever the chosen framework's build command is into that layer's
+  `verify` alongside the typecheck and the tests, and declare what the
+  build reads as `verify_radius` (Step 4b) — a whole-app build reads the
+  whole app, not just this layer's scope.
 - **A `verify` filter token must cross-check against that same layer's
   `scope`.** When `verify` includes a test-runner filter string (`pnpm
   test <token>`, `pnpm test <token1> <token2> ...`), each token is a
@@ -364,6 +429,8 @@ to change only until the file lands. Hard stop.
   cross-checked against that same layer's scope globs (Step 5).
 - The module-axis decision, named as such, with the consequence stated
   (intents × layers tasks, or one task per layer).
+- For any layer that deploys or publishes: where the push happens
+  relative to that layer's commit (Step 4c) — or that no layer deploys.
 - That this is an authored core: the sequence was designed for this
   project, not battle-tested across many, and it carries the same
   enforcement as a Golden Core but a weaker guarantee.


### PR DESCRIPTION
Two authoring rules for `hedgehog-core-design`, both from failures on a real 36-task build whose core this skill designed.

**This is a prose change to an authoring skill, and it is unproven.** There is no reproduction that can demonstrate an authoring rule works — the only test is whether a future core author reads the rule and answers it, which nothing in this repo can check mechanically. What is verified is stated at the bottom.

## Rule 1 — a new Step 4c, "say where the push happens"

The designed core mandated GitOps with ArgoCD, and its `deploy` layer's verify required an Application to report `Healthy`. But `hedgehog verify` writes the commit **only after** the verify passes, and nothing in the payload pushes. So at the moment the gate judges the world, the manifests it is judging exist in the working tree and nowhere else.

The failure is silent rather than loud: the controller synced the revision it could see, found no manifests, managed **zero resources**, and reported healthy — an empty set is trivially healthy. The gate asked "is it healthy?", got yes, and committed a vacuous claim. A continuous-sync policy compounds it by reverting whatever the verify applied out of band, including on revisions moved by later commits that never touched the manifests, and a verify that re-applies the controller's own Application manifest re-arms that policy on every run.

The rule forces the author to answer one question before Step 5 for any layer that acts outside the working tree, and names the two answers that are expressible — the layer applies directly and asserts against what it applied, or the push is an out-of-band step between two layers that must be declared as a manual precondition. It also states plainly that a third combination — deployed state reconciled from the committed repository, with the verify judging that reconciled state — **is not expressible**, because it requires a commit before the verify that gates the commit.

Saying that a combination is impossible seems more useful than leaving an author to discover it on the last layer of the sequence, after all the domain work is done.

## Rule 2 — a new constraint in Step 5

A layer built for Next.js passed its verify — `tsc --noEmit` clean, 39 tests green — while producing code the framework could not build: a relative import written with an explicit `.js` extension, correct under `NodeNext`, invalid under the web app's `moduleResolution: bundler`.

The blast radius is what makes it silent rather than merely slow. Next compiles every route under `src/app` regardless of what triggered the build, so one unbuildable file blocked **every** new image of the web app, not just that module's. It surfaced two layers later as "nothing deploys" rather than "this layer is wrong".

The rule: a layer whose output a framework compiles must run that build in its `verify`, because a typechecker and a test runner are different module resolvers reading different config. It also requires declaring what the build reads as `verify_radius` — a whole-app build reads the whole app, not just the layer's scope.

## The shipped full-stack-app core does not satisfy rule 2

Found while checking the rule against reality, and worth flagging separately since it is a live gap rather than guidance:

- `src/golden-cores/full-stack-app/tsconfig.base.json` sets `"moduleResolution": "nodenext"`;
- `src/golden-cores/full-stack-app/apps/web/tsconfig.json` sets `"bundler"`;
- the `screen` layer's verify is `pnpm nx test web --testPathPattern={module} && pnpm nx test mobile --testPathPattern={module}`, and the terminal `join` layer's is `pnpm typecheck && pnpm nx run-many -t test`. `next build` appears **zero** times in the whole file.

That is exactly the split that caused the failure above. A `full-stack-app` project can therefore reach `join` complete with a web app Next.js cannot build. The new rule is scoped to authored cores, so this is not a contradiction — but it is the same hole in a core you ship, and fixing it is a `core.yaml` change I have not made here.

## What was deliberately cut

The first draft carried the war-story specifics — a 16-second revert timing, `managedFields` attribution, a `kubectl delete job` → `field is immutable` sequence. They prove the diagnosis but are not checks an author can apply, so they came out. A three-answer menu collapsed into two expressible answers plus one explicitly inexpressible combination, and a "prefer a text-source deployment" style recommendation was dropped entirely.

What remains is answerable yes or no: does any layer act outside the working tree; where does the push happen; is an automated-sync controller in a layer's committed output; does this layer's framework have a build command, is it in `verify`, and is `verify_radius` declared for it.

## What is actually verified

- **No new `core.yaml` field was invented.** Checked against `src/db/core.mjs`: the parser accepts only `id`, `depends_on`, `scope`, `verify`, `commit`, `exclusive`, `verify_radius`. Step 4c's answer is recorded in `core-design.md` prose; rule 2 reuses `verify` and the existing `verify_radius`.
- **The ordering claim behind Step 4c.** `hedgehog verify` commits only on pass, and nothing in the payload pushes — `grep` for `git push` across `src/` returns only `conventional-commits`'s "Never push. Commits only."
- `node scripts/check.mjs` passes. Only `src/skills/hedgehog-core-design/SKILL.md` is touched; no other skill changed.

The check validates frontmatter, cross-references, both shipped cores, the tarball and the CLI — the skill body is prose it does not parse. A clean check means nothing broke, not that the rules are right. The failure narratives come from the reported build, not from anything re-run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
