### PR TITLE
feat(packet): make runtime honesty a standing requirement instead of something a human remembers to ask for

### DIFF
--- a/repro/fixture.mjs
+++ b/repro/fixture.mjs
@@ -1,0 +1,107 @@
+// Shared fixture for the packet reproductions. Builds a throwaway
+// Hedgehog project in a temp dir (its own `hedgehog-honesty-` prefix, so
+// it never collides with another working copy's temp dirs), compiles one
+// intent through a two-layer authored core, and runs the real CLI's
+// `hedgehog next` against it.
+//
+// The graph is built through the same modules the CLI itself imports
+// (dbInit / addIntent / loadCore / planTasks) rather than by shelling out
+// to `hedgehog plan`, because `plan` spawns a detached graph server and
+// an OS browser-open on success — neither belongs in a reproduction. The
+// assertion target, `hedgehog next`, is driven as the real CLI process.
+
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = resolve(__dirname, '..');
+export const CLI = join(REPO_ROOT, 'bin/cli.mjs');
+
+const CORE_YAML = `id: honesty-fixture
+layers:
+  - id: schema
+    scope: [src/schema/**]
+    verify: node --version
+    commit: "feat(schema): fixture"
+  - id: service
+    depends_on: schema
+    scope: [src/service/**]
+    verify: node --version
+    commit: "feat(service): fixture"
+`;
+
+const INTENT = {
+  id: 'billing',
+  goal: 'Charge a customer for a subscription period',
+  outcome: 'An invoice exists for every closed period',
+  priority: 1,
+  rules: [
+    'An invoice is immutable once issued',
+    'A period with no usage still produces an invoice',
+  ],
+};
+
+// Creates the temp project and returns its absolute path. Caller is
+// responsible for cleanup via `cleanup(dir)` — never by globbing the
+// temp root, which would delete sibling fixtures.
+export async function makeFixture() {
+  const dir = await mkdtemp(join(tmpdir(), 'hedgehog-honesty-'));
+  await mkdir(join(dir, '.hedgehog'), { recursive: true });
+  await writeFile(join(dir, '.hedgehog/core.yaml'), CORE_YAML);
+
+  const cwd = process.cwd();
+  process.chdir(dir);
+  try {
+    const { dbInit, openDb } = await import(join(REPO_ROOT, 'src/db/init.mjs'));
+    const { addIntent } = await import(join(REPO_ROOT, 'src/db/intent.mjs'));
+    const { loadCore } = await import(join(REPO_ROOT, 'src/db/core.mjs'));
+    const { planTasks } = await import(join(REPO_ROOT, 'src/db/plan.mjs'));
+
+    await dbInit();
+    const core = await loadCore(join(dir, '.hedgehog/core.yaml'));
+    const db = openDb();
+    try {
+      await addIntent(db, INTENT);
+      planTasks(db, core);
+    } finally {
+      db.close();
+    }
+  } finally {
+    process.chdir(cwd);
+  }
+
+  return dir;
+}
+
+// Runs the real CLI's `next` in the fixture and returns its stdout.
+// NO_COLOR keeps the output free of ANSI escapes so it can be compared
+// literally.
+export function runNext(dir) {
+  return execFileSync(process.execPath, [CLI, 'next'], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+}
+
+export async function cleanup(dir) {
+  await rm(dir, { recursive: true, force: true });
+}
+
+// Minimal assertion helpers — no test framework, by design.
+export function fail(what, expected, actual) {
+  console.error(`FAIL  ${what}`);
+  console.error('\n--- expected ---');
+  console.error(expected);
+  console.error('\n--- actual ---');
+  console.error(actual);
+  console.error();
+  process.exitCode = 1;
+}
+
+export function pass(what) {
+  console.log(`PASS  ${what}`);
+}

--- a/repro/packet-honesty-section.mjs
+++ b/repro/packet-honesty-section.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// Reproduction: every task packet carries a standing honesty
+// requirement.
+//
+// The packet is the only thing a layer agent is guaranteed to read on
+// every task. On a real 36-task build the defensive behaviour that
+// caught silent failures — a stub that threw by name, a UI that said
+// "unavailable" instead of showing a fabricated 0, an agent that
+// reported an undecided requirement rather than inventing one — came
+// from a human hand-writing that instruction into each dispatch. A
+// packet generated from core.yaml carried nothing of the kind.
+//
+// Run: node repro/packet-honesty-section.mjs
+// Exits non-zero if the HONESTY section is missing or altered.
+
+import { makeFixture, runNext, cleanup, fail, pass } from './fixture.mjs';
+
+const EXPECTED_SECTION = [
+  'HONESTY',
+  "  Build what this layer can; make what it can't obvious.",
+  '  - A stub or placeholder throws a named error at first use — never',
+  '    returns empty, null, or success from something unbuilt.',
+  '  - A value that cannot be computed is surfaced as unavailable — never',
+  '    replaced by 0, "", or a plausible default.',
+  "  - A decision RELEVANT RULES doesn't make is reported, not invented.",
+  '  - A scope that turns out to be wrong is reported, not widened.',
+  '  Reporting one of these is a successful outcome. Papering over it is',
+  '  the failure VERIFICATION cannot catch.',
+].join('\n');
+
+const dir = await makeFixture();
+let out;
+try {
+  out = runNext(dir);
+} finally {
+  await cleanup(dir);
+}
+
+const honestyAt = out.indexOf('\nHONESTY\n');
+const section = honestyAt === -1 ? null : out.slice(honestyAt + 1).trimEnd();
+
+if (section === null) {
+  fail('hedgehog next emits an HONESTY section', EXPECTED_SECTION, out);
+} else if (section !== EXPECTED_SECTION) {
+  fail('the HONESTY section reads exactly as designed', EXPECTED_SECTION, section);
+} else {
+  pass('hedgehog next emits the HONESTY section verbatim');
+}
+
+// The four cases are load-bearing individually — a section that keeps
+// the heading but drops the "never fabricate a value" clause buys
+// nothing. Named here so a partial regression reports which case went.
+const CASES = {
+  'noisy stub': 'throws a named error at first use',
+  'no fabricated value': 'surfaced as unavailable',
+  'no invented decision': 'is reported, not invented',
+  'no widened scope': 'is reported, not widened',
+};
+
+for (const [name, phrase] of Object.entries(CASES)) {
+  if (!out.includes(phrase)) {
+    fail(
+      `packet states the "${name}" case`,
+      phrase,
+      section === null ? '(no HONESTY section in the packet at all)' : section,
+    );
+  } else {
+    pass(`packet states the "${name}" case`);
+  }
+}
+
+// The section has to survive being skimmed. A packet is read on every
+// task; a wall of prose is read on none of them.
+const sectionLines = EXPECTED_SECTION.split('\n').length;
+if (sectionLines > 12) {
+  fail(
+    'the HONESTY section stays short enough to be read',
+    'at most 12 lines',
+    `${sectionLines} lines`,
+  );
+} else {
+  pass(`the HONESTY section is ${sectionLines} lines`);
+}
+
+if (process.exitCode) {
+  console.error('Reproduction failed: the packet does not carry the honesty requirement.');
+} else {
+  console.log('\nAll assertions passed.');
+}

--- a/repro/packet-sections-preserved.mjs
+++ b/repro/packet-sections-preserved.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// Reproduction: adding the HONESTY section changes nothing else about
+// the packet.
+//
+// The packet is a contract with every agent definition, skill, and host
+// dispatch file that names its sections (src/agents/layer-eng.md,
+// src/skills/hedgehog-authored-loop/SKILL.md, src/hosts/routing.mjs, …).
+// This asserts the pre-existing packet is byte-identical to what it was
+// before, in the same order, and that the new section is strictly
+// appended after VERIFICATION rather than inserted among them.
+//
+// Run: node repro/packet-sections-preserved.mjs
+// Exits non-zero if any pre-existing line, section, or ordering moved.
+
+import { makeFixture, runNext, cleanup, fail, pass } from './fixture.mjs';
+
+// The exact `hedgehog next` output for this fixture at v4.0.3, before
+// the honesty section existed. Recorded literally: this is the text that
+// must not move.
+const BASELINE = `TASK  BILLING-SCHEMA
+schema for billing
+
+STATUS   READY
+
+INTENT
+  Charge a customer for a subscription period
+  An invoice exists for every closed period
+
+RELEVANT RULES
+  - An invoice is immutable once issued
+  - A period with no usage still produces an invoice
+
+WHY NOW
+  ✓ Intent "billing" compiled into the graph
+  ✓ Domain module "billing" resolved
+  ✓ No incomplete dependencies
+
+BLOCKED DOWNSTREAM
+  ✗ BILLING-SERVICE   service
+
+ALLOWED SCOPE
+  src/schema/**
+
+VERIFICATION
+  node --version`;
+
+const SECTION_ORDER = [
+  'STATUS',
+  'INTENT',
+  'RELEVANT RULES',
+  'WHY NOW',
+  'BLOCKED DOWNSTREAM',
+  'ALLOWED SCOPE',
+  'VERIFICATION',
+  'HONESTY',
+];
+
+const dir = await makeFixture();
+let out;
+try {
+  out = runNext(dir);
+} finally {
+  await cleanup(dir);
+}
+
+// 1. Every pre-existing byte is still there, unchanged, as one
+//    contiguous block starting at the top of the packet.
+if (!out.startsWith(BASELINE)) {
+  const actual = out.slice(0, BASELINE.length);
+  fail('the pre-existing packet is unchanged and still leads the output', BASELINE, actual);
+} else {
+  pass('the pre-existing packet is unchanged and still leads the output');
+}
+
+// 2. Section headings appear once each, in this order. Headings are
+//    column-0 lines; every body line in the packet is indented. The
+//    first two lines are the task id and its objective, not a section.
+const headings = out
+  .split('\n')
+  .slice(2)
+  .filter((l) => l.length > 0 && l === l.trimStart())
+  .map((l) => l.split(/\s{2,}/)[0]);
+
+if (headings.join(' | ') !== SECTION_ORDER.join(' | ')) {
+  fail('packet sections appear once each, in order', SECTION_ORDER.join(' | '), headings.join(' | '));
+} else {
+  pass(`packet sections in order: ${headings.join(' → ')}`);
+}
+
+// 3. The new section is appended, not interleaved — nothing pre-existing
+//    is pushed below it.
+const honestyAt = out.indexOf('\nHONESTY\n');
+const verificationAt = out.indexOf('\nVERIFICATION\n');
+if (honestyAt === -1) {
+  fail('HONESTY is appended after VERIFICATION', 'an HONESTY section after VERIFICATION', out);
+} else if (honestyAt < verificationAt) {
+  fail(
+    'HONESTY is appended after VERIFICATION',
+    'HONESTY after VERIFICATION',
+    `HONESTY at ${honestyAt}, VERIFICATION at ${verificationAt}`,
+  );
+} else {
+  pass('HONESTY is appended after VERIFICATION');
+}
+
+if (process.exitCode) {
+  console.error('Reproduction failed: the packet is not the old packet plus one section.');
+} else {
+  console.log('\nAll assertions passed.');
+}

--- a/src/agents/backend-eng.md
+++ b/src/agents/backend-eng.md
@@ -92,6 +92,14 @@ needed.
   well-named schema field, function, or variable already says that.
 - Never self-certify a task as done or run `git commit` for its changes —
   see Workflow step 3.
+- Never fake completeness. The packet's HONESTY section is binding: a
+  placeholder for something this layer can't reach yet throws a named
+  domain error at first use rather than returning `undefined` or an
+  empty list; a value you can't compute is surfaced as unavailable
+  rather than as `0`; a semantic the RELEVANT RULES never decided
+  (cascade-on-delete, retention, defaults for a nullable column) is
+  reported rather than chosen here. `verify` cannot check any of this,
+  which is exactly why it's on you.
 - Never import another module's repository, service, or schema directly
   — cross-module references are FK-by-ID, resolved at the
   contract/controller layer (parallel calls) or via a same-repository

--- a/src/agents/front-end-eng.md
+++ b/src/agents/front-end-eng.md
@@ -95,6 +95,12 @@ don't reach for a second one.
   well-named component, hook, or variable already says that.
 - Never self-certify a task as done or run `git commit` for its changes —
   see Workflow step 3.
+- Never fake completeness. The packet's HONESTY section is binding: a
+  screen renders "unavailable" for a figure the hook can't supply rather
+  than a fabricated `0`, an empty chart, or placeholder rows that look
+  like data; an interaction the contract can't back is reported rather
+  than wired to a no-op handler. `verify` cannot check any of this,
+  which is exactly why it's on you.
 - Never add a data-fetching call that bypasses the hook/contract layer —
   the Nx boundary rule (`scope:web` / `scope:mobile` only depend on
   `scope:contracts`, `scope:hooks`, `scope:shared`) makes a direct

--- a/src/agents/layer-eng.md
+++ b/src/agents/layer-eng.md
@@ -74,6 +74,12 @@ parsing and typing, and the layer after it consumes the result.
   well-named symbol already says that.
 - Never self-certify a task as done or run `git commit` for its changes —
   see Workflow step 4.
+- Never fake completeness. The packet's HONESTY section is binding: a
+  stub throws a named error at first use rather than returning empty or
+  succeeding; a value you can't compute is surfaced as unavailable
+  rather than as `0` or a plausible default; a decision RELEVANT RULES
+  doesn't make is reported rather than invented. `verify` cannot check
+  any of this, which is exactly why it's on you.
 - Never write outside the packet's ALLOWED SCOPE. Scope is what stops
   this layer from quietly rewriting the previous one's work; `hedgehog
   verify` enforces it, and a change that needs to land elsewhere is a

--- a/src/db/next.mjs
+++ b/src/db/next.mjs
@@ -127,12 +127,45 @@ export function stalledTasks(db) {
     .all();
 }
 
+// The standing honesty requirement, appended to every packet.
+//
+// Every other section is task-specific — this one is constant, which is
+// exactly why it lives in the renderer rather than in the graph. The
+// build's mechanical gate can only ask "did the verify command exit 0",
+// so a layer that stubs a dependency permissively, returns 0 where it
+// meant "unknown", or invents a decision the requirements never made
+// passes the gate and fails later, somewhere else. The defensive
+// behaviour that catches those — a stub that throws by name, a value
+// surfaced as unavailable, an undecided question reported instead of
+// answered — only ever happened when a human wrote the instruction into
+// the dispatch by hand. Generating it into the packet makes it standing
+// rather than remembered.
+//
+// Kept to ten lines on purpose: an agent reads this on every task, and
+// a section long enough to skim is a section that isn't read.
+const HONESTY = [
+  'HONESTY',
+  "  Build what this layer can; make what it can't obvious.",
+  '  - A stub or placeholder throws a named error at first use — never',
+  '    returns empty, null, or success from something unbuilt.',
+  '  - A value that cannot be computed is surfaced as unavailable — never',
+  '    replaced by 0, "", or a plausible default.',
+  "  - A decision RELEVANT RULES doesn't make is reported, not invented.",
+  '  - A scope that turns out to be wrong is reported, not widened.',
+  '  Reporting one of these is a successful outcome. Papering over it is',
+  '  the failure VERIFICATION cannot catch.',
+];
+
 // Renders a packet into the STATUS / INTENT / RELEVANT RULES / WHY NOW /
-// BLOCKED DOWNSTREAM / ALLOWED SCOPE / VERIFICATION format. The spec
-// splits this across two examples — the `hedgehog next` display and "The
-// task packet" (which carries the intent and its rules) — but an agent
-// receives one thing, so the packet is one thing: everything the worker
-// needs to build the task without reading the plan.
+// BLOCKED DOWNSTREAM / ALLOWED SCOPE / VERIFICATION / HONESTY format. The
+// spec splits this across two examples — the `hedgehog next` display and
+// "The task packet" (which carries the intent and its rules) — but an
+// agent receives one thing, so the packet is one thing: everything the
+// worker needs to build the task without reading the plan.
+//
+// HONESTY is last deliberately: it's the one section that qualifies the
+// gate above it, so it reads as the answer to "and what if I can't clear
+// VERIFICATION honestly" rather than as preamble.
 export function formatNext(packet) {
   const { task, intent, requirements, dependents } = packet;
   const scopeGlobs = JSON.parse(task.scope_globs);
@@ -175,6 +208,8 @@ export function formatNext(packet) {
   lines.push('');
   lines.push('VERIFICATION');
   lines.push(`  ${task.verify_command}`);
+  lines.push('');
+  lines.push(...HONESTY);
 
   return lines.join('\n');
 }

--- a/src/skills/hedgehog-authored-loop/SKILL.md
+++ b/src/skills/hedgehog-authored-loop/SKILL.md
@@ -59,12 +59,12 @@ runtime detail.
 1. **Run `hedgehog claim --count N --owner <owner>`.** `<owner>` is this
    session. Claim is atomic and lease-based, and returns up to N task
    packets (STATUS/INTENT/RELEVANT RULES/WHY NOW/BLOCKED
-   DOWNSTREAM/ALLOWED SCOPE/VERIFICATION each) that the scheduler has
-   already verified are safe to run together — trust it: a packet is
-   never handed out unless its dependencies are `complete` and it
-   doesn't conflict with anything else in the batch. `--count` is a
-   maximum, not a promise. `hedgehog ready` previews the claimable/held-
-   back split without claiming anything.
+   DOWNSTREAM/ALLOWED SCOPE/VERIFICATION/HONESTY each) that the
+   scheduler has already verified are safe to run together — trust it:
+   a packet is never handed out unless its dependencies are `complete`
+   and it doesn't conflict with anything else in the batch. `--count`
+   is a maximum, not a promise. `hedgehog ready` previews the
+   claimable/held-back split without claiming anything.
 2. **Dispatch each claimed packet to its own `layer-eng` subagent** — in
    ONE message with parallel tool calls when there's more than one — along
    with the reminder to read `.hedgehog/core-design.md` for what its


### PR DESCRIPTION
On a real 36-task build, four different layer agents did notably honest things when they hit the limits of their scope: wired a **noisy stub** that throws a named domain error at first use rather than a permissive one; **refused to invent** cascade-delete semantics the requirements had not decided; rendered *"aggregates unavailable"* rather than a fabricated `0`; and **reported instead of writing out of scope** when the scope turned out to be wrong.

That is real defensive behaviour, and it is why several silent failures were caught at all. But it existed because **each packet was hand-written with an explicit honesty requirement in it**. Nothing in Hedgehog asks for it, and a packet generated from `core.yaml` — which is what the tool actually emits — does not.

The evaluation's conclusion was blunt: the quality did not come from the discipline, it came from a human remembering to ask, every time.

## What the packet says today

`formatNext` renders sections that are entirely about *what* and *where*:

```js
lines.push(`TASK  ${task.id}`); lines.push(task.objective);
lines.push('STATUS   READY');
lines.push('INTENT');             // goal, outcome
lines.push('RELEVANT RULES');
lines.push('WHY NOW');
lines.push('BLOCKED DOWNSTREAM');
lines.push('ALLOWED SCOPE');
lines.push('VERIFICATION');
```

Nothing about *how* to build. `src/agents/layer-eng.md`'s Constraints cover scope, self-certification, and never weakening a verify command — but never the case where the layer **cannot do what it was asked**.

## What this adds

A `HONESTY` section, appended after `VERIFICATION`:

```
HONESTY
  Build what this layer can; make what it can't obvious.
  - A stub or placeholder throws a named error at first use — never
    returns empty, null, or success from something unbuilt.
  - A value that cannot be computed is surfaced as unavailable — never
    replaced by 0, "", or a plausible default.
  - A decision RELEVANT RULES doesn't make is reported, not invented.
  - A scope that turns out to be wrong is reported, not widened.
  Reporting one of these is a successful outcome. Papering over it is
  the failure VERIFICATION cannot catch.
```

Ten lines, because a packet is read on every task and a long section gets skimmed. Each bullet names one of the four observed behaviours, and it refers to sections the packet already carries rather than inventing vocabulary.

The last two lines are the load-bearing ones: an agent that believes reporting a gap counts as failing its task will fabricate instead. Removing that incentive is most of the work.

## Where it lives, and why both places

- **The packet (primary).** It is the only surface guaranteed to be read on every task, it is regenerated per task rather than remembered, and it is emitted by the CLI — so a project running `npx @skyf0xx/hedgehog` gets it on the next version bump, with no `hedgehog update` and no re-install.

  Placing it **last** is deliberate: it qualifies the gate directly above it, so it reads as the answer to "what if I can't clear VERIFICATION honestly" rather than as preamble.
- **The agent payload (reinforcement).** `layer-eng.md`, `backend-eng.md` and `front-end-eng.md` each gain one Constraints bullet, tailored to what that role actually fakes — a permissive stub; a schema semantic like cascade-on-delete that the rules never decided; a screen rendering `0` or placeholder rows for a figure the hook cannot supply. This reaches existing projects only on `hedgehog update`, which is exactly why it cannot be the only home — but it puts the rule where that agent's other behavioural rules live.
- `hedgehog-authored-loop/SKILL.md`, the one place enumerating the packet's sections exhaustively, now lists `…/VERIFICATION/HONESTY`. The abbreviated enumerations in `templates/CLAUDE.md`, `hosts/routing.mjs` and `hedgehog-landing-loop` were left alone: they already elide `INTENT`/`RELEVANT RULES`, so they do not claim exhaustiveness, and touching them would only widen the conflict surface with #19.

Nothing existing was reworded. The only non-additive hunk is a six-line re-wrap in `hedgehog-authored-loop/SKILL.md` — same words, moved across line breaks to keep the paragraph under the file's wrap after the longer section list.

## Evidence

Two reproductions, each building a two-layer authored core in a temp dir and driving the real CLI with `NO_COLOR=1`. (Graph construction goes through the same modules the CLI imports rather than through `hedgehog plan`, because `plan` spawns a detached graph server and an OS browser-open on success.)

**Before**, both exit 1:

```
FAIL  hedgehog next emits an HONESTY section
FAIL  packet states the "noisy stub" case
FAIL  packet states the "no fabricated value" case
FAIL  packet states the "no invented decision" case
FAIL  packet states the "no widened scope" case
--
PASS  the pre-existing packet is unchanged and still leads the output
FAIL  packet sections appear once each, in order
      expected: … ALLOWED SCOPE | VERIFICATION | HONESTY
      actual:   … ALLOWED SCOPE | VERIFICATION
```

**After**, both exit 0, including the ordering assertion across all eight sections.

Packet diff on an unchanged fixture — additions only, at the end:

```diff
@@ -24,3 +24,14 @@
 VERIFICATION
   node --version
+
+HONESTY
+  Build what this layer can; make what it can't obvious.
+  ...
```

`node scripts/check.mjs` passes. `repro/` is outside `package.json`'s `files`, so the published tarball is unchanged.

## What this does and does not buy

It is a prompt-level instruction, and `hedgehog verify` cannot check it. Nothing here detects a permissive stub, a fabricated `0`, or an invented cascade semantic — verify still only asks whether the command exited 0 and whether the writes stayed in scope.

What changes is that the requirement is **standing** rather than **remembered**: it arrives on every task from the tool, instead of depending on a human writing it into each dispatch. That is precisely the failure the evaluation identified, and the behaviour it asks for was already demonstrably achievable by these agents when asked.

Whether they comply unprompted is a question this makes measurable, not one it settles. No mechanical check was attempted, because I do not think a credible one exists at this layer — and a check that looks like enforcement without being it would be worse than none.

## Conflicts

Expected, in different places, with two open PRs:

- **#12** (`claim` emits the full packet) — no conflict in `next.mjs`. If #12 routes `claimCommand` through `formatNext`, HONESTY arrives in claim output for free. A conflict arises only if #12 duplicates the renderer rather than reusing it.
- **#19** (`GOAL`/`OUTCOME` labels + `INHERITED DEBT`) — conflicts in `formatNext`'s body and header comment, and in the skill's section enumeration. Mechanical to resolve: #19 edits and inserts among the mid-packet sections, this only appends after the last `lines.push`. The concerns are orthogonal — theirs is what the intent asked for, this is how to build when you cannot deliver it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
