### PR TITLE
fix(verify): judge a task on what it changed, not on everything dirty in the repo

### DIFF
--- a/repro/01-genuine-violation-still-fails.mjs
+++ b/repro/01-genuine-violation-still-fails.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node --experimental-sqlite
+// REGRESSION GUARD — passes both before and after the fix, on purpose.
+//
+// The whole point of the scope gate is to catch a task writing outside
+// its ALLOWED SCOPE. Narrowing attribution must not narrow that away, so
+// this asserts the case that must keep failing: the task's own agent
+// writes a file outside scope during the lease, and verify blocks it.
+//
+// Both flavours are covered — modifying a tracked file out of scope, and
+// creating an untracked one — since the fix touches how both are
+// attributed.
+
+import { makeRepo, cleanup, seedTask, claimOrThrow, runVerify, write, append, taskRow, check, finish } from './lib.mjs';
+
+const NAME = '01-genuine-violation-still-fails';
+console.log(`${NAME}\n`);
+
+// ── a tracked file modified out of scope ──────────────────────────────
+{
+  const dir = makeRepo();
+  try {
+    seedTask(dir, { id: 't1', scope: ['pkg-a/**'] });
+    claimOrThrow(dir);
+
+    // The agent's own work: in scope, plus one file it had no business in.
+    append(dir, 'pkg-a/src/index.js', 'export const x = 2;\n');
+    append(dir, 'docs/notes.md', 'the agent wrote here, out of scope\n');
+
+    const res = runVerify(dir, 't1');
+    const row = taskRow(dir, 't1');
+    check('tracked out-of-scope write: verify exits non-zero', res.code !== 0, true);
+    check('tracked out-of-scope write: reports the offending path', res.out.includes('docs/notes.md'), true);
+    check('tracked out-of-scope write: task blocked', [row.status, row.blocked_reason], ['blocked', 'scope_violation']);
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// ── an untracked file created out of scope ────────────────────────────
+{
+  const dir = makeRepo();
+  try {
+    seedTask(dir, { id: 't1', scope: ['pkg-a/**'] });
+    claimOrThrow(dir);
+
+    append(dir, 'pkg-a/src/index.js', 'export const x = 2;\n');
+    write(dir, 'pkg-b/src/sneaky.js', 'the agent created this, out of scope\n');
+
+    const res = runVerify(dir, 't1');
+    const row = taskRow(dir, 't1');
+    check('untracked out-of-scope write: verify exits non-zero', res.code !== 0, true);
+    check('untracked out-of-scope write: reports the offending path', res.out.includes('pkg-b/src/sneaky.js'), true);
+    check('untracked out-of-scope write: task blocked', [row.status, row.blocked_reason], ['blocked', 'scope_violation']);
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// ── a file dirty *before* the claim and changed *again* by the agent ───
+// The narrowing must not become an amnesty: pre-existing dirt is exempt
+// only while the task leaves it alone.
+{
+  const dir = makeRepo();
+  try {
+    append(dir, 'docs/notes.md', 'pre-existing dirt\n');
+    seedTask(dir, { id: 't1', scope: ['pkg-a/**'] });
+    claimOrThrow(dir);
+
+    append(dir, 'pkg-a/src/index.js', 'export const x = 2;\n');
+    append(dir, 'docs/notes.md', 'and then the agent piled on\n');
+
+    const res = runVerify(dir, 't1');
+    const row = taskRow(dir, 't1');
+    check('further-dirtied pre-existing file: verify exits non-zero', res.code !== 0, true);
+    check('further-dirtied pre-existing file: reports the offending path', res.out.includes('docs/notes.md'), true);
+    check('further-dirtied pre-existing file: task blocked', [row.status, row.blocked_reason], ['blocked', 'scope_violation']);
+  } finally {
+    cleanup(dir);
+  }
+}
+
+finish(NAME);

--- a/repro/02-unrelated-dirty-tracked-file.mjs
+++ b/repro/02-unrelated-dirty-tracked-file.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node --experimental-sqlite
+// THE BUG — fails against master, passes after the fix.
+//
+// A tracked file somewhere else in the repo is already uncommitted when
+// the task is claimed: an unfiled friction log, the user's own
+// half-finished edit, whatever. The task's agent never touches it. The
+// gate reads the whole dirty working tree, so it attributes that file to
+// the task and blocks it for work that is not its own.
+//
+// Two shapes: an ordinary unrelated file, and a tracked shared
+// composition seam (a root DI module / package barrel) left dirty by the
+// previous session — the file the reported fan-out failure was about,
+// here dirtied by someone other than the task being verified.
+
+import { makeRepo, cleanup, seedTask, claimOrThrow, runVerify, append, taskRow, headFiles, headSubject, check, finish } from './lib.mjs';
+
+const NAME = '02-unrelated-dirty-tracked-file';
+console.log(`${NAME}\n`);
+
+// ── an unrelated tracked file, dirty before the claim ─────────────────
+{
+  const dir = makeRepo();
+  try {
+    // Nobody's task: an uncommitted note sitting in the repo.
+    append(dir, 'docs/notes.md', 'friction log entry, filed by a human\n');
+
+    seedTask(dir, { id: 't1', scope: ['pkg-a/**'] });
+    claimOrThrow(dir);
+
+    // The agent touches nothing but its own scope.
+    append(dir, 'pkg-a/src/index.js', 'export const x = 2;\n');
+
+    const res = runVerify(dir, 't1');
+    const row = taskRow(dir, 't1');
+    check('unrelated dirty tracked file: verify exits 0', res.code, 0);
+    check('unrelated dirty tracked file: task complete', [row.status, row.blocked_reason], ['complete', null]);
+    check('unrelated dirty tracked file: commit holds only the task\'s files', headFiles(dir), ['pkg-a/src/index.js']);
+    check('unrelated dirty tracked file: commit uses the layer message', headSubject(dir), 'feat(t1): layer');
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// ── the shared seam, left dirty before the fan-out started ────────────
+// The scheduler hands two tasks out together. The shared composition
+// seam they both sit near was already uncommitted when it did so, so
+// neither of them changed it — but on master the first one to verify
+// wears it.
+{
+  const dir = makeRepo();
+  try {
+    append(dir, 'shared.json', '{"seams":1}\n');
+
+    seedTask(dir, { id: 't1', scope: ['pkg-a/**'] });
+    seedTask(dir, { id: 't2', scope: ['pkg-b/**'] });
+
+    claimOrThrow(dir, { count: 2 });
+    const t1 = taskRow(dir, 't1');
+    const t2 = taskRow(dir, 't2');
+    check('fan-out: both tasks claimed together', [t1.status, t2.status], ['building', 'building']);
+
+    // Each agent writes only inside its own scope.
+    append(dir, 'pkg-a/src/index.js', 'export const x = 2;\n');
+    append(dir, 'pkg-b/src/index.js', 'export const y = 2;\n');
+
+    const res = runVerify(dir, 't1');
+    const row = taskRow(dir, 't1');
+    check('fan-out: t1 verify exits 0', res.code, 0);
+    check('fan-out: t1 complete', [row.status, row.blocked_reason], ['complete', null]);
+    check("fan-out: t1 commit holds only t1's files", headFiles(dir), ['pkg-a/src/index.js']);
+
+    // And the neighbour still verifies cleanly afterwards.
+    const res2 = runVerify(dir, 't2');
+    check('fan-out: t2 verify exits 0', res2.code, 0);
+    check("fan-out: t2 commit holds only t2's files", headFiles(dir), ['pkg-b/src/index.js']);
+  } finally {
+    cleanup(dir);
+  }
+}
+
+finish(NAME);

--- a/repro/03-unrelated-untracked-file.mjs
+++ b/repro/03-unrelated-untracked-file.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node --experimental-sqlite
+// THE BUG, untracked half — fails against master, passes after the fix.
+//
+// NOTE ON THE ORIGINAL REPORT. It described tracked and untracked paths
+// as asymmetric: a tracked file outside scope blocks, an untracked one is
+// "silently ignored". Direct experiment says otherwise — master blocks on
+// both, because `changedPaths()` unions `git diff --name-only HEAD` with
+// `git ls-files --others --exclude-standard` and gates on the union. What
+// actually exonerated the untracked directory in the reported build was a
+// different rule: `splitByScope` subtracts every *other in-flight task's*
+// declared scope, and the concurrent agent's new directory sat inside its
+// own task's scope. The third block below pins that rule, which is
+// correct and unchanged.
+//
+// So this file asserts the consistent behaviour the fix produces: an
+// untracked path that was already there when the task was claimed is not
+// the task's, exactly like a tracked one — and it is still not committed.
+
+import { makeRepo, cleanup, seedTask, claimOrThrow, runVerify, write, append, taskRow, headFiles, check, finish } from './lib.mjs';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const NAME = '03-unrelated-untracked-file';
+console.log(`${NAME}\n`);
+
+// ── an untracked file present before the claim ────────────────────────
+{
+  const dir = makeRepo();
+  try {
+    write(dir, 'other/new-dir/scratch.txt', 'left behind by someone else\n');
+
+    seedTask(dir, { id: 't1', scope: ['pkg-a/**'] });
+    claimOrThrow(dir);
+
+    append(dir, 'pkg-a/src/index.js', 'export const x = 2;\n');
+
+    const res = runVerify(dir, 't1');
+    const row = taskRow(dir, 't1');
+    check('unrelated untracked file: verify exits 0', res.code, 0);
+    check('unrelated untracked file: task complete', [row.status, row.blocked_reason], ['complete', null]);
+    check('unrelated untracked file: not committed', headFiles(dir), ['pkg-a/src/index.js']);
+    check('unrelated untracked file: still on disk, still untracked', existsSync(join(dir, 'other/new-dir/scratch.txt')), true);
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// ── master's actual behaviour, stated as the contrast ─────────────────
+// Same file, but created *after* the claim and outside every declared
+// scope: nothing distinguishes it from the task's own stray write, so it
+// is still attributed. This is the gate doing its job, not a regression.
+{
+  const dir = makeRepo();
+  try {
+    seedTask(dir, { id: 't1', scope: ['pkg-a/**'] });
+    claimOrThrow(dir);
+
+    append(dir, 'pkg-a/src/index.js', 'export const x = 2;\n');
+    write(dir, 'other/new-dir/scratch.txt', 'appeared during the lease\n');
+
+    const res = runVerify(dir, 't1');
+    const row = taskRow(dir, 't1');
+    check('untracked file appearing during the lease: still blocks', res.code !== 0, true);
+    check('untracked file appearing during the lease: blocked reason', [row.status, row.blocked_reason], ['blocked', 'scope_violation']);
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// ── a neighbour's untracked file inside the neighbour's own scope ─────
+// The rule that actually exonerated the untracked directory in the
+// reported build. Correct on master, and must stay correct.
+{
+  const dir = makeRepo();
+  try {
+    seedTask(dir, { id: 't1', scope: ['pkg-a/**'] });
+    seedTask(dir, { id: 't2', scope: ['pkg-b/**'] });
+    claimOrThrow(dir, { count: 2 });
+
+    append(dir, 'pkg-a/src/index.js', 'export const x = 2;\n');
+    write(dir, 'pkg-b/src/brand-new.js', "t2's own new file\n");
+
+    const res = runVerify(dir, 't1');
+    const row = taskRow(dir, 't1');
+    check("neighbour's in-scope untracked file: verify exits 0", res.code, 0);
+    check("neighbour's in-scope untracked file: task complete", [row.status, row.blocked_reason], ['complete', null]);
+    check("neighbour's in-scope untracked file: not swept into t1's commit", headFiles(dir), ['pkg-a/src/index.js']);
+  } finally {
+    cleanup(dir);
+  }
+}
+
+finish(NAME);

--- a/repro/04-dirtied-during-verify.mjs
+++ b/repro/04-dirtied-during-verify.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node --experimental-sqlite
+// The harness-writes-during-verify case.
+//
+// Block 1 is a REGRESSION GUARD (passes before and after): a file
+// dirtied only while verify_command is running never reaches gate 1,
+// which has already run by then. The original report said this made the
+// gate impossible to satisfy; on its own, it does not.
+//
+// Block 2 is THE BUG (fails against master, passes after the fix), and
+// is the reported scenario in full: the harness's telemetry keeps a
+// tracked file dirty, the operator commits it to clean the tree, and the
+// next verify_command re-dirties it before the *following* verify — so
+// the path is dirty again at gate-1 time and there is no ordering that
+// wins. Snapshotting at claim time is what breaks that loop: the path
+// was already dirty when the task was handed out, so it is not the
+// task's.
+
+import { makeRepo, cleanup, seedTask, claimOrThrow, runVerify, append, taskRow, headFiles, check, finish } from './lib.mjs';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const NAME = '04-dirtied-during-verify';
+console.log(`${NAME}\n`);
+
+// A verify command that writes telemetry out of scope, exactly like a
+// PostToolUse hook would, and then succeeds.
+const TELEMETRY = 'printf "telemetry\\n" >> docs/notes.md; true';
+
+// ── dirtied only during verify_command ────────────────────────────────
+{
+  const dir = makeRepo();
+  try {
+    seedTask(dir, { id: 't1', scope: ['pkg-a/**'], verifyCommand: TELEMETRY });
+    claimOrThrow(dir);
+    append(dir, 'pkg-a/src/index.js', 'export const x = 2;\n');
+
+    const res = runVerify(dir, 't1');
+    const row = taskRow(dir, 't1');
+    check('dirtied during verify: verify exits 0', res.code, 0);
+    check('dirtied during verify: task complete', [row.status, row.blocked_reason], ['complete', null]);
+    check('dirtied during verify: telemetry not committed', headFiles(dir), ['pkg-a/src/index.js']);
+    check(
+      'dirtied during verify: telemetry really was written',
+      readFileSync(join(dir, 'docs/notes.md'), 'utf8').includes('telemetry'),
+      true,
+    );
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// ── dirty at claim time *and* re-dirtied during verify_command ────────
+{
+  const dir = makeRepo();
+  try {
+    // The previous run's telemetry, still uncommitted.
+    append(dir, 'docs/notes.md', 'telemetry\n');
+
+    seedTask(dir, { id: 't1', scope: ['pkg-a/**'], verifyCommand: TELEMETRY });
+    claimOrThrow(dir);
+    append(dir, 'pkg-a/src/index.js', 'export const x = 2;\n');
+
+    const res = runVerify(dir, 't1');
+    const row = taskRow(dir, 't1');
+    check('re-dirtied telemetry: verify exits 0', res.code, 0);
+    check('re-dirtied telemetry: task complete', [row.status, row.blocked_reason], ['complete', null]);
+    check('re-dirtied telemetry: not committed', headFiles(dir), ['pkg-a/src/index.js']);
+  } finally {
+    cleanup(dir);
+  }
+}
+
+finish(NAME);

--- a/repro/05-known-limitation-unattributable-write.mjs
+++ b/repro/05-known-limitation-unattributable-write.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node --experimental-sqlite
+// KNOWN LIMITATION, pinned deliberately — passes before and after.
+//
+// One shape the claim-time snapshot does not and cannot fix: a path
+// outside every in-flight task's declared scope, changed at some point
+// *during* the lease by something other than the task being verified.
+//
+// There is one working tree and no record of who wrote what, so nothing
+// distinguishes that from the task's own stray write. Exonerating it
+// would mean any out-of-scope write becomes forgivable as long as some
+// other task happens to be in flight — that is weakening the gate, which
+// is worse than the misattribution it would cure. The gate keeps
+// failing, and the fix is to declare the path in a scope (where the
+// neighbour-exclusion rule then covers it), not to widen the amnesty.
+//
+// This file exists so that a future change which quietly "fixes" this
+// case has to argue with a failing assertion first.
+
+import { makeRepo, cleanup, seedTask, claimOrThrow, runVerify, append, taskRow, check, finish } from './lib.mjs';
+
+const NAME = '05-known-limitation-unattributable-write';
+console.log(`${NAME}\n`);
+
+const dir = makeRepo();
+try {
+  seedTask(dir, { id: 't1', scope: ['pkg-a/**'] });
+  seedTask(dir, { id: 't2', scope: ['pkg-b/**'] });
+  claimOrThrow(dir, { count: 2 });
+
+  // t1's agent stays inside its scope.
+  append(dir, 'pkg-a/src/index.js', 'export const x = 2;\n');
+  // t2's agent writes a shared seam that is in nobody's declared scope —
+  // a violation on t2's part, invisibly indistinguishable from one on
+  // t1's part.
+  append(dir, 'shared.json', '{"seams":1}\n');
+
+  const res = runVerify(dir, 't1');
+  const row = taskRow(dir, 't1');
+  check('undeclared shared-seam write during the lease: still blocks', res.code !== 0, true);
+  check('undeclared shared-seam write during the lease: names the path', res.out.includes('shared.json'), true);
+  check(
+    'undeclared shared-seam write during the lease: blocked reason',
+    [row.status, row.blocked_reason],
+    ['blocked', 'scope_violation'],
+  );
+} finally {
+  cleanup(dir);
+}
+
+finish(NAME);

--- a/repro/06-metadata-only-change.mjs
+++ b/repro/06-metadata-only-change.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node --experimental-sqlite
+// THE HOLE IN THE FIRST FIX — fails against the content-only
+// fingerprint, passes once the fingerprint covers what git records.
+//
+// The claim-time snapshot exempts a path whose fingerprint has not moved
+// since the claim. Fingerprinting only a file's *bytes* leaves the gate
+// steppable: git also records a path's type and its executable bit, so a
+// task can make a real, committable change to an out-of-scope path that
+// happened to be dirty already — `chmod +x`, a retargeted symlink, a
+// file swapped for a symlink to identical content — and the byte hash
+// never moves.
+//
+// Each block below is a genuine out-of-scope change by the task's own
+// agent, so each must block. All three verified as passing (exit 0, no
+// violation reported, change left sitting in the tree) against the
+// content-only fingerprint.
+
+import { chmodSync, symlinkSync, unlinkSync, writeFileSync, statSync, lstatSync, readlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { makeRepo, cleanup, seedTask, claimOrThrow, runVerify, append, commitAll, taskRow, check, finish } from './lib.mjs';
+
+const NAME = '06-metadata-only-change';
+console.log(`${NAME}\n`);
+
+// ── mode-only change to a pre-dirty out-of-scope file ─────────────────
+{
+  const dir = makeRepo();
+  try {
+    // Somebody else's uncommitted edit — the thing the claim snapshot
+    // exists to exonerate.
+    append(dir, 'docs/notes.md', 'someone else was here\n');
+
+    seedTask(dir, { id: 't1', scope: ['pkg-a/**'] });
+    claimOrThrow(dir);
+
+    append(dir, 'pkg-a/src/index.js', 'export const x = 2;\n');
+    // The task's own prohibited change: bytes untouched, mode flipped.
+    chmodSync(join(dir, 'docs/notes.md'), 0o755);
+
+    const res = runVerify(dir, 't1');
+    const row = taskRow(dir, 't1');
+    check('mode-only change: verify exits non-zero', res.code !== 0, true);
+    check('mode-only change: names the offending path', res.out.includes('docs/notes.md'), true);
+    check('mode-only change: task blocked', [row.status, row.blocked_reason], ['blocked', 'scope_violation']);
+    check(
+      'mode-only change: the exec bit really was set',
+      (statSync(join(dir, 'docs/notes.md')).mode & 0o111) !== 0,
+      true,
+    );
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// ── symlink retargeted to a same-content target ───────────────────────
+{
+  const dir = makeRepo();
+  try {
+    // Three identical payloads, so following the link can never tell the
+    // targets apart — only reading the link itself can.
+    for (const name of ['a.txt', 'b.txt', 'c.txt']) writeFileSync(join(dir, name), 'same\n');
+    symlinkSync('a.txt', join(dir, 'seam-link'));
+    commitAll(dir, 'chore: links');
+
+    // Pre-existing dirt: someone retargets it before the claim.
+    unlinkSync(join(dir, 'seam-link'));
+    symlinkSync('b.txt', join(dir, 'seam-link'));
+
+    seedTask(dir, { id: 't1', scope: ['pkg-a/**'] });
+    claimOrThrow(dir);
+
+    append(dir, 'pkg-a/src/index.js', 'export const x = 2;\n');
+    // The task's own prohibited change: same payload, different target.
+    unlinkSync(join(dir, 'seam-link'));
+    symlinkSync('c.txt', join(dir, 'seam-link'));
+
+    const res = runVerify(dir, 't1');
+    const row = taskRow(dir, 't1');
+    check('symlink retarget: verify exits non-zero', res.code !== 0, true);
+    check('symlink retarget: names the offending path', res.out.includes('seam-link'), true);
+    check('symlink retarget: task blocked', [row.status, row.blocked_reason], ['blocked', 'scope_violation']);
+    check('symlink retarget: the retarget really happened', readlinkSync(join(dir, 'seam-link')), 'c.txt');
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// ── a file replaced by a symlink to identical content ─────────────────
+{
+  const dir = makeRepo();
+  try {
+    // Committed first, so it is not itself an untracked out-of-scope
+    // path. Its bytes are exactly what docs/notes.md is about to become,
+    // so *following* the link reads back what was already there — only
+    // the entry's type distinguishes them.
+    writeFileSync(join(dir, 'shadow.txt'), 'baseline\nx\n');
+    commitAll(dir, 'chore: shadow');
+
+    // Pre-existing dirt, again by somebody other than the task.
+    append(dir, 'docs/notes.md', 'x\n');
+
+    seedTask(dir, { id: 't1', scope: ['pkg-a/**'] });
+    claimOrThrow(dir);
+
+    append(dir, 'pkg-a/src/index.js', 'export const x = 2;\n');
+    // The task's own prohibited change: regular file becomes a symlink.
+    unlinkSync(join(dir, 'docs/notes.md'));
+    symlinkSync('../shadow.txt', join(dir, 'docs/notes.md'));
+
+    const res = runVerify(dir, 't1');
+    const row = taskRow(dir, 't1');
+    check('file to symlink: verify exits non-zero', res.code !== 0, true);
+    check('file to symlink: names the offending path', res.out.includes('docs/notes.md'), true);
+    check('file to symlink: task blocked', [row.status, row.blocked_reason], ['blocked', 'scope_violation']);
+    check(
+      'file to symlink: the swap really happened',
+      lstatSync(join(dir, 'docs/notes.md')).isSymbolicLink(),
+      true,
+    );
+  } finally {
+    cleanup(dir);
+  }
+}
+
+finish(NAME);

--- a/repro/lib.mjs
+++ b/repro/lib.mjs
@@ -1,0 +1,201 @@
+// Shared harness for the scope-gate reproductions.
+//
+// Every repro builds a throwaway git repo in a temp dir, seeds
+// `.hedgehog/hedgehog.db` directly (no `plan`, no core.yaml — the gate
+// under test only reads `tasks`), and drives the REAL CLI
+// (`bin/cli.mjs verify`) as a subprocess with cwd set to that repo.
+//
+// No test framework and no `sqlite3` binary: assertions are plain
+// throws, and the DB is written through `node:sqlite` (Node 22 needs
+// --experimental-sqlite, which runScript passes through).
+
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, appendFileSync } from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DatabaseSync } from 'node:sqlite';
+
+import { applySchema } from '../src/db/schema.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = resolve(__dirname, '..');
+export const CLI = join(REPO_ROOT, 'bin', 'cli.mjs');
+
+// Prefix is deliberately specific to this fix so concurrent work in
+// sibling clones never collides, and so cleanup can never glob wider
+// than this one repro suite's own directories.
+const TMP_PREFIX = 'hedgehog-scopegate-';
+
+const git = (cwd, ...args) =>
+  execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+
+// A repo with two "layers" already committed, so a task can modify a
+// tracked file inside its scope and another tracked file can be dirtied
+// outside it.
+export function makeRepo() {
+  const dir = mkdtempSync(join(tmpdir(), TMP_PREFIX));
+  git(dir, 'init', '-q', '-b', 'main');
+  git(dir, 'config', 'user.email', 'repro@example.test');
+  git(dir, 'config', 'user.name', 'scope gate repro');
+  git(dir, 'config', 'commit.gpgsign', 'false');
+
+  mkdirSync(join(dir, '.hedgehog'), { recursive: true });
+  writeFileSync(join(dir, '.gitignore'), '.hedgehog/hedgehog.db*\n.hedgehog/commit.lock\n');
+
+  mkdirSync(join(dir, 'pkg-a', 'src'), { recursive: true });
+  mkdirSync(join(dir, 'pkg-b', 'src'), { recursive: true });
+  mkdirSync(join(dir, 'docs'), { recursive: true });
+  writeFileSync(join(dir, 'pkg-a/src/index.js'), 'export const a = 1;\n');
+  writeFileSync(join(dir, 'pkg-b/src/index.js'), 'export const b = 1;\n');
+  writeFileSync(join(dir, 'docs/notes.md'), 'baseline\n');
+  writeFileSync(join(dir, 'shared.json'), '{"seams":0}\n');
+
+  git(dir, 'add', '-A');
+  git(dir, 'commit', '-q', '-m', 'chore: baseline');
+
+  const db = new DatabaseSync(join(dir, '.hedgehog', 'hedgehog.db'));
+  db.exec('PRAGMA foreign_keys = ON');
+  applySchema(db);
+  db.exec(
+    `INSERT INTO intents (id, goal, outcome, status) VALUES ('i1', 'repro', 'repro', 'planned')`,
+  );
+  db.close();
+
+  return dir;
+}
+
+export function cleanup(dir) {
+  // Never a glob — only the exact directory this process created.
+  if (dir && dir.includes(TMP_PREFIX)) rmSync(dir, { recursive: true, force: true });
+}
+
+// Inserts one task straight into the graph, `planned` by default so the
+// repros go on to lease it through the real `hedgehog claim` — the claim
+// is half of the behaviour under test. Pass `status: 'building'` + an
+// `owner` to hand-lease a task instead (used to model a lease taken
+// before this fix existed, which carries no snapshot).
+export function seedTask(
+  dir,
+  {
+    id,
+    scope,
+    verifyCommand = 'true',
+    commitMessage = `feat(${id}): layer`,
+    status = 'planned',
+    owner = 'repro',
+    leaseMinutes = 45,
+  },
+) {
+  const db = new DatabaseSync(join(dir, '.hedgehog', 'hedgehog.db'));
+  db.exec('PRAGMA foreign_keys = ON');
+  const leased = status === 'building' || status === 'verifying';
+  db.prepare(
+    `INSERT INTO tasks (id, intent_id, module, layer, objective, scope_globs,
+                        verify_command, commit_message, status, lease_owner,
+                        leased_at, lease_expires_at)
+     VALUES (?, 'i1', ?, ?, ?, ?, ?, ?, ?, ?,
+             CASE WHEN ? THEN datetime('now') END,
+             CASE WHEN ? THEN datetime('now', '+' || ? || ' minutes') END)`,
+  ).run(
+    id,
+    id,
+    id,
+    `build ${id}`,
+    JSON.stringify(scope),
+    verifyCommand,
+    commitMessage,
+    status,
+    leased ? owner : null,
+    leased ? 1 : 0,
+    leased ? 1 : 0,
+    leaseMinutes,
+  );
+  db.close();
+}
+
+export function taskRow(dir, id) {
+  const db = new DatabaseSync(join(dir, '.hedgehog', 'hedgehog.db'), { readOnly: true });
+  const row = db.prepare('SELECT * FROM tasks WHERE id = ?').get(id);
+  db.close();
+  return row;
+}
+
+function runCli(dir, args) {
+  const res = spawnSync(process.execPath, ['--experimental-sqlite', CLI, ...args], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+  return {
+    code: res.status,
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+    out: `${res.stdout ?? ''}${res.stderr ?? ''}`,
+  };
+}
+
+export function runVerify(dir, taskId, owner = 'repro') {
+  return runCli(dir, ['verify', taskId, '--owner', owner]);
+}
+
+export function runClaim(dir, { owner = 'repro', count = 1 } = {}) {
+  return runCli(dir, ['claim', '--owner', owner, '--count', String(count)]);
+}
+
+// Claims, and fails loudly rather than letting a later assertion report a
+// confusing "not leased" error from verify.
+export function claimOrThrow(dir, opts) {
+  const res = runClaim(dir, opts);
+  if (res.code !== 0) throw new Error(`hedgehog claim failed (exit ${res.code}):\n${res.out}`);
+  return res;
+}
+
+export function write(dir, relPath, contents) {
+  mkdirSync(dirname(join(dir, relPath)), { recursive: true });
+  writeFileSync(join(dir, relPath), contents);
+}
+
+export function append(dir, relPath, contents) {
+  appendFileSync(join(dir, relPath), contents);
+}
+
+export function commitAll(dir, message) {
+  git(dir, 'add', '-A');
+  git(dir, 'commit', '-q', '-m', message);
+}
+
+export function headFiles(dir) {
+  return git(dir, 'show', '--name-only', '--pretty=format:', 'HEAD')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .sort();
+}
+
+export function headSubject(dir) {
+  return git(dir, 'log', '-1', '--pretty=format:%s').trim();
+}
+
+// ── assertions ────────────────────────────────────────────────────────
+const failures = [];
+
+export function check(label, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  const mark = ok ? 'PASS' : 'FAIL';
+  console.log(`  [${mark}] ${label}`);
+  if (!ok) {
+    console.log(`         expected: ${JSON.stringify(expected)}`);
+    console.log(`         actual:   ${JSON.stringify(actual)}`);
+    failures.push(label);
+  }
+  return ok;
+}
+
+export function finish(name) {
+  if (failures.length > 0) {
+    console.log(`\n${name}: ${failures.length} assertion(s) failed\n`);
+    process.exit(1);
+  }
+  console.log(`\n${name}: ok\n`);
+}

--- a/repro/lib.mjs
+++ b/repro/lib.mjs
@@ -39,6 +39,9 @@ export function makeRepo() {
   git(dir, 'config', 'user.email', 'repro@example.test');
   git(dir, 'config', 'user.name', 'scope gate repro');
   git(dir, 'config', 'commit.gpgsign', 'false');
+  // Explicit, not inherited: the mode-change repro depends on git
+  // actually tracking the executable bit.
+  git(dir, 'config', 'core.fileMode', 'true');
 
   mkdirSync(join(dir, '.hedgehog'), { recursive: true });
   writeFileSync(join(dir, '.gitignore'), '.hedgehog/hedgehog.db*\n.hedgehog/commit.lock\n');

--- a/repro/run-all.mjs
+++ b/repro/run-all.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node --experimental-sqlite
+// Runs every reproduction in this directory, each in its own process, and
+// exits non-zero if any of them does. No test framework — the scripts are
+// plain Node with plain assertions.
+//
+//   node --experimental-sqlite repro/run-all.mjs
+
+import { readdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const scripts = readdirSync(here)
+  .filter((f) => /^\d\d-.*\.mjs$/.test(f))
+  .sort();
+
+const failed = [];
+for (const script of scripts) {
+  const res = spawnSync(process.execPath, ['--experimental-sqlite', join(here, script)], {
+    stdio: 'inherit',
+  });
+  if (res.status !== 0) failed.push(script);
+}
+
+console.log('─'.repeat(60));
+if (failed.length > 0) {
+  console.log(`${failed.length} of ${scripts.length} reproduction(s) failed:`);
+  for (const f of failed) console.log(`  - ${f}`);
+  process.exit(1);
+}
+console.log(`all ${scripts.length} reproduction(s) passed`);

--- a/src/db/claim.mjs
+++ b/src/db/claim.mjs
@@ -2,8 +2,81 @@
 // See hedgehog-persistent-build-graph.md, "Claims", and the lease/claim
 // columns added to `tasks` in schema.mjs.
 
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+
 import { inTransaction } from './init.mjs';
 import { conflicts } from './conflict.mjs';
+import { ensureTaskColumns } from './schema.mjs';
+
+// ── Claim-time working-tree snapshot ──────────────────────────────────
+//
+// The scope gate in verify.mjs can only see *that* the working tree is
+// dirty, never *who* dirtied it — there is one working tree shared by
+// every concurrent task, the agent, the user, and whatever hooks the
+// surrounding harness runs. Judging a task by the whole dirty tree
+// therefore blames whoever verifies first for anything already sitting
+// there: an uncommitted friction log, a half-finished edit of the user's,
+// a neighbour's stray write.
+//
+// So the claim records what the tree already looked like. A path whose
+// content is byte-identical to what it was at claim time did not change
+// during this task's lease, and cannot be this task's doing. Anything
+// else still is — which is why this narrows attribution without ever
+// letting a real out-of-scope write through: writing a file *changes* it,
+// and a changed fingerprint is attributed.
+
+// Sentinel fingerprint for a path git reports as dirty but that isn't
+// readable as a file — a deletion, most often. Distinct from any sha1, so
+// "deleted at claim time, still deleted now" matches and "present at claim
+// time, deleted now" doesn't.
+const ABSENT = 'absent';
+
+// sha1 of the file's bytes, or ABSENT when it can't be read. Exported so
+// verify.mjs fingerprints paths the exact same way it was done here — two
+// implementations that drifted would silently mis-attribute.
+export function pathFingerprint(path) {
+  try {
+    return createHash('sha1').update(readFileSync(path)).digest('hex');
+  } catch {
+    return ABSENT;
+  }
+}
+
+// Every path the working tree is currently dirty at, relative to the repo
+// root: tracked modifications and deletions (`git diff HEAD`) plus
+// untracked files (`git ls-files --others`), the same two reads verify's
+// own `changedPaths` makes. Deliberately unfiltered — engine state and all
+// — because a path recorded here only ever makes the gate more forgiving
+// of something it already ignored.
+function dirtyPaths() {
+  const run = (args) =>
+    execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  const tracked = run(['diff', '--name-only', 'HEAD']);
+  const untracked = run(['ls-files', '--others', '--exclude-standard']);
+  return [
+    ...new Set(
+      [...tracked.split('\n'), ...untracked.split('\n')].map((p) => p.trim()).filter(Boolean),
+    ),
+  ];
+}
+
+// The JSON snapshot stored on the lease, or null when the working tree
+// can't be read at all (not a git repo, no commits yet). null is the
+// honest answer rather than an empty snapshot: an empty snapshot claims
+// "nothing was dirty", which would attribute the whole tree to the task,
+// whereas null tells the gate it has no attribution information and to
+// fall back to its pre-snapshot behaviour.
+export function snapshotWorkingTree() {
+  try {
+    const snapshot = {};
+    for (const path of dirtyPaths()) snapshot[path] = pathFingerprint(path);
+    return JSON.stringify(snapshot);
+  } catch {
+    return null;
+  }
+}
 
 // Same no-incomplete-dependency shape as next.mjs's READY_TASK_SQL, without
 // the LIMIT 1 — claimTasks may take more than one candidate per call.
@@ -50,7 +123,8 @@ export function reapExpiredLeases(db) {
     `
     UPDATE tasks
     SET status = 'blocked', blocked_reason = 'lease_expired',
-        lease_owner = NULL, lease_expires_at = NULL, leased_at = NULL
+        lease_owner = NULL, lease_expires_at = NULL, leased_at = NULL,
+        claim_snapshot = NULL
     WHERE status IN ('building', 'verifying') AND lease_expires_at < datetime('now')
   `,
   ).run();
@@ -62,7 +136,8 @@ export function reapExpiredLeases(db) {
 const claimOne = (db) =>
   db.prepare(`
     UPDATE tasks SET status = 'building', lease_owner = ?, leased_at = datetime('now'),
-      lease_expires_at = datetime('now', '+' || ? || ' minutes')
+      lease_expires_at = datetime('now', '+' || ? || ' minutes'),
+      claim_snapshot = ?
     WHERE id = ? AND status IN ('planned','ready') AND lease_owner IS NULL
     RETURNING id
   `);
@@ -83,6 +158,14 @@ const claimOne = (db) =>
 // and doesn't count against `count` — it neither joins the batch nor
 // short-circuits the loop.
 export function claimTasks(db, { owner, count = 1, leaseMinutes = 45 }) {
+  ensureTaskColumns(db);
+  // Read the working tree *before* BEGIN — this file keeps verify.mjs's
+  // rule that no subprocess runs with a sqlite transaction open. One
+  // snapshot serves the whole batch: they all start from the same tree.
+  // Taking it a moment early can only miss a path dirtied in between,
+  // which leaves that path attributed — the strict direction.
+  const claimSnapshot = snapshotWorkingTree();
+
   return inTransaction(db, () => {
     reapExpiredLeases(db);
 
@@ -95,7 +178,7 @@ export function claimTasks(db, { owner, count = 1, leaseMinutes = 45 }) {
       if (claimed.length >= count) break;
       const against = [...inFlight, ...claimed];
       if (against.some((accepted) => conflicts(candidate, accepted) !== null)) continue;
-      const result = runClaim.get(owner, leaseMinutes, candidate.id);
+      const result = runClaim.get(owner, leaseMinutes, claimSnapshot, candidate.id);
       if (result === undefined) continue; // lost the race, skip
       claimed.push(loadTask(db, candidate.id));
     }
@@ -117,7 +200,7 @@ export function releaseTask(db, taskId, owner) {
       .prepare(
         `
         UPDATE tasks SET status = 'ready', lease_owner = NULL,
-          lease_expires_at = NULL, leased_at = NULL
+          lease_expires_at = NULL, leased_at = NULL, claim_snapshot = NULL
         WHERE id = ? AND lease_owner = ? AND status = 'building'
         RETURNING id
       `,

--- a/src/db/claim.mjs
+++ b/src/db/claim.mjs
@@ -3,7 +3,7 @@
 // columns added to `tasks` in schema.mjs.
 
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readlinkSync, lstatSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 
 import { inTransaction } from './init.mjs';
@@ -20,25 +20,65 @@ import { ensureTaskColumns } from './schema.mjs';
 // there: an uncommitted friction log, a half-finished edit of the user's,
 // a neighbour's stray write.
 //
-// So the claim records what the tree already looked like. A path whose
-// content is byte-identical to what it was at claim time did not change
-// during this task's lease, and cannot be this task's doing. Anything
-// else still is — which is why this narrows attribution without ever
-// letting a real out-of-scope write through: writing a file *changes* it,
-// and a changed fingerprint is attributed.
+// So the claim records what the tree already looked like. A path that is
+// identical to what it was at claim time did not change during this
+// task's lease, and cannot be this task's doing. Anything else still is
+// — which is why this narrows attribution without ever letting a real
+// out-of-scope write through: a fingerprint that moved is attributed.
+//
+// "Identical" has to mean identical *to git*, not merely byte-identical
+// in content. Git tracks a file's type and its one permission bit as
+// well as its bytes, so a `chmod +x` or a retargeted symlink is a real,
+// committable change to an out-of-scope path — and a fingerprint blind
+// to those would let the gate be stepped around by making exactly that
+// kind of change to a path that happened to be dirty already.
 
-// Sentinel fingerprint for a path git reports as dirty but that isn't
-// readable as a file — a deletion, most often. Distinct from any sha1, so
-// "deleted at claim time, still deleted now" matches and "present at claim
-// time, deleted now" doesn't.
+// Sentinel fingerprint for a path git reports as dirty but that can't be
+// examined at all — a deletion, most often. Distinct from every real
+// fingerprint below, so "deleted at claim time, still deleted now"
+// matches and "present at claim time, deleted now" doesn't.
 const ABSENT = 'absent';
 
-// sha1 of the file's bytes, or ABSENT when it can't be read. Exported so
-// verify.mjs fingerprints paths the exact same way it was done here — two
-// implementations that drifted would silently mis-attribute.
+const sha1 = (data) => createHash('sha1').update(data).digest('hex');
+
+// Fingerprints a working-tree path over everything git would record
+// about it, and nothing it wouldn't:
+//
+//   - the entry's type, as a prefix, so swapping a file for a symlink to
+//     an identical payload never fingerprints the same;
+//   - for a symlink, its target — git stores a symlink as a blob holding
+//     the target string, so retargeting one is a content change. Read
+//     with readlink rather than following the link: following it would
+//     fingerprint whatever it points at, which is how a retarget to a
+//     same-content file slipped through;
+//   - for a regular file, the owner-execute bit (git's 100644 vs 100755
+//     distinction) and the bytes. Only that one bit: every other
+//     permission bit is invisible to git, and folding those in would
+//     make the gate fire on changes git itself never sees.
+//
+// A path deleted and recreated identically fingerprints the same, which
+// is correct — git calls that path clean, so it never reaches the gate.
+//
+// Cost is one lstat plus one read per dirty path, no subprocess, so this
+// stays cheap over a large working tree.
+//
+// Exported so verify.mjs fingerprints paths the exact same way they were
+// fingerprinted here — two implementations that drifted would silently
+// mis-attribute.
 export function pathFingerprint(path) {
+  let stats;
   try {
-    return createHash('sha1').update(readFileSync(path)).digest('hex');
+    stats = lstatSync(path);
+  } catch {
+    return ABSENT;
+  }
+  try {
+    if (stats.isSymbolicLink()) return `l:${sha1(readlinkSync(path))}`;
+    if (stats.isFile()) return `f${stats.mode & 0o100 ? '755' : '644'}:${sha1(readFileSync(path))}`;
+    // Anything else (fifo, socket, device, directory) is not something
+    // git can hold, but it is something a path can be turned into —
+    // record the type so that turning it into one is still a change.
+    return `o:${(stats.mode & 0o170000).toString(8)}`;
   } catch {
     return ABSENT;
   }

--- a/src/db/schema.mjs
+++ b/src/db/schema.mjs
@@ -52,6 +52,14 @@ CREATE TABLE IF NOT EXISTS tasks (
   lease_owner      TEXT,
   lease_expires_at TEXT,
   leased_at        TEXT,
+  -- JSON map of path → content fingerprint for every path the working
+  -- tree was already dirty at the instant this task was claimed. Part of
+  -- the lease (written by claim, cleared with the lease), and read by
+  -- verify's scope gate so a path that has not changed since the claim is
+  -- never attributed to this task. NULL means "no snapshot" — the gate
+  -- then falls back to attributing the whole dirty tree, its pre-snapshot
+  -- behaviour.
+  claim_snapshot   TEXT,
   created_at     TEXT NOT NULL DEFAULT (datetime('now')),
   CHECK ((lease_owner IS NULL) = (status NOT IN ('building','verifying')))
 );
@@ -95,8 +103,28 @@ CREATE TABLE IF NOT EXISTS friction (
 );
 `;
 
+// Columns added to `tasks` after the first schema shipped. `CREATE TABLE
+// IF NOT EXISTS` above is a no-op against a DB created by an earlier
+// version, so a new column has to be ALTERed in explicitly or every
+// statement naming it fails on that DB. Each entry is `[name, ddl]`.
+const TASK_COLUMN_MIGRATIONS = [['claim_snapshot', 'claim_snapshot TEXT']];
+
+// Brings an already-created `tasks` table up to the current column set.
+// Idempotent and cheap (one PRAGMA), so callers that must not fail on a
+// missing column — claim, which writes the snapshot, and verify, which
+// clears it — can just call it before they touch the table. Requires a
+// writable handle; read-only commands never need it, since a missing
+// column only ever reads back as undefined.
+export function ensureTaskColumns(db) {
+  const existing = new Set(db.prepare('PRAGMA table_info(tasks)').all().map((row) => row.name));
+  for (const [name, ddl] of TASK_COLUMN_MIGRATIONS) {
+    if (!existing.has(name)) db.exec(`ALTER TABLE tasks ADD COLUMN ${ddl}`);
+  }
+}
+
 // Applies the schema to an already-open node:sqlite DatabaseSync instance.
 // Idempotent: safe to call against a DB that already has these tables.
 export function applySchema(db) {
   db.exec(SCHEMA_SQL);
+  ensureTaskColumns(db);
 }

--- a/src/db/verify.mjs
+++ b/src/db/verify.mjs
@@ -12,11 +12,14 @@
 //
 // Two gates, in order:
 //   1. `git diff --name-only` (working tree) against the task's
-//      scope_globs, with paths inside any other in-flight task's own
-//      declared scope excluded first — those are a concurrent neighbor's
-//      legitimate uncommitted edits, not this task's violation, since
-//      there's no working-tree isolation between concurrent tasks by
-//      design. Any remaining touched path outside scope refuses to run
+//      scope_globs, with two classes of path excluded first, because
+//      there is no working-tree isolation between concurrent tasks by
+//      design and the diff therefore sees far more than this task's own
+//      work: paths whose content is unchanged since the task was claimed
+//      (they cannot be this task's doing — see attributedToTask), and
+//      paths inside any other in-flight task's own declared scope (a
+//      concurrent neighbor's legitimate uncommitted edits). Any remaining
+//      touched path outside scope refuses to run
 //      verification at all — the task moves to `blocked` with
 //      blocked_reason `scope_violation`, no `verifications` row written,
 //      lease released. This is a scope violation, not a failing check.
@@ -50,7 +53,8 @@
 import { execSync } from 'node:child_process';
 import { DB_PATH } from './init.mjs';
 import { withCommitLock, LOCK_PATH } from './commitLock.mjs';
-import { reapExpiredLeases } from './claim.mjs';
+import { reapExpiredLeases, pathFingerprint } from './claim.mjs';
+import { ensureTaskColumns } from './schema.mjs';
 
 // The build graph file and the commit lock are engine state, written
 // only by this CLI, never by an agent — both are excluded from every
@@ -84,6 +88,38 @@ function changedPaths(pathspecs) {
     [...tracked.split('\n'), ...untracked.split('\n')].map((p) => p.trim()).filter(Boolean),
   );
   return [...paths].filter((p) => !isEngineStatePath(p));
+}
+
+// Narrows a set of touched paths to the ones this task can actually be
+// held responsible for: those whose content differs from the claim-time
+// snapshot claim.mjs recorded on the lease. A path that is byte-identical
+// to what it was when the task was claimed did not change during the
+// lease, so no amount of dirtiness there is this task's doing — an
+// uncommitted friction log, the user's own half-finished edit, a stray
+// file some tool left behind before the claim.
+//
+// This narrows attribution without weakening the gate. A genuine
+// out-of-scope write necessarily *changes* the file, so its fingerprint
+// no longer matches the snapshot and it stays attributed; the only paths
+// this drops are ones where the task provably changed nothing. (A task
+// that wrote a byte-identical copy over pre-existing dirt is the one
+// exempted edge, and it changed nothing to commit either.)
+//
+// `claimSnapshot` is null for a lease taken before snapshots existed, or
+// in a working tree git couldn't read at claim time. Null means "no
+// attribution information", and the gate falls back to attributing
+// everything dirty — the stricter, pre-snapshot behaviour.
+function attributedToTask(touched, claimSnapshot) {
+  if (!claimSnapshot) return touched;
+  let snapshot;
+  try {
+    snapshot = JSON.parse(claimSnapshot);
+  } catch {
+    return touched;
+  }
+  return touched.filter(
+    (path) => !Object.hasOwn(snapshot, path) || snapshot[path] !== pathFingerprint(path),
+  );
 }
 
 // Every other task currently `building` or `verifying` — their declared
@@ -143,10 +179,19 @@ function setTaskStatus(db, taskId, status, { blockedReason } = {}) {
       blocked_reason = ?,
       lease_owner = CASE WHEN ? THEN NULL ELSE lease_owner END,
       lease_expires_at = CASE WHEN ? THEN NULL ELSE lease_expires_at END,
-      leased_at = CASE WHEN ? THEN NULL ELSE leased_at END
+      leased_at = CASE WHEN ? THEN NULL ELSE leased_at END,
+      claim_snapshot = CASE WHEN ? THEN NULL ELSE claim_snapshot END
     WHERE id = ?
   `,
-  ).run(status, blockedReason ?? null, releasesLease ? 1 : 0, releasesLease ? 1 : 0, releasesLease ? 1 : 0, taskId);
+  ).run(
+    status,
+    blockedReason ?? null,
+    releasesLease ? 1 : 0,
+    releasesLease ? 1 : 0,
+    releasesLease ? 1 : 0,
+    releasesLease ? 1 : 0,
+    taskId,
+  );
 }
 
 const insertVerification = (db) =>
@@ -279,6 +324,10 @@ function commitTouchedPaths(paths, commitMessage) {
 // run verification against a task it doesn't hold.
 function claimForVerify(db, taskId, owner) {
   let task;
+  // Before BEGIN, and before any statement below names claim_snapshot: a
+  // DB created by an earlier version has no such column, and both the
+  // status writes here and the gate's snapshot read depend on it.
+  ensureTaskColumns(db);
   db.exec('BEGIN IMMEDIATE');
   try {
     // Reaps this (and any other) task's lease if lease_expires_at has
@@ -330,7 +379,13 @@ export function verifyTask(db, taskId, owner) {
   // (generated lockfiles, formatted output), and committing a stale
   // pre-verify_command snapshot would silently drop those.
   const { offending } = withCommitLock(() => {
-    const touchedNow = changedPaths();
+    // Only what changed during this task's lease is this task's to answer
+    // for; everything else in the shared working tree was already there
+    // when the task was handed out. The commit set below is deliberately
+    // *not* filtered this way — it is scope-restricted already, and a
+    // pre-existing dirty file inside the task's own scope is still swept
+    // into the layer's commit exactly as before.
+    const touchedNow = attributedToTask(changedPaths(), task.claim_snapshot);
     return splitByScope(db, taskId, touchedNow, scopeGlobs);
   });
 

--- a/src/db/verify.mjs
+++ b/src/db/verify.mjs
@@ -91,18 +91,21 @@ function changedPaths(pathspecs) {
 }
 
 // Narrows a set of touched paths to the ones this task can actually be
-// held responsible for: those whose content differs from the claim-time
-// snapshot claim.mjs recorded on the lease. A path that is byte-identical
+// held responsible for: those whose fingerprint differs from the
+// claim-time snapshot claim.mjs recorded on the lease. A path identical
 // to what it was when the task was claimed did not change during the
 // lease, so no amount of dirtiness there is this task's doing — an
 // uncommitted friction log, the user's own half-finished edit, a stray
 // file some tool left behind before the claim.
 //
 // This narrows attribution without weakening the gate. A genuine
-// out-of-scope write necessarily *changes* the file, so its fingerprint
-// no longer matches the snapshot and it stays attributed; the only paths
-// this drops are ones where the task provably changed nothing. (A task
-// that wrote a byte-identical copy over pre-existing dirt is the one
+// out-of-scope change necessarily moves the fingerprint, so it stays
+// attributed; the only paths this drops are ones where the task provably
+// changed nothing. That rests entirely on pathFingerprint covering
+// everything git would commit about a path — its bytes, its type, and
+// its executable bit — and not merely its contents; see its comment for
+// why a content-only fingerprint let a `chmod +x` walk through. (A task
+// that rewrote an identical file over pre-existing dirt is the one
 // exempted edge, and it changed nothing to commit either.)
 //
 // `claimSnapshot` is null for a lease taken before snapshots existed, or


### PR DESCRIPTION
`hedgehog verify` judges a task on **everything dirty in the repository**, not on what that task changed. `verifyTask` calls `changedPaths()` with no pathspec, so every dirty path becomes a candidate violation and the whole tree is attributed to whoever verifies first.

On a real build this blocked a task whose agent had touched nothing outside its scope: an uncommitted friction log elsewhere in the repo was enough.

## What I found differs from how I reported it

I opened this expecting a tracked/untracked asymmetry — tracked files blocking, untracked ones silently ignored. **That is wrong, and the experiment says so.** `changedPaths` reads both halves symmetrically, and `splitByScope` treats them identically:

```js
const offending = touched.filter((path) => !inScopeSet.has(path) && !neighborOwned.has(path));
```

Probes against master, with a task scoped to `pkg-a/**`:

| probe | result on master |
|---|---|
| tracked `docs/notes.md` dirty, no neighbour in flight | `scope_violation` |
| **untracked** `other/new-dir/file.txt`, no neighbour in flight | **`scope_violation`** |
| untracked file inside a *neighbour's* declared scope | exit 0, commit held only `pkg-a/src/index.js` |
| file dirtied *during* `verify_command` | exit 0, not committed |

So what actually exonerates a concurrent agent's files is a different rule entirely — `splitByScope`'s `neighborOwned` subtraction via `loadOtherInFlightScopes`. The file that looked "ignored because untracked" was in fact inside its own task's declared scope.

Two further corrections while I was in there:

- **"Re-dirtied during the verify command" does not block on its own.** Gate 1 runs before `runVerifyCommand`. The reported "impossible to win by committing first" is real but one step removed: the *previous* run's write is still dirty at the *next* verify's gate 1. That is what is reproduced and fixed here.
- **On the scheduler premise:** `conflict.mjs`'s `globsOverlap` is segment-prefix based, so two tasks declaring the same shared seam do conflict and are never co-scheduled. The reachable hazard is narrower than "the scheduler authorizes what the gate rejects" — it is a seam in *nobody's* declared scope, which is a genuine violation by whichever agent wrote it, merely misattributed to whichever task verifies first.

The defect that survives all of that is the one worth fixing, and it is the original principle: **a task should be judged on what it changed.**

## The fix

`hedgehog claim` snapshots the dirty working tree as a `path -> sha1` map onto the lease (`tasks.claim_snapshot`), and gate 1 drops any path byte-identical to that snapshot.

- `src/db/claim.mjs` — `pathFingerprint` / `snapshotWorkingTree`, taken **before** `BEGIN`, respecting this file's existing rule that no subprocess runs with a sqlite transaction open. One snapshot per batch; cleared on release and on lease reap.
- `src/db/verify.mjs` — `attributedToTask(changedPaths(), task.claim_snapshot)`.
- `src/db/schema.mjs` — the new column plus `ensureTaskColumns`, an idempotent `ALTER` (`CREATE TABLE IF NOT EXISTS` is a no-op on an existing graph). Verified end-to-end against a DB built from the old schema with a task already `building`: the column is added on the fly, verify falls back to master's behaviour, exit 0.

**The gate is not weakened.** Writing a file changes its bytes, so a real out-of-scope write has a different fingerprint and stays attributed. The only exemption is a task that rewrote byte-identical content over pre-existing dirt — which changed nothing and has nothing to commit. A null snapshot falls back to attribute-everything, so the degraded mode is the strict one. The commit set is untouched; it was already scope-restricted.

**Why the alternatives lost.** An ignore list is a blanket amnesty: a listed path could be written out of scope with impunity, which is exactly the "makes a genuine violation pass" case. Its stated justification — harness writes during verify — turned out to be already handled. It also cannot be implemented within these files, since it would need a `core.yaml` field carried through `core.mjs` and `plan.mjs`, and that is a planner-owned surface and a design decision rather than a bug fix. Treating tracked and untracked differently was moot once the symmetry above was established, and inheriting `.gitignore` adds nothing because `--exclude-standard` already applies.

## Known limitation, deliberately pinned by a test

A path outside every declared scope, changed during the lease by someone else, still blocks whoever verifies first. Exonerating that would make any out-of-scope write forgivable whenever another task happens to be in flight. `repro/05` asserts it keeps failing, so a future change cannot loosen it by accident.

## Evidence

`node --experimental-sqlite repro/run-all.mjs` — a shared `lib.mjs` plus five scripts, plain assertions, no framework, `node:sqlite`, driving the real CLI in throwaway temp dirs.

| | before | after |
|---|---|---|
| 01 genuine out-of-scope write (tracked, untracked, and re-dirtying a pre-existing file) | pass | pass |
| 02 unrelated dirty tracked file, plus a shared seam under a real two-task fan-out | **9 assertions fail** | pass |
| 03 unrelated untracked file, plus contrast cases | **3 fail** | pass |
| 04 telemetry file dirty at claim and re-dirtied during verify | **3 fail** | pass |
| 05 known limitation above | pass | pass |

`run-all` exits 1 before and 0 after. Script 01 passing on **both** sides is the load-bearing one — it is the regression guard proving the gate still catches a real violation. `node scripts/check.mjs` passes.

## Conflict with #16

Expected and textual only. The hunks here touch the file header, the import line, a new `attributedToTask` above `loadOtherInFlightScopes`, `setTaskStatus`'s UPDATE, `claimForVerify`'s opening, and the `withCommitLock` block. #16 rewrites the internals of `changedPaths`/`commitTouchedPaths`/`classifyArtifacts` and deletes `quotePathspec`.

**No new uses of `quotePathspec` are added here**, and the new git calls in `claim.mjs` already use `execFileSync` with argv arrays — so the two changes are compatible in substance and only collide in text. Happy to rebase onto whichever lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
