### PR TITLE
fix(full-stack-app): repair verify commands that cannot run, and lint the core definition so they cannot recur

### DIFF
--- a/repro/core-verify-lint.mjs
+++ b/repro/core-verify-lint.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+// Lint over the shipped Golden Cores' verify commands, plus the regression
+// fixture for the bugs it was written from.
+//
+// Run: node repro/core-verify-lint.mjs
+//
+// ── What went wrong ──────────────────────────────────────────────────
+// src/golden-cores/full-stack-app/core.yaml shipped verify commands that
+// could not run at all against the workspace the same directory ships:
+//
+//   1. `pnpm nx test db --testPathPattern={module}` (and five more like it).
+//      `--testPathPattern` is a Jest flag. This core pins `vitest ~4.1.0`,
+//      and Vitest's CLI parser rejects unknown options outright:
+//        CACError: Unknown option `--testPathPattern`
+//      Every one of those gates aborted before running a single test — a
+//      gate that could never pass, whatever the code did.
+//
+//   2. `pnpm typecheck && pnpm nx run-many -t test` on the join layer.
+//      The core's package.json defines exactly one script, `dev`:
+//        ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "typecheck" not found
+//
+//   3. A bare `{module}` as the test filter. Vitest's positional filter is
+//      a substring match against the whole test file path, so a module
+//      named `card` also pulled in `src/board/use-board-cards.spec.ts` —
+//      and a module named `list` hit `vitest list`, Vitest's
+//      list-collected-tests subcommand, which prints the collected tests
+//      and exits 0. That is a gate that cannot fail.
+//
+// Both (1) and (2) are decidable from the core definition alone — no
+// workspace, no install, no network. That is what this file automates, so
+// the next core that ships a verify command naming a flag or a script that
+// does not exist fails here instead of on someone's first build.
+
+import { readFile, readdir, access } from 'node:fs/promises';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseCoreYaml, validateCore } from '../src/db/core.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const CORES_DIR = join(ROOT, 'src/golden-cores');
+
+const failures = [];
+const fail = (msg) => failures.push(msg);
+
+// ── Flags that belong to Jest and do not exist in Vitest's CLI. Vitest
+//    exits on the first unknown option, so any of these is a gate that can
+//    never pass. ────────────────────────────────────────────────────────
+const JEST_ONLY_FLAGS = [
+  'testPathPattern',
+  'testPathPatterns',
+  'testPathIgnorePatterns',
+  'runTestsByPath',
+  'runInBand',
+  'detectOpenHandles',
+  'forceExit',
+  'collectCoverageFrom',
+  'moduleNameMapper',
+  'setupFilesAfterEnv',
+  'testMatch',
+  'roots',
+];
+
+// ── `pnpm <word>` is a package.json script unless <word> is one of pnpm's
+//    own subcommands or a binary from a declared dependency. ────────────
+const PNPM_SUBCOMMANDS = new Set([
+  'add', 'audit', 'bin', 'config', 'create', 'dedupe', 'deploy', 'dlx', 'env',
+  'exec', 'fetch', 'i', 'import', 'init', 'install', 'licenses', 'link', 'list',
+  'ls', 'outdated', 'pack', 'patch', 'prune', 'publish', 'rebuild', 'remove',
+  'root', 'run', 'server', 'setup', 'start', 'store', 'test', 'unlink', 'update',
+  'why', 'why-command',
+]);
+
+// ── Projects the core ships whose `nx test` target does not exist yet.
+//    Each entry is a known-open defect, not a style exemption: the shipped
+//    apps/api and apps/web carry no vitest config, so they have no `test`
+//    target, and a verify naming `nx test api`/`nx test web` dies with
+//    "Cannot find configuration for task api:test" no matter how the
+//    filter is spelled. Fixing it means adding a vitest config, a spec,
+//    and (for web) jsdom + @testing-library to the core — a core
+//    regeneration, tracked separately. The lint fails if an entry here
+//    becomes unnecessary, so the list cannot rot. ───────────────────────
+const KNOWN_MISSING_TEST_TARGET = {
+  'full-stack-app': ['api', 'web'],
+};
+
+const exists = async (p) => {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+// Splits a verify command on shell operators into individual commands.
+const splitCommands = (verify) =>
+  verify
+    .split(/&&|\|\||;|(?<!\|)\|(?!\|)/)
+    .map((c) => c.trim())
+    .filter(Boolean);
+
+// ── Check 1: no Jest-only flag anywhere in a verify command. ───────────
+function checkJestFlags(label, verify) {
+  for (const flag of JEST_ONLY_FLAGS) {
+    if (new RegExp(`--${flag}\\b`).test(verify)) {
+      fail(
+        `${label}: verify uses Jest-only flag \`--${flag}\` — this core runs Vitest, ` +
+          `whose CLI exits with "CACError: Unknown option" before any test runs`,
+      );
+    }
+  }
+}
+
+// ── Check 2: every `pnpm <script>` a verify names exists. ──────────────
+function checkPnpmScripts(label, verify, pkg) {
+  if (!pkg) return;
+  const scripts = new Set(Object.keys(pkg.scripts ?? {}));
+  const deps = new Set([
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.devDependencies ?? {}),
+  ]);
+  for (const command of splitCommands(verify)) {
+    const tokens = command.split(/\s+/);
+    if (tokens[0] !== 'pnpm') continue;
+    // skip pnpm's own flags (`pnpm --filter x exec ...`)
+    let i = 1;
+    while (i < tokens.length && tokens[i].startsWith('-')) i += 2;
+    const name = tokens[i];
+    if (!name || PNPM_SUBCOMMANDS.has(name) || deps.has(name)) continue;
+    if (!scripts.has(name)) {
+      fail(
+        `${label}: verify runs \`pnpm ${name}\`, but the core's package.json defines no ` +
+          `"${name}" script (has: ${[...scripts].join(', ') || 'none'})`,
+      );
+    }
+  }
+}
+
+// ── Check 3: a {module} used as a test filter is path-anchored. ────────
+//    A bare `{module}` token is a substring match against the whole test
+//    file path; it must carry its layer's directory and a trailing slash.
+function checkAnchoredFilter(label, verify) {
+  for (const token of verify.split(/\s+/)) {
+    if (!token.includes('{module}')) continue;
+    if (token === '{module}') {
+      fail(
+        `${label}: verify passes a bare \`{module}\` as a test filter — Vitest matches it ` +
+          `as a substring of the whole file path, so it also selects another module's files ` +
+          `(and a module named "list" hits \`vitest list\`, which exits 0 without running ` +
+          `anything). Anchor it on the layer's own directory, e.g. \`src/schema/{module}/\``,
+      );
+    } else if (token.startsWith('{module}/') || (token.includes('/') && !token.endsWith('/'))) {
+      fail(
+        `${label}: test-filter path \`${token}\` is not anchored on the layer's own directory ` +
+          `with a trailing slash`,
+      );
+    }
+  }
+}
+
+// ── Check 4: `nx test <project>` names a project with a test target. ───
+async function checkNxTestTargets(coreName, coreDir, label, verify) {
+  const shipped = new Map(); // project name -> project dir
+  for (const group of ['apps', 'packages']) {
+    const groupDir = join(coreDir, group);
+    if (!(await exists(groupDir))) continue;
+    for (const entry of await readdir(groupDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const pkgPath = join(groupDir, entry.name, 'package.json');
+      if (!(await exists(pkgPath))) continue;
+      const { name } = JSON.parse(await readFile(pkgPath, 'utf8'));
+      if (name) shipped.set(name, join(groupDir, entry.name));
+    }
+  }
+  const allowed = new Set(KNOWN_MISSING_TEST_TARGET[coreName] ?? []);
+  for (const m of verify.matchAll(/\bnx\s+test\s+([A-Za-z0-9@/._-]+)/g)) {
+    const project = m[1];
+    if (project.includes('{module}')) continue; // per-module project, generated later
+    const dir = shipped.get(project);
+    if (!dir) continue; // not shipped by the core (add-on or loop-created)
+    const hasVitest = (
+      await Promise.all(
+        ['vitest.config.mts', 'vitest.config.ts', 'vitest.config.mjs', 'vitest.config.js'].map(
+          (f) => exists(join(dir, f)),
+        ),
+      )
+    ).some(Boolean);
+    if (!hasVitest && !allowed.has(project)) {
+      fail(
+        `${label}: verify runs \`nx test ${project}\`, but the shipped ${project} project has ` +
+          `no vitest config, so it has no \`test\` target ("Cannot find configuration for ` +
+          `task ${project}:test")`,
+      );
+    }
+    if (hasVitest && allowed.has(project)) {
+      fail(
+        `KNOWN_MISSING_TEST_TARGET["${coreName}"] still lists "${project}", but that project ` +
+          `now ships a vitest config — drop the entry`,
+      );
+    }
+  }
+}
+
+// ── Lint the shipped cores ────────────────────────────────────────────
+const coreNames = (await readdir(CORES_DIR, { withFileTypes: true }))
+  .filter((e) => e.isDirectory())
+  .map((e) => e.name);
+
+for (const coreName of coreNames) {
+  const coreDir = join(CORES_DIR, coreName);
+  const core = parseCoreYaml(await readFile(join(coreDir, 'core.yaml'), 'utf8'));
+  validateCore(core);
+
+  const pkgPath = join(coreDir, 'package.json');
+  const pkg = (await exists(pkgPath)) ? JSON.parse(await readFile(pkgPath, 'utf8')) : null;
+
+  for (const layer of core.layers) {
+    const label = `${coreName}/core.yaml layer "${layer.id}"`;
+    checkJestFlags(label, layer.verify);
+    checkPnpmScripts(label, layer.verify, pkg);
+    checkAnchoredFilter(label, layer.verify);
+    await checkNxTestTargets(coreName, coreDir, label, layer.verify);
+  }
+}
+
+// ── Regression fixture: the exact strings that shipped in 4.0.3 must be
+//    rejected by the checks above. Without this the lint could silently
+//    stop detecting the bug it was written for. ─────────────────────────
+const SHIPPED_4_0_3 = [
+  ['schema', 'pnpm nx test db --testPathPattern={module}'],
+  ['contract', 'pnpm nx test contracts --testPathPattern={module}'],
+  ['controller', 'pnpm nx test api --testPathPattern={module}'],
+  ['hook', 'pnpm nx test hooks --testPathPattern={module}'],
+  [
+    'screen',
+    'pnpm nx test web --testPathPattern={module} && pnpm nx test mobile --testPathPattern={module}',
+  ],
+  ['join', 'pnpm typecheck && pnpm nx run-many -t test'],
+];
+const UNANCHORED = [['hook', 'pnpm nx test hooks -- {module}']];
+
+{
+  const fsaPkg = JSON.parse(
+    await readFile(join(CORES_DIR, 'full-stack-app/package.json'), 'utf8'),
+  );
+  for (const [layerId, verify] of SHIPPED_4_0_3) {
+    const before = failures.length;
+    const label = `fixture "${layerId}"`;
+    checkJestFlags(label, verify);
+    checkPnpmScripts(label, verify, fsaPkg);
+    if (failures.length === before) {
+      fail(`regression fixture: shipped 4.0.3 ${layerId} verify was NOT detected: ${verify}`);
+    } else {
+      failures.length = before; // expected — discard
+    }
+  }
+  for (const [layerId, verify] of UNANCHORED) {
+    const before = failures.length;
+    checkAnchoredFilter(`fixture "${layerId}"`, verify);
+    if (failures.length === before) {
+      fail(`regression fixture: unanchored {module} filter was NOT detected: ${verify}`);
+    } else {
+      failures.length = before;
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} verify-command check(s) failed:\n`);
+  for (const f of failures) console.error(`  ✗ ${f}`);
+  console.error('');
+  process.exit(1);
+}
+console.log(
+  `ok — verify commands lint clean across ${coreNames.length} cores ` +
+    `(${coreNames.join(', ')}), and the 4.0.3 regression fixture is still detected`,
+);

--- a/src/golden-cores/full-stack-app/core.yaml
+++ b/src/golden-cores/full-stack-app/core.yaml
@@ -19,17 +19,71 @@
 # type/integration breakage isn't caught at the task that caused it once
 # schema/hook run per-module; join catches it once, after every module's
 # layers land, in exchange for those layers running in parallel.
+#
+# ── How the test filter is spelled, and why ──────────────────────────
+# This core runs Vitest 4, not Jest. `--testPathPattern=` is a Jest flag;
+# Vitest's CLI parser (CAC) rejects unknown options outright, so every
+# templated verify died with `CACError: Unknown option --testPathPattern`
+# before a single test ran — a gate that could never pass, whatever the
+# code did. Vitest's own file filter is positional, and `nx test <project>
+# -- <args>` forwards everything after `--` to the underlying command
+# (verified against a real instantiated workspace: `nx run db:test
+# src/schema/board/` → `vitest src/schema/board/`).
+#
+# Each filter is anchored on the layer's own scope directory, relative to
+# that project's root — `src/schema/{module}/`, never a bare `{module}`.
+# A bare module name is a substring match against the whole test file
+# path, so `card` also matches `src/board/use-board-cards.spec.ts` and
+# verifies (or fails on) another module's work. Worse, several plausible
+# module names are Vitest subcommands: `vitest list` runs Vitest's
+# list-collected-tests command, which prints the collected tests and
+# exits 0 — measured, with a deliberately broken test in place, on a
+# module named `list`. That is a gate that cannot fail. The trailing
+# slash matters too: it keeps `src/{module}/` from matching a sibling
+# directory that merely starts with the same characters.
+#
+# A filter that matches nothing exits 1 ("No test files found"), so a
+# layer that lands source with no test is caught rather than waved
+# through.
+#
+# ── screen and the optional Mobile add-on ────────────────────────────
+# `apps/mobile` exists only when planning intake turns the Mobile add-on
+# on (.hedgehog/addons.yaml); the core itself never lands it. So the
+# shipped verify runs web only — the half that is always true. core.yaml's
+# grammar is flat scalars with no conditional, so it cannot express "also
+# run mobile, if mobile exists", and the shell tricks that could are all
+# gates that pass silently when they do nothing: `nx run-many -t test -p
+# mobile` exits 0 with "No tasks were run" when no such project exists —
+# and equally when mobile exists but its test target does not. Extending
+# this layer's verify with `&& pnpm nx test mobile -- src/{module}/`
+# belongs to hedgehog-bootstrap's Mobile add-on step, alongside the
+# `nx g @nx/expo:app apps/mobile` that creates the project. Until then
+# join's run-many sweep is what covers apps/mobile. The mobile scope glob
+# stays either way: with the add-on on, the screen layer must be allowed
+# to write there.
+#
+# ── join ─────────────────────────────────────────────────────────────
+# join runs the same typecheck/lint/test sweep
+# hedgehog-bootstrap-full-stack-app-core verifies the workspace with. The
+# template's `pnpm typecheck` named a root package.json script this core
+# has never defined (its only script is `dev`), so join died with
+# `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "typecheck" not found`.
+# The typecheck target itself is real — nx.json registers it through the
+# @nx/js/typescript plugin — so run-many reaches it directly with no root
+# script to keep in sync. Keeping typecheck in join is what makes a
+# type-only regression (which Vitest's esbuild transform strips rather
+# than reports) fail somewhere.
 id: full-stack-app
 layers:
   - id: schema
     scope: ["packages/db/src/schema/{module}/**"]
-    verify: "pnpm nx test db --testPathPattern={module}"
+    verify: "pnpm nx test db -- src/schema/{module}/"
     verify_radius: ["packages/db/**"]
     commit: "feat({module}): schema"
   - id: contract
     depends_on: schema
     scope: ["packages/contracts/src/{module}/**"]
-    verify: "pnpm nx test contracts --testPathPattern={module}"
+    verify: "pnpm nx test contracts -- src/{module}/"
     commit: "feat({module}): contract"
   - id: repository
     depends_on: contract
@@ -44,22 +98,22 @@ layers:
   - id: controller
     depends_on: service
     scope: ["apps/api/src/app/{module}/**"]
-    verify: "pnpm nx test api --testPathPattern={module}"
+    verify: "pnpm nx test api -- src/app/{module}/"
     commit: "feat({module}): api"
   - id: hook
     depends_on: controller
     scope: ["packages/hooks/src/{module}/**"]
-    verify: "pnpm nx test hooks --testPathPattern={module}"
+    verify: "pnpm nx test hooks -- src/{module}/"
     verify_radius: ["packages/hooks/**"]
     commit: "feat({module}): hooks"
   - id: screen
     depends_on: hook
     scope: ["apps/web/src/app/{module}/**", "apps/mobile/src/{module}/**"]
-    verify: "pnpm nx test web --testPathPattern={module} && pnpm nx test mobile --testPathPattern={module}"
+    verify: "pnpm nx test web -- src/app/{module}/"
     commit: "feat({module}): screen-web"
   - id: join
     depends_on: screen
     scope: ["**"]
-    verify: "pnpm typecheck && pnpm nx run-many -t test"
+    verify: "pnpm nx run-many -t typecheck,lint,test"
     exclusive: true
     commit: "chore({module}): join"


### PR DESCRIPTION
Every project created from the `full-stack-app` Golden Core starts with verify commands that cannot run. This was found while checking an authoring rule against reality, and validated against a **real instantiated workspace** rather than by reading.

## Three confirmed defects

**1. `--testPathPattern` is a Jest flag; this core runs Vitest 4.** Six occurrences across five lines (`schema`, `contract`, `controller`, `hook`, and `screen` which has two). `package.json` pins `"vitest": "~4.1.0"`. Baseline against the real workspace:

```
> nx run db:test --testPathPattern=board
> vitest --testPathPattern=board
CACError: Unknown option `--testPathPattern`   → exit 1
```

The gate aborts before running a single test.

**2. `pnpm typecheck` does not exist.** The core's `package.json` has exactly one script, `dev`. The `join` layer's verify begins with `pnpm typecheck`. Baseline: `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command "typecheck" not found`.

**3. An unanchored `{module}` filter — and this one is worse than a wrong match.** A bare `{module}` is a substring match against the whole path, so `card` also selected `src/board/use-board-cards.spec.ts` (measured: 2 files vs 1).

But `list` is a **Vitest subcommand**, alongside `run`, `related` and `watch`. So for a module named `list` the command becomes `vitest list`, which collects and prints tests and exits 0. Measured, with a deliberately broken `use-list.ts` in place:

```
pnpm nx test hooks -- list        → exit 0     (the `list` subcommand; nothing ran)
pnpm nx test hooks -- src/list/   → exit 1     FAIL src/list/use-list.spec.ts
```

A module named `list` gets a gate that **cannot fail**.

## Validated against a real workspace

`node bin/cli.mjs init --ts-full-stack-app` into a temp dir, `pnpm install` (exit 0, 1.2 GB, lockfile byte-identical to the shipped one), then modules `board`/`list`/`card` scaffolded across all eight layers, plus the projects the core does not ship. Docker was unavailable but is not needed — these tests are pure.

## The fix

| layer | verify |
|---|---|
| schema | `pnpm nx test db -- src/schema/{module}/` |
| contract | `pnpm nx test contracts -- src/{module}/` |
| repository / service | unchanged |
| controller | `pnpm nx test api -- src/app/{module}/` |
| hook | `pnpm nx test hooks -- src/{module}/` |
| screen | `pnpm nx test web -- src/app/{module}/` |
| join | `pnpm nx run-many -t typecheck,lint,test` |

`nx test <project> -- <path>` forwards positionally, verified: `> nx run db:test src/schema/board/` → `> vitest src/schema/board/`. The Nx form was kept rather than `pnpm --filter … exec vitest`, because this core's `verify_radius` reasoning is written against `nx test` and `dependsOn: ["^build"]` is part of the gate.

For `join`, `run-many -t typecheck,lint,test` was chosen over adding a `typecheck` script: it is the exact sweep the bootstrap skill already verifies the workspace with, and it reaches the `typecheck` target `@nx/js/typescript` registers, leaving no root script to drift out of sync.

## A fourth defect, which `core.yaml` genuinely cannot express

`screen`'s verify also ran `pnpm nx test mobile`, but `apps/mobile` only exists when the Mobile add-on is on. With it off there is no project and no target.

The tempting workaround was measured and rejected: `nx run-many -t test -p mobile` exits **0** with "No tasks were run" when the project is absent — and equally when it exists with no test target. That is a gate that silently does nothing, which is the failure mode this core keeps hitting.

`core.yaml`'s grammar is flat scalars with no conditional, so it cannot express "only when this add-on is on". So `screen` now verifies web only; the mobile scope glob stays, since the layer must still be allowed to write there; `join`'s sweep covers `apps/mobile`; and extending the verify belongs to the add-on's own bootstrap step. All of this is documented in the file's header rather than left implicit.

## Evidence

All eight commands were materialized straight out of the fixed `core.yaml` and run against the workspace:

- **Pass:** all 8 exit 0 (`join` = typecheck + lint + test across 10 projects).
- **Fail:** each layer's own artifact broken → all 8 exit 1. `join` was given a **mobile-only** break and still caught it, which is what backs the mobile decision above.
- **Anchoring:** broken board file → `-- card` exits 1 (wrongly failing card's gate), `-- src/card/` exits 0. Broken list file → `-- list` exits 0, `-- src/list/` exits 1.
- **Empty filter:** a module with source and no tests → `No test files found, exiting with code 1`, so a testless layer is caught rather than waved through.

The failing half is the load-bearing one. A gate that runs but cannot fail is the same defect in a different costume.

## A lint over the core definition

`repro/core-verify-lint.mjs` checks both shipped cores for: Jest-only flags; `pnpm <script>` references that do not resolve; unanchored `{module}` filters; and `nx test <project>` naming a shipped project with no test target. It ends with the literal 4.0.3 strings as a regression fixture, so it cannot quietly stop detecting what it was written for.

Against the original `core.yaml` it reports all six defects and exits 1; against the fixed one, exit 0. `node scripts/check.mjs` passes.

This lint is arguably worth more than the fix — it would have caught all of this at authoring time.

## One confirmed defect deliberately left open

**`apps/api` and `apps/web` ship no vitest config, so they have no `nx test` target at all.** Baseline: `NX Cannot find configuration for task api:test` / `web:test`. The `controller` and `screen` verifies therefore still cannot run on a freshly bootstrapped core, whatever the filter says.

Corroborated independently: a real project built on this core had to hand-add `apps/api/vitest.config.mts`, `apps/web/vitest.config.mts` + `vitest.setup.ts`, both `tsconfig.spec.json` files, and `jsdom` / `@vitejs/plugin-react` / `@testing-library/*` devDependencies.

Fixing it means new dependencies, a regenerated 734 KB lockfile, and placeholder specs — a vitest config with no test files would make bootstrap's own `nx run-many -t test` fail. That is a core regeneration via `scripts/regenerate-full-stack-app-core.sh`, not a verify-command edit, so it is out of scope here. It is recorded as `KNOWN_MISSING_TEST_TARGET` in the lint, which fails if that list ever goes stale in either direction. The command *form* for those two layers was proved by adding the missing targets in the throwaway fixture.

## Also outside this PR's paths

`src/skills/hedgehog-core-design/SKILL.md` still quotes `--testPathPattern={module}` as exemplary at lines 227 and 249, and `pnpm typecheck` at line 267. Left untouched here to keep this PR to the core definition, but they will re-teach the bug to every future core author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
