### PR TITLE
feat(core): require a verify_radius to contain its scope, and flag a verify that never exercises the radius it declares

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -18,7 +18,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join, relative, resolve } from 'node:path';
 import { spawn } from 'node:child_process';
 import { dbInit, DB_PATH, openDb } from '../src/db/init.mjs';
-import { loadCore } from '../src/db/core.mjs';
+import { loadCore, lintCore } from '../src/db/core.mjs';
 import { planTasks } from '../src/db/plan.mjs';
 import { addIntent, INTENTS_DIR } from '../src/db/intent.mjs';
 import { nextTask, formatNext, stalledTasks } from '../src/db/next.mjs';
@@ -947,6 +947,34 @@ async function renewCommand(args) {
   console.log(`${green(bold('Renewed.'))} Task ${bold(taskId)}'s lease extended by ${minutes} minute(s).`);
 }
 
+// Heuristic problems with the project's own core definition, rendered for
+// `hedgehog status`. Surfaced here because status is the command every
+// session starts with, and a core-definition smell is a build-wide fact
+// rather than one task's: a layer whose verify command doesn't reach the
+// verify_radius it declared lets a task break a neighbour and still
+// commit green, and nothing later in the loop will say so. Warnings only
+// — the certainties throw from validateCore, on load.
+async function coreWarningLines() {
+  const corePath = await resolveCorePath();
+  if (!corePath) return [];
+  const label = relative(DEST_ROOT, corePath) || corePath;
+  let core;
+  try {
+    core = await loadCore(corePath);
+  } catch (err) {
+    // Every other command that loads the core fails outright on this; say
+    // so here rather than letting `hedgehog status` die with a stack.
+    return ['', `${red('CORE')}  ${bold(label)} is invalid: ${err.message}`];
+  }
+  const warnings = lintCore(core);
+  if (warnings.length === 0) return [];
+  return [
+    '',
+    `${yellow('CORE WARNINGS')}  ${dim(label)}`,
+    ...warnings.map((warning) => `  ${yellow('!')} ${warning}`),
+  ];
+}
+
 async function statusCommand() {
   await ensureDb();
 
@@ -965,6 +993,8 @@ async function statusCommand() {
   }
 
   console.log(formatStatus(result));
+  const warningLines = await coreWarningLines();
+  if (warningLines.length > 0) console.log(warningLines.join('\n'));
 }
 
 // `hedgehog ready` — read-only preview of what a `hedgehog claim` call

--- a/repro/radius-covers-scope.mjs
+++ b/repro/radius-covers-scope.mjs
@@ -21,10 +21,59 @@ import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { loadCore } from '../src/db/core.mjs';
+import { loadCore, lintCore } from '../src/db/core.mjs';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const failures = [];
+
+// Containment between two globs, in the dialect verify.mjs enforces scope
+// with (git pathspec `:(glob)`): `*`/`?` stay inside one segment, `**`
+// spans any number. A segment-prefix comparison — the scheduler's own
+// globsOverlap algebra — answers "could these two globs ever meet", which
+// is NOT containment: every `reject` row below shares a literal prefix
+// with its scope glob while matching none, some, or the wrong part of it.
+//
+// `accept` rows must load: a wrong hard failure is worse than a missing
+// one, since it breaks every command on a legitimate core.
+const CONTAINMENT = {
+  reject: [
+    // The reviewer's case: a single-segment wildcard cannot reach a
+    // deeper path, however much literal prefix it shares.
+    { scope: ['a/b/**'], radius: ['a/*.ts'], why: 'a/*.ts matches nothing under a/b/' },
+    { scope: ['a/b/**'], radius: ['a/*'], why: 'a/* is one segment deep, a/b/** is deeper' },
+    { scope: ['apps/api/src/**'], radius: ['apps/api/*.ts'], why: 'sibling files, not the tree' },
+    { scope: ['a/b/c.ts'], radius: ['a/*/d.ts'], why: 'literal segment mismatch under the wildcard' },
+    { scope: ['a/**'], radius: ['a/b/**'], why: 'radius is the narrower subtree' },
+    { scope: ['a/b/**'], radius: ['a/b'], why: 'a bare directory path is not its subtree' },
+  ],
+  accept: [
+    { scope: ['a/b/**'], radius: ['a/**'], why: 'trailing ** covers everything below' },
+    { scope: ['a/b/**'], radius: ['a/b/**'], why: 'identical' },
+    { scope: ['a/b/c.ts'], radius: ['a/*/c.ts'], why: 'wildcard segment matches the literal' },
+    { scope: ['a/b/c.ts'], radius: ['a/b/*.ts'], why: 'in-segment wildcard matches the file' },
+    { scope: ['a/{module}/**'], radius: ['a/**'], why: 'module placeholder is a literal segment' },
+    // Shapes the shipped and real authored cores actually use.
+    { scope: ['packages/db/src/schema/{module}/**'], radius: ['packages/db/**'], why: 'full-stack-app schema' },
+    { scope: ['packages/hooks/src/{module}/**'], radius: ['packages/hooks/**'], why: 'full-stack-app hook' },
+    { scope: ['apps/api/src/{module}/http/**', 'apps/api/src/app.module.ts'], radius: ['apps/api/**'], why: 'authored api layer' },
+    // The union covers it even though no single glob does — must not be
+    // a hard failure, because rejecting it would be rejecting a core that
+    // is actually fine.
+    { scope: ['a/b/**'], radius: ['a/b/*', 'a/b/*/**'], why: 'covered by the union' },
+  ],
+};
+
+function containmentYaml(scope, radius) {
+  return `
+id: repro-containment
+layers:
+  - id: only
+    scope: [${scope.map((g) => `"${g}"`).join(', ')}]
+    verify: "pnpm test"
+    verify_radius: [${radius.map((g) => `"${g}"`).join(', ')}]
+    commit: "feat: only"
+`;
+}
 
 const NARROW_RADIUS = `
 id: repro-narrow-radius
@@ -108,11 +157,65 @@ try {
     );
   }
 
-  // ── 4. No false alarm: both shipped cores still load. ───────────────
+  // ── 4. Containment, both directions. A radius sharing a literal
+  //    prefix with the scope is not thereby covering it; and a radius
+  //    that genuinely covers must still load. ─────────────────────────
+  let caseIndex = 0;
+  for (const { scope, radius, why } of CONTAINMENT.reject) {
+    const result = await loadYaml(dir, `reject-${caseIndex++}`, containmentYaml(scope, radius));
+    if (result.ok) {
+      failures.push(
+        `containment/reject: scope ${JSON.stringify(scope)} radius ${JSON.stringify(radius)} (${why})\n` +
+          '      expected: loadCore throws — the radius does not cover the scope\n' +
+          '      actual:   loaded clean',
+      );
+    }
+  }
+  for (const { scope, radius, why } of CONTAINMENT.accept) {
+    const result = await loadYaml(dir, `accept-${caseIndex++}`, containmentYaml(scope, radius));
+    if (!result.ok) {
+      failures.push(
+        `containment/accept: scope ${JSON.stringify(scope)} radius ${JSON.stringify(radius)} (${why})\n` +
+          '      expected: loads clean — rejecting this would hard-fail a legitimate core\n' +
+          `      actual:   rejected — ${result.message}`,
+      );
+    }
+  }
+
+  // ── 5. What can be neither proven nor disproven degrades to a
+  //    warning, not a throw — the union case loads, and says so. ──────
+  {
+    const union = await loadYaml(
+      dir,
+      'union',
+      containmentYaml(['a/b/**'], ['a/b/*', 'a/b/*/**']),
+    );
+    if (union.ok) {
+      const warnings = lintCore(union.core).filter((w) => w.includes('cannot prove'));
+      if (warnings.length !== 1) {
+        failures.push(
+          'unprovable containment: scope ["a/b/**"] radius ["a/b/*", "a/b/*/**"]\n' +
+            '      expected: 1 "cannot prove" warning — loaded, but flagged for the author\n' +
+            `      actual:   ${warnings.length} — ${JSON.stringify(lintCore(union.core), null, 2)}`,
+        );
+      }
+    }
+  }
+
+  // ── 6. No false alarm: both shipped cores still load, and neither
+  //    trips the "cannot prove" warning. ──────────────────────────────
   for (const core of ['full-stack-app', 'landing-page']) {
     const path = join(ROOT, 'src/golden-cores', core, 'core.yaml');
     try {
-      await loadCore(path);
+      const loaded = await loadCore(path);
+      const unprovable = lintCore(loaded).filter((w) => w.includes('cannot prove'));
+      if (unprovable.length > 0) {
+        failures.push(
+          `shipped core "${core}"\n` +
+            '      expected: every radius provably covers its scope\n' +
+            `      actual:   ${unprovable.join(' | ')}`,
+        );
+      }
     } catch (err) {
       failures.push(
         `shipped core "${core}"\n` +
@@ -130,4 +233,7 @@ if (failures.length > 0) {
   for (const f of failures) console.error(`  ✗ ${f}\n`);
   process.exit(1);
 }
-console.log('radius-covers-scope: ok — narrow and empty radii rejected, good radius and both shipped cores load clean');
+console.log(
+  `radius-covers-scope: ok — narrow/empty radii rejected, ${CONTAINMENT.reject.length} non-covering radii rejected, ` +
+    `${CONTAINMENT.accept.length} covering radii accepted, unprovable containment warned not thrown, both shipped cores clean`,
+);

--- a/repro/radius-covers-scope.mjs
+++ b/repro/radius-covers-scope.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Repro: a layer may declare a `verify_radius` that does not contain its
+// own `scope`, and the loader accepts it.
+//
+// Why that is wrong, in the scheduler's own terms: src/db/conflict.mjs's
+// conflicts() compares scope against scope, then radius against radius.
+// Nothing compares one task's scope against another task's radius, and
+// verifyRadius() returns the declared radius ALONE when set (it is not
+// unioned with scope). So "task A writes a file task B's verify reads" is
+// only ever detected because every layer's radius contains its own scope.
+// A radius that drops part of its scope silently deletes that detection
+// and the two tasks co-schedule.
+//
+// Expected after the fix: loadCore/validateCore rejects it, both shipped
+// cores still load, and a radius that does contain its scope still loads.
+//
+// No build graph, no sqlite — this is a core-definition-level defect.
+// Run: node repro/radius-covers-scope.mjs
+
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadCore } from '../src/db/core.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const failures = [];
+
+const NARROW_RADIUS = `
+id: repro-narrow-radius
+layers:
+  - id: api
+    scope: ["apps/api/src/{module}/**", "apps/api/src/app.module.ts"]
+    verify: "pnpm --filter api exec vitest run"
+    verify_radius: ["apps/api/src/{module}/**"]
+    commit: "feat({module}): api"
+`;
+
+const EMPTY_RADIUS = `
+id: repro-empty-radius
+layers:
+  - id: api
+    scope: ["apps/api/src/{module}/**"]
+    verify: "pnpm --filter api exec vitest run"
+    verify_radius: []
+    commit: "feat({module}): api"
+`;
+
+const GOOD_RADIUS = `
+id: repro-good-radius
+layers:
+  - id: api
+    scope: ["apps/api/src/{module}/**", "apps/api/src/app.module.ts"]
+    verify: "pnpm --filter api exec vitest run"
+    verify_radius: ["apps/api/**"]
+    commit: "feat({module}): api"
+`;
+
+async function loadYaml(dir, name, text) {
+  const path = join(dir, `${name}.yaml`);
+  await writeFile(path, text, 'utf8');
+  try {
+    return { ok: true, core: await loadCore(path) };
+  } catch (err) {
+    return { ok: false, message: err.message };
+  }
+}
+
+const dir = await mkdtemp(join(tmpdir(), 'hedgehog-radius-'));
+try {
+  // ── 1. A radius that omits part of its own scope must be rejected. ──
+  const narrow = await loadYaml(dir, 'narrow', NARROW_RADIUS);
+  if (narrow.ok) {
+    failures.push(
+      'repro-narrow-radius: scope ["apps/api/src/{module}/**", "apps/api/src/app.module.ts"] ' +
+        'with verify_radius ["apps/api/src/{module}/**"]\n' +
+        '      expected: loadCore throws — "apps/api/src/app.module.ts" is written inside scope but sits outside the declared radius\n' +
+        '      actual:   loaded clean, verify_radius = ' +
+        JSON.stringify(narrow.core.layers[0].verify_radius),
+    );
+  } else if (!/verify_radius/.test(narrow.message) || !/app\.module\.ts/.test(narrow.message)) {
+    failures.push(
+      'repro-narrow-radius: rejected, but the message names neither verify_radius nor the uncovered glob\n' +
+        `      actual:   ${narrow.message}`,
+    );
+  }
+
+  // ── 2. An empty declared radius covers nothing, so it is the same
+  //    defect in its most extreme form (and is NOT the same thing as
+  //    omitting the field, which falls back to scope). ────────────────
+  const empty = await loadYaml(dir, 'empty', EMPTY_RADIUS);
+  if (empty.ok) {
+    failures.push(
+      'repro-empty-radius: verify_radius []\n' +
+        '      expected: loadCore throws — an empty radius conflicts with nothing on the verify axis\n' +
+        '      actual:   loaded clean, verify_radius = ' +
+        JSON.stringify(empty.core.layers[0].verify_radius),
+    );
+  }
+
+  // ── 3. No false alarm: a radius that does contain its scope loads. ──
+  const good = await loadYaml(dir, 'good', GOOD_RADIUS);
+  if (!good.ok) {
+    failures.push(
+      'repro-good-radius: scope under verify_radius ["apps/api/**"]\n' +
+        '      expected: loads clean\n' +
+        `      actual:   rejected — ${good.message}`,
+    );
+  }
+
+  // ── 4. No false alarm: both shipped cores still load. ───────────────
+  for (const core of ['full-stack-app', 'landing-page']) {
+    const path = join(ROOT, 'src/golden-cores', core, 'core.yaml');
+    try {
+      await loadCore(path);
+    } catch (err) {
+      failures.push(
+        `shipped core "${core}"\n` +
+          '      expected: loads clean\n' +
+          `      actual:   rejected — ${err.message}`,
+      );
+    }
+  }
+} finally {
+  await rm(dir, { recursive: true, force: true });
+}
+
+if (failures.length > 0) {
+  console.error(`\nradius-covers-scope: ${failures.length} failure(s)\n`);
+  for (const f of failures) console.error(`  ✗ ${f}\n`);
+  process.exit(1);
+}
+console.log('radius-covers-scope: ok — narrow and empty radii rejected, good radius and both shipped cores load clean');

--- a/repro/verify-covers-radius.mjs
+++ b/repro/verify-covers-radius.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+// Repro: a layer's verify command can be narrower than the verify_radius
+// it declares, and nothing says so.
+//
+// The radius is the layer's claim that its verify run READS that whole
+// set; src/db/conflict.mjs serializes other tasks against exactly that
+// claim. When the command's only path arguments sit inside the layer's
+// own `scope`, the command is anchored to the scope directory: everything
+// between scope and the radius is never executed, and a task that breaks
+// a neighbour inside its own declared radius commits green. Observed for
+// real — an `api` layer scoped to `apps/api/src/{module}/http/**` with
+// `verify_radius: ["apps/api/**"]` and `vitest run src/{module}/http/`
+// bound an adapter to a port and invalidated another module's spec
+// asserting the port was still unbound. tsc saw no type error, the spec
+// never ran.
+//
+// Distinct from the Step 5 filter-token rule (upstream #5), which
+// cross-checks verify's filter tokens against the layer's own SCOPE. A
+// command can satisfy that perfectly — case B below does — and still
+// leave its declared radius unexercised.
+//
+// Expected after the fix: lintCore() warns on the anchored-command case,
+// stays silent where it has no evidence, and reports nothing on either
+// shipped core.
+//
+// No build graph, no sqlite — this is a core-definition-level defect.
+// Run: node repro/verify-covers-radius.mjs
+
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadCore, parseCoreYaml } from '../src/db/core.mjs';
+import * as coreModule from '../src/db/core.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const failures = [];
+
+if (typeof coreModule.lintCore !== 'function') {
+  console.error('\nverify-covers-radius: 1 failure\n');
+  console.error(
+    '  ✗ src/db/core.mjs\n' +
+      '      expected: an exported lintCore(core) reporting a verify command narrower than its declared verify_radius\n' +
+      `      actual:   no such export (exports: ${Object.keys(coreModule).join(', ')})\n`,
+  );
+  process.exit(1);
+}
+const { lintCore } = coreModule;
+
+// A — the observed defect: radius is the whole app, the command's only
+//     path argument is the layer's own scope directory.
+const ANCHORED = `
+id: repro-anchored
+layers:
+  - id: domain-service
+    scope: ["apps/api/src/{module}/domain/**"]
+    verify: "pnpm --filter api exec tsc -p tsconfig.json --noEmit && pnpm --filter api exec vitest run src/{module}/domain/"
+    verify_radius: ["apps/api/**"]
+    commit: "feat({module}): domain-service"
+  - id: api
+    depends_on: domain-service
+    scope: ["apps/api/src/{module}/http/**"]
+    verify: "pnpm --filter api exec tsc -p tsconfig.json --noEmit && pnpm --filter api exec vitest run src/{module}/http/"
+    verify_radius: ["apps/api/**"]
+    commit: "feat({module}): api"
+`;
+
+// B — the fix: same radius, command runs the whole app's suite. Note it
+//     still satisfies the Step 5 filter-token rule; the two axes differ.
+const WHOLE_SUITE = `
+id: repro-whole-suite
+layers:
+  - id: api
+    scope: ["apps/api/src/{module}/http/**"]
+    verify: "pnpm --filter api exec tsc -p tsconfig.json --noEmit && pnpm --filter api exec vitest run"
+    verify_radius: ["apps/api/**"]
+    commit: "feat({module}): api"
+`;
+
+// C — also correct: the command's path argument is an ANCESTOR of scope,
+//     so it reaches the radius rather than being pinned inside scope.
+const ANCESTOR_PATH = `
+id: repro-ancestor
+layers:
+  - id: api
+    scope: ["apps/api/src/{module}/http/**"]
+    verify: "pnpm --filter api exec vitest run src/"
+    verify_radius: ["apps/api/**"]
+    commit: "feat({module}): api"
+`;
+
+// D — no radius declared at all: radius defaults to scope, so there is no
+//     gap between them and nothing to warn about, however narrow the
+//     command's path argument is.
+const NO_RADIUS = `
+id: repro-no-radius
+layers:
+  - id: api
+    scope: ["apps/api/src/{module}/http/**"]
+    verify: "pnpm --filter api exec vitest run src/{module}/http/"
+    commit: "feat({module}): api"
+`;
+
+function warn(text) {
+  return lintCore(parseCoreYaml(text));
+}
+
+// ── 1. The defect is reported, once per affected layer, naming the
+//    neighbouring layer whose scope the radius covers. ────────────────
+{
+  const warnings = warn(ANCHORED);
+  if (warnings.length !== 2) {
+    failures.push(
+      'repro-anchored: two layers with verify_radius ["apps/api/**"] and vitest filtered to their own scope\n' +
+        '      expected: 2 warnings (one per layer)\n' +
+        `      actual:   ${warnings.length} — ${JSON.stringify(warnings, null, 2)}`,
+    );
+  } else {
+    if (!warnings.some((w) => w.includes('"api"') && w.includes('"domain-service"'))) {
+      failures.push(
+        'repro-anchored: the warning for layer "api" does not name the neighbouring layer "domain-service" its radius covers\n' +
+          `      actual:   ${warnings.join(' | ')}`,
+      );
+    }
+    if (!warnings.every((w) => w.includes('verify_radius'))) {
+      failures.push(
+        'repro-anchored: a warning does not name verify_radius\n' +
+          `      actual:   ${warnings.join(' | ')}`,
+      );
+    }
+  }
+}
+
+// ── 2-4. No false alarms on the correct shapes. ─────────────────────
+for (const [label, text] of [
+  ['repro-whole-suite (command runs the whole app suite)', WHOLE_SUITE],
+  ['repro-ancestor (command path argument is above scope)', ANCESTOR_PATH],
+  ['repro-no-radius (no verify_radius declared)', NO_RADIUS],
+]) {
+  const warnings = warn(text);
+  if (warnings.length !== 0) {
+    failures.push(
+      `${label}\n` +
+        '      expected: 0 warnings\n' +
+        `      actual:   ${warnings.length} — ${JSON.stringify(warnings, null, 2)}`,
+    );
+  }
+}
+
+// ── 5. No false alarms on either shipped core. full-stack-app's schema
+//    and hook layers both declare a package-wide radius; their commands
+//    narrow by flag (`--testPathPattern={module}`), not by path, which
+//    is not evidence the check can read — it abstains. ────────────────
+for (const name of ['full-stack-app', 'landing-page']) {
+  const core = await loadCore(join(ROOT, 'src/golden-cores', name, 'core.yaml'));
+  const warnings = lintCore(core);
+  if (warnings.length !== 0) {
+    failures.push(
+      `shipped core "${name}"\n` +
+        '      expected: 0 warnings\n' +
+        `      actual:   ${warnings.length} — ${JSON.stringify(warnings, null, 2)}`,
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`\nverify-covers-radius: ${failures.length} failure(s)\n`);
+  for (const f of failures) console.error(`  ✗ ${f}\n`);
+  process.exit(1);
+}
+console.log(
+  'verify-covers-radius: ok — anchored commands warned (2), whole-suite/ancestor/no-radius silent, both shipped cores clean',
+);

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -14,7 +14,7 @@ import { fileURLToPath } from 'node:url';
 import { execFileSync } from 'node:child_process';
 import { parse } from '../src/hosts/frontmatter.mjs';
 import { AGENT_CAPABILITY } from '../src/hosts/capabilities.mjs';
-import { loadCore } from '../src/db/core.mjs';
+import { loadCore, lintCore } from '../src/db/core.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -101,12 +101,18 @@ for (const { label, text } of allEntries) {
   }
 }
 
-// ── 5. Both shipped core.yaml files load and validate cleanly. ─────────
+// ── 5. Both shipped core.yaml files load, validate, and lint cleanly.
+//    The lint (core.mjs's lintCore) is heuristic and only warns in a
+//    project, but a shipped core is the worked example every authored
+//    core is written against, so a warning on one is a release blocker
+//    here — and a shipped core tripping it is also the evidence that the
+//    heuristic cries wolf. ────────────────────────────────────────────
 for (const core of ['full-stack-app', 'landing-page']) {
   const path = join(ROOT, 'src/golden-cores', core, 'core.yaml');
   try {
     const loaded = await loadCore(path);
     if (loaded.id !== core) fail(`${path}: id "${loaded.id}" != directory name "${core}"`);
+    for (const warning of lintCore(loaded)) fail(`${path}: ${warning}`);
   } catch (err) {
     fail(`${path}: failed to load — ${err.message}`);
   }

--- a/src/db/conflict.mjs
+++ b/src/db/conflict.mjs
@@ -5,7 +5,10 @@
 
 // Path-segment-wise prefix before the first wildcard character. A glob
 // with no wildcard is a literal path and is its own full prefix.
-function globPrefix(glob) {
+// Exported so core.mjs's verify-radius checks reason in exactly the glob
+// algebra the scheduler decides conflicts with, rather than a second,
+// drifting copy of it.
+export function globPrefix(glob) {
   const wildcard = glob.search(/[*?[]/);
   const literal = wildcard === -1 ? glob : glob.slice(0, wildcard);
   const segments = literal.split('/');

--- a/src/db/core.mjs
+++ b/src/db/core.mjs
@@ -10,6 +10,7 @@
 // stance src/db/schema.mjs takes with node:sqlite.
 
 import { readFile } from 'node:fs/promises';
+import { globPrefix } from './conflict.mjs';
 
 function stripComment(line) {
   // '#' only starts a comment outside a quoted string.
@@ -124,6 +125,95 @@ export function parseCoreYaml(text) {
   return core;
 }
 
+// ── verify-radius checks ────────────────────────────────────────────────
+// A layer's `scope` is what it may write; its `verify_radius` is what its
+// verify command reads. conflict.mjs compares like with like — scope
+// against scope, then radius against radius — so the two below are the
+// only things about that pair a file can decide on its own.
+
+// Full segment list of a glob: the literal path itself when it has no
+// wildcard, otherwise the scheduler's own segment-wise prefix. globPrefix
+// deliberately drops a literal glob's last segment (it answers "could
+// these two globs ever meet"); coverage is a containment question, so a
+// literal path counts as all of itself here.
+function globSegments(glob) {
+  if (glob.search(/[*?[]/) === -1) {
+    return glob.split('/').filter((segment) => segment !== '');
+  }
+  return globPrefix(glob);
+}
+
+// True when `outer` is at least as broad as `inner` — outer's segments are
+// a segment-wise prefix of inner's. Deliberately permissive about the
+// wildcard tail (`a/*.ts` counts as covering `a/b/**`): every caller uses
+// this to decide whether to complain, so the error direction is silence.
+function globCovers(outer, inner) {
+  const o = globSegments(outer);
+  const i = globSegments(inner);
+  if (o.length > i.length) return false;
+  for (let k = 0; k < o.length; k++) {
+    if (o[k] !== i[k]) return false;
+  }
+  return true;
+}
+
+function covered(globs, glob) {
+  return globs.some((candidate) => globCovers(candidate, glob));
+}
+
+// Path-like arguments in a verify command, as evidence of what the command
+// anchors itself to. Only tokens that are unambiguously a relative path
+// count: anything flag-shaped, absolute, variable-interpolated, a URL, or
+// carrying an `=` is dropped rather than guessed at. The list is evidence,
+// never a claim of completeness — a command with no path arguments yields
+// an empty list, which the lint reads as "no evidence", not "reads
+// nothing".
+function pathArguments(command) {
+  const tokens = command.split(/[\s;|&()]+/);
+  const paths = [];
+  for (const raw of tokens) {
+    const token = raw.replace(/^['"]+/, '').replace(/['"]+$/, '');
+    if (!token.includes('/')) continue;
+    if (!/^[A-Za-z0-9._{]/.test(token)) continue; // flags, redirects, absolute paths
+    if (token.includes('=') || token.includes('$') || token.includes('://')) continue;
+    const normalized = token.replace(/^\.\//, '').replace(/\/+$/, '');
+    if (normalized !== '') paths.push(normalized);
+  }
+  return paths;
+}
+
+// True when `token` names a path at or below `glob`'s own directory —
+// "inside", as opposed to an ancestor of it. The token is matched at any
+// segment offset, because a verify command's path arguments are relative
+// to whatever directory the runner chdir'd into (`pnpm --filter api exec
+// vitest run src/{module}/http/` is repo-relative to `apps/api`), not to
+// the repo root. At least one segment must match: a zero-overlap
+// alignment would make every token "inside" every recursive glob.
+function tokenInsideGlob(token, glob) {
+  const t = token.split('/').filter((segment) => segment !== '');
+  const dir = globSegments(glob);
+  const recursive = glob.includes('**');
+  for (let i = 0; i < dir.length; i++) {
+    const overlap = Math.min(t.length, dir.length - i);
+    if (overlap === 0) continue;
+    let matches = true;
+    for (let j = 0; j < overlap; j++) {
+      if (t[j] !== dir[i + j]) {
+        matches = false;
+        break;
+      }
+    }
+    if (!matches) continue;
+    // Shorter than what's left of the glob's own directory: the token is
+    // an ancestor of the scope, so the command reaches wider, not narrower.
+    if (t.length < dir.length - i) continue;
+    // Deeper than the glob's directory only lands inside a recursive glob.
+    if (t.length > dir.length - i && !recursive) continue;
+    return true;
+  }
+  return false;
+}
+
 // Enforces the interview's rule (spec: "Authored cores") — a layer without
 // scope or without a verify command is rejected. Applied uniformly to
 // shipped and authored cores alike; the loader has no shipped-core-only
@@ -140,6 +230,30 @@ export function validateCore(core) {
     }
     if (!layer.verify) {
       throw new Error(`layer "${layer.id}" missing verify`);
+    }
+
+    // A declared radius REPLACES scope on the verify axis — conflict.mjs's
+    // verifyRadius() returns the declared list alone, never the union with
+    // scope — and conflicts() only ever compares scope against scope and
+    // radius against radius. Nothing compares one task's scope against
+    // another's radius, so the writes-vs-reads case (A writes a file B's
+    // verify reads) is only visible to the scheduler when every layer's
+    // radius contains its own scope. The unset default (radius = scope)
+    // holds that invariant for free; a declared radius that drops part of
+    // its own scope breaks it silently, and the two tasks co-schedule.
+    if (layer.verify_radius !== null) {
+      if (layer.verify_radius.length === 0) {
+        throw new Error(
+          `layer "${layer.id}" declares an empty verify_radius — omit the field to fall back to scope (conflict.mjs's verifyRadius), rather than declaring a radius that covers nothing`,
+        );
+      }
+      for (const glob of layer.scope) {
+        if (!covered(layer.verify_radius, glob)) {
+          throw new Error(
+            `layer "${layer.id}" declares verify_radius [${layer.verify_radius.join(', ')}], which does not cover its own scope glob "${glob}" — a declared radius replaces scope on the verify axis (conflict.mjs), so anything in scope but outside the radius is a file this layer writes while the scheduler believes no one is reading it`,
+          );
+        }
+      }
     }
   }
 
@@ -167,6 +281,63 @@ export function validateCore(core) {
   }
 
   return core;
+}
+
+// Heuristic checks on a core definition — everything that is a smell
+// rather than a certainty, so it warns instead of throwing (validateCore
+// owns the certainties). Returns a list of human-readable strings; empty
+// means nothing detectable is wrong.
+//
+// The one check here is the verify-command-versus-verify_radius axis. A
+// layer's radius is its claim that its verify command reads that whole
+// set, and the scheduler serializes other tasks against the claim. When
+// the command's only path arguments sit inside the layer's own `scope`,
+// the command is anchored to the scope directory and everything between
+// scope and the radius goes unexercised — the layer collects the
+// serialization without doing the reading, and a task that breaks a
+// neighbour inside its own declared radius still commits green.
+//
+// It fires on evidence only. A command with no path arguments at all
+// (`pnpm nx test db --testPathPattern={module}`) yields nothing to reason
+// from: whether that flag's filter reaches the whole radius depends on
+// the test corpus, not on this file, so the check abstains rather than
+// asserting a conclusion it can't see. That blind spot is exactly why
+// hedgehog-core-design carries the question as an authoring rule too.
+export function lintCore(core) {
+  const warnings = [];
+  for (const layer of core.layers) {
+    if (layer.verify_radius === null) continue;
+
+    // Only a radius strictly wider than scope has an unexercised gap.
+    const wider = layer.verify_radius.some((glob) => !covered(layer.scope, glob));
+    if (!wider) continue;
+
+    const paths = pathArguments(layer.verify);
+    if (paths.length === 0) continue; // no evidence either way — abstain
+    const anchored = paths.every((path) =>
+      layer.scope.some((glob) => tokenInsideGlob(path, glob)),
+    );
+    if (!anchored) continue; // something in the command reaches outside scope
+
+    const neighbours = core.layers
+      .filter(
+        (other) =>
+          other.id !== layer.id &&
+          other.scope.some((glob) => covered(layer.verify_radius, glob)),
+      )
+      .map((other) => `"${other.id}"`);
+    const reach =
+      neighbours.length > 0
+        ? ` The radius covers layer ${neighbours.join(', ')}'s scope, which this command never runs.`
+        : '';
+
+    warnings.push(
+      `layer "${layer.id}": verify_radius [${layer.verify_radius.join(', ')}] is wider than scope, but every path in verify (${paths
+        .map((path) => `"${path}"`)
+        .join(', ')}) is inside that scope — the command only exercises what the layer writes.${reach} A task that breaks something else inside the declared radius passes green. Widen the command to the radius, or narrow the radius to what the command reads.`,
+    );
+  }
+  return warnings;
 }
 
 export async function loadCore(path) {

--- a/src/db/core.mjs
+++ b/src/db/core.mjs
@@ -131,34 +131,158 @@ export function parseCoreYaml(text) {
 // against scope, then radius against radius — so the two below are the
 // only things about that pair a file can decide on its own.
 
-// Full segment list of a glob: the literal path itself when it has no
-// wildcard, otherwise the scheduler's own segment-wise prefix. globPrefix
-// deliberately drops a literal glob's last segment (it answers "could
-// these two globs ever meet"); coverage is a containment question, so a
-// literal path counts as all of itself here.
-function globSegments(glob) {
-  if (glob.search(/[*?[]/) === -1) {
-    return glob.split('/').filter((segment) => segment !== '');
+// The glob dialect is git's pathspec `:(glob)` — what verify.mjs actually
+// enforces scope with: `*` and `?` stay inside one path segment, `**`
+// spans any number of them. Every function below reads globs that way.
+function segmentsOf(glob) {
+  return glob.split('/').filter((segment) => segment !== '');
+}
+
+const WILDCARD = /[*?[]/;
+
+// One segment pattern compiled to a regex over a single path segment.
+// `{module}` and friends carry no wildcard characters, so they compile to
+// literals and compare exactly — the same on both sides of any comparison,
+// since plan.mjs fills scope and radius from the same module name.
+function segmentRegExp(pattern) {
+  let source = '^';
+  for (let i = 0; i < pattern.length; i++) {
+    const ch = pattern[i];
+    if (ch === '*') source += '[^/]*';
+    else if (ch === '?') source += '[^/]';
+    else if (ch === '[') {
+      const end = pattern.indexOf(']', i + 1);
+      if (end === -1) source += '\\[';
+      else {
+        source += pattern.slice(i, end + 1);
+        i = end;
+      }
+    } else source += ch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
+  return new RegExp(`${source}$`);
+}
+
+function segmentMatches(pattern, segment) {
+  return segmentRegExp(pattern).test(segment);
+}
+
+// Does a concrete path (as segments) match a glob? Standard `**`-aware
+// walk. Used only on paths this file generated, to prove non-containment.
+function matchesGlob(pathSegments, glob) {
+  const g = segmentsOf(glob);
+  const walk = (gi, pi) => {
+    if (gi === g.length) return pi === pathSegments.length;
+    if (g[gi] === '**') {
+      for (let k = pi; k <= pathSegments.length; k++) {
+        if (walk(gi + 1, k)) return true;
+      }
+      return false;
+    }
+    if (pi >= pathSegments.length) return false;
+    if (!segmentMatches(g[gi], pathSegments[pi])) return false;
+    return walk(gi + 1, pi + 1);
+  };
+  return walk(0, 0);
+}
+
+// Does the single-segment pattern `outer` match everything `inner` does?
+// 'unknown' wherever deciding it would mean comparing two wildcard
+// languages — the callers treat that as "can't prove", never as an error.
+function segmentContains(outer, inner) {
+  if (outer === inner) return 'yes';
+  if (outer === '*') return 'yes'; // any one segment
+  if (!WILDCARD.test(inner)) return segmentMatches(outer, inner) ? 'yes' : 'no';
+  // inner is a wildcard pattern: `*` or `?` in it matches more than any
+  // single literal can, so a literal outer provably misses something.
+  if (!WILDCARD.test(outer)) return /[*?]/.test(inner) ? 'no' : 'unknown';
+  return 'unknown';
+}
+
+// Structural containment: 'yes' only when every path `inner` matches is
+// provably matched by `outer`. globPrefix (the scheduler's own algebra,
+// which conflict.mjs uses) deliberately answers a different question —
+// "could these two globs ever meet" — and a prefix comparison cannot
+// decide containment: `a/*.ts` shares the prefix `a` with `a/b/**` while
+// matching none of its paths. So this walks the segments instead.
+function structuralContains(outer, inner) {
+  const o = segmentsOf(outer);
+  const i = segmentsOf(inner);
+  let uncertain = false;
+  let oi = 0;
+  let ii = 0;
+  while (oi < o.length) {
+    if (o[oi] === '**') {
+      // A trailing `**` covers everything below the prefix matched so far.
+      // An interior one needs alignment this analysis doesn't attempt.
+      if (oi === o.length - 1) return uncertain ? 'unknown' : 'yes';
+      return 'unknown';
+    }
+    // outer still demands segments inner never produces, or inner can
+    // expand across segments outer matches one at a time.
+    if (ii >= i.length) return 'no';
+    if (i[ii] === '**') return 'no';
+    const rel = segmentContains(o[oi], i[ii]);
+    if (rel === 'no') return 'no';
+    if (rel === 'unknown') uncertain = true;
+    oi++;
+    ii++;
+  }
+  // outer matched exactly its own length; inner going deeper escapes it.
+  if (ii < i.length) return 'no';
+  return uncertain ? 'unknown' : 'yes';
+}
+
+// A few concrete paths the glob certainly matches, used as witnesses for
+// non-containment. Returns none where a witness can't be constructed with
+// certainty (interior `**`, character classes) — no witness means no
+// proof, which the caller reads as "unknown", never as "covered".
+function witnessPaths(glob) {
+  const segments = segmentsOf(glob);
+  const base = [];
+  for (let i = 0; i < segments.length; i++) {
+    const segment = segments[i];
+    if (segment === '**') {
+      if (i !== segments.length - 1) return [];
+      // `**` matches one segment and it matches two; both are witnesses,
+      // and neither depends on whether it also matches zero.
+      return [
+        [...base, 'w1'],
+        [...base, 'w1', 'w2'],
+      ];
+    }
+    if (segment.includes('[')) return [];
+    base.push(segment.replace(/[*?]/g, 'w'));
+  }
+  return [base];
+}
+
+// Is `glob` covered by the union of `globs`? 'yes' / 'no' / 'unknown'.
+//
+// 'no' is only ever returned with a proof: a concrete path `glob` matches
+// that no glob in the set does. That matters because 'no' is a hard load
+// failure — and because the union can cover something no single member
+// covers (["a/b/*", "a/b/*/**"] together cover "a/b/**"), so "no member
+// contains it" is not on its own grounds to reject a core. Unprovable
+// either way comes back 'unknown' and is warned about, not thrown.
+function coverage(globs, glob) {
+  for (const candidate of globs) {
+    if (structuralContains(candidate, glob) === 'yes') return 'yes';
+  }
+  for (const witness of witnessPaths(glob)) {
+    if (!globs.some((candidate) => matchesGlob(witness, candidate))) return 'no';
+  }
+  return 'unknown';
+}
+
+// Literal directory segments of a glob — everything before its first
+// wildcard, or the whole path when it has none. This is the scheduler's
+// own globPrefix, except that a literal path counts as all of itself:
+// globPrefix drops the last segment because a file path's directory is
+// what could collide with another glob, while here the question is where
+// a command's path argument sits relative to the scope.
+function literalDirSegments(glob) {
+  if (!WILDCARD.test(glob)) return segmentsOf(glob);
   return globPrefix(glob);
-}
-
-// True when `outer` is at least as broad as `inner` — outer's segments are
-// a segment-wise prefix of inner's. Deliberately permissive about the
-// wildcard tail (`a/*.ts` counts as covering `a/b/**`): every caller uses
-// this to decide whether to complain, so the error direction is silence.
-function globCovers(outer, inner) {
-  const o = globSegments(outer);
-  const i = globSegments(inner);
-  if (o.length > i.length) return false;
-  for (let k = 0; k < o.length; k++) {
-    if (o[k] !== i[k]) return false;
-  }
-  return true;
-}
-
-function covered(globs, glob) {
-  return globs.some((candidate) => globCovers(candidate, glob));
 }
 
 // Path-like arguments in a verify command, as evidence of what the command
@@ -190,8 +314,8 @@ function pathArguments(command) {
 // the repo root. At least one segment must match: a zero-overlap
 // alignment would make every token "inside" every recursive glob.
 function tokenInsideGlob(token, glob) {
-  const t = token.split('/').filter((segment) => segment !== '');
-  const dir = globSegments(glob);
+  const t = segmentsOf(token);
+  const dir = literalDirSegments(glob);
   const recursive = glob.includes('**');
   for (let i = 0; i < dir.length; i++) {
     const overlap = Math.min(t.length, dir.length - i);
@@ -247,8 +371,11 @@ export function validateCore(core) {
           `layer "${layer.id}" declares an empty verify_radius — omit the field to fall back to scope (conflict.mjs's verifyRadius), rather than declaring a radius that covers nothing`,
         );
       }
+      // Only a proven miss throws — coverage() returns 'no' solely when
+      // it holds a concrete path in this layer's scope that no radius
+      // glob matches. Anything it can't decide is left to lintCore.
       for (const glob of layer.scope) {
-        if (!covered(layer.verify_radius, glob)) {
+        if (coverage(layer.verify_radius, glob) === 'no') {
           throw new Error(
             `layer "${layer.id}" declares verify_radius [${layer.verify_radius.join(', ')}], which does not cover its own scope glob "${glob}" — a declared radius replaces scope on the verify axis (conflict.mjs), so anything in scope but outside the radius is a file this layer writes while the scheduler believes no one is reading it`,
           );
@@ -288,7 +415,12 @@ export function validateCore(core) {
 // owns the certainties). Returns a list of human-readable strings; empty
 // means nothing detectable is wrong.
 //
-// The one check here is the verify-command-versus-verify_radius axis. A
+// Two checks. The first is the other half of validateCore's radius rule:
+// where containment between the radius and the scope can be neither
+// proven nor disproven, the author is told to check it rather than the
+// core being rejected on a guess.
+//
+// The second is the verify-command-versus-verify_radius axis. A
 // layer's radius is its claim that its verify command reads that whole
 // set, and the scheduler serializes other tasks against the claim. When
 // the command's only path arguments sit inside the layer's own `scope`,
@@ -308,8 +440,18 @@ export function lintCore(core) {
   for (const layer of core.layers) {
     if (layer.verify_radius === null) continue;
 
+    for (const glob of layer.scope) {
+      if (coverage(layer.verify_radius, glob) === 'unknown') {
+        warnings.push(
+          `layer "${layer.id}": cannot prove verify_radius [${layer.verify_radius.join(', ')}] covers scope glob "${glob}" — check it by hand. A radius that misses part of its own scope leaves this layer writing files the scheduler believes nobody is reading (conflict.mjs compares scope against scope and radius against radius, never one against the other).`,
+        );
+      }
+    }
+
     // Only a radius strictly wider than scope has an unexercised gap.
-    const wider = layer.verify_radius.some((glob) => !covered(layer.scope, glob));
+    const wider = layer.verify_radius.some(
+      (glob) => coverage(layer.scope, glob) !== 'yes',
+    );
     if (!wider) continue;
 
     const paths = pathArguments(layer.verify);
@@ -323,7 +465,7 @@ export function lintCore(core) {
       .filter(
         (other) =>
           other.id !== layer.id &&
-          other.scope.some((glob) => covered(layer.verify_radius, glob)),
+          other.scope.some((glob) => coverage(layer.verify_radius, glob) === 'yes'),
       )
       .map((other) => `"${other.id}"`);
     const reach =

--- a/src/skills/hedgehog-core-design/SKILL.md
+++ b/src/skills/hedgehog-core-design/SKILL.md
@@ -255,7 +255,9 @@ modules' schema tasks correctly serialize against each other on that
 radius even though their scopes don't overlap.
 
 A declared radius must contain the layer's own `scope` — `validateCore`
-rejects one that doesn't, because `conflict.mjs` compares scope against
+rejects one that provably doesn't (a concrete path in `scope` that no
+radius glob matches), and `hedgehog status` warns where containment can't
+be decided either way, because `conflict.mjs` compares scope against
 scope and radius against radius and never one against the other, so a
 radius missing part of its scope hides the case where one task writes a
 file another task's verify reads. Having declared a radius here, Step 5's

--- a/src/skills/hedgehog-core-design/SKILL.md
+++ b/src/skills/hedgehog-core-design/SKILL.md
@@ -254,6 +254,14 @@ files. Its true verify radius is the whole package —
 modules' schema tasks correctly serialize against each other on that
 radius even though their scopes don't overlap.
 
+A declared radius must contain the layer's own `scope` — `validateCore`
+rejects one that doesn't, because `conflict.mjs` compares scope against
+scope and radius against radius and never one against the other, so a
+radius missing part of its scope hides the case where one task writes a
+file another task's verify reads. Having declared a radius here, Step 5's
+last constraint is where you check that the `verify` command actually
+reaches it.
+
 ## Step 5 — write `.hedgehog/core.yaml`
 
 The loader parses `id` plus a `layers` list of flat maps. Every layer
@@ -318,6 +326,36 @@ if missed:
   own test-file paths back to confirm each has a covering token — fix
   both directions (add the missing scope path, or add the missing
   filter token) before Step 6, not after a build discovers the gap live.
+- **A layer that declares a wider `verify_radius` must run a `verify`
+  that reaches that far.** The constraint above cross-checks `verify`
+  against the layer's own `scope`; this one checks it against
+  `verify_radius`, which is a strictly wider set whenever Step 4b
+  declared one. A command can satisfy the first perfectly and still
+  leave everything between `scope` and the radius unexercised. The
+  radius is a claim that this layer's verify run *reads* that whole set,
+  and the scheduler serializes other tasks against exactly that claim
+  (`conflict.mjs`); a `verify` that runs only its own scope's specs
+  collects the serialization without doing the reading, and the gap is
+  invisible — the layer looks correct in isolation. Concretely: a layer
+  scoped to `apps/api/src/{module}/http/**` with `verify_radius:
+  ["apps/api/**"]` and `verify: "... vitest run src/{module}/http/"`
+  typechecks all of `apps/api` but runs only its own module's specs, so
+  binding a real adapter to a port can falsify a *neighbouring* module's
+  spec asserting that port is still unbound — that spec is outside the
+  filter and never runs, `tsc` sees a type error but not a false
+  assertion, and the task commits green having broken a module it
+  declared it was reading. For every layer with a `verify_radius`,
+  answer yes or no: **for each path in my radius that lies outside my
+  `scope`, does some part of my `verify` command actually execute
+  against it?** If no, widen the command (drop the path filter, run the
+  package's whole suite — the radius already serializes those tasks, so
+  this costs runtime, not concurrency) or narrow the radius to what the
+  command really reads; prefer widening, since Step 4b declared the
+  radius for a reason. `hedgehog status` warns on the form it can see —
+  a wider radius whose `verify` command's only path arguments sit inside
+  `scope` — but a filter expressed as a flag rather than a path
+  (`--testPathPattern={module}`, `-t <name>`) is invisible to it, so on
+  those the answer is yours, not the linter's.
 
 Verify the file loads before showing it back, by calling the loader
 directly:


### PR DESCRIPTION
A layer's verify command can be narrower than the `verify_radius` it declares, so a task can break another module's tests and still pass green.

Observed on a real build: a layer declared `verify_radius: ["apps/api/**"]` — correctly, since its command typechecks the whole project — but the test half of its command ran only its own module's specs. Binding a real adapter to a port then invalidated, by construction, a test in *another* module asserting that port was still unbound. That spec lives outside the filter, so it never ran. `tsc` catches a type error but not a false assertion, and the pre-commit hook only typechecks packages with staged files and never runs tests — so the defect crossed both gates. It was caught only because a human hand-wrote the packet with an instruction to also run the neighbouring module's tests.

## How this differs from #5

#5 (fixed in `4b6d086`) checks `verify`'s filter tokens against the layer's **own `scope`**. This axis checks `verify` against **`verify_radius`**, the strictly wider set. A command can satisfy #5 perfectly and still leave everything between scope and radius unexercised. The new rule sits immediately after that one and refers to it rather than restating it.

## A stronger finding underneath, and the hard check it justifies

`verifyRadius()` returns the declared radius **alone**, not unioned with scope:

```js
export function verifyRadius(task) {
  if (task.verify_radius == null) return scope(task);
  return JSON.parse(task.verify_radius);
}

export function conflicts(a, b) {
  if (a.exclusive || b.exclusive) return 'exclusive';
  if (scopesOverlap(scope(a), scope(b))) return 'scope';
  if (scopesOverlap(verifyRadius(a), verifyRadius(b))) return 'verify';
  return null;
}
```

Nothing ever compares one task's *scope* against another's *radius*. So the writes-vs-reads case — A writes a file that B's verify reads — is visible to the scheduler **only because each radius contains its own scope**. The unset default holds that invariant for free; a declared radius narrower than scope silently breaks it, and two tasks that genuinely interfere are handed out together.

`validateCore` never looked at `verify_radius` at all; the parser's only mention is the `null` sentinel.

**Hard check (throws from `validateCore`):** a declared `verify_radius` must contain the layer's own `scope`, and an empty declared radius is rejected separately. Unambiguously wrong, so it fails rather than warns.

## The warning, and the three checks that were rejected

**Warning (`lintCore()`, a new export):** radius strictly wider than scope, **and** every path argument in the verify command sits inside that scope → warn, naming the neighbouring layer whose scope the radius covers. It fires on evidence, never on absence of it.

Against the real authored core it reports four true positives, including:

> layer "api": verify_radius [apps/api/**] is wider than scope, but every path in verify ("src/{module}/http") is inside that scope … The radius covers layer "domain-service"'s scope, which this command never runs.

— naming precisely the neighbour whose spec broke.

Three candidate checks were evaluated and **rejected**, which matters as much as the one kept:

- *"Wider radius and no path-like token outside scope"* — the naive form. It reports on the **absence** of evidence. `pnpm nx test db --testPathPattern={module}` has no path token at all, so it would fire on full-stack-app's own `schema` and `hook` layers — a conclusion the checker has no basis for, since whether a regex filter reaches the whole radius depends on the test corpus, not the core file.
- *"Radius overlaps another layer's scope and the command cannot reach it"* — reachability is the undecidable part, and the observed break was cross-**module** within a layer, not cross-layer. Folded into the warning's message instead of standing as its own check.
- *"Command references a path outside the declared radius"* (the inverse) — a command's path arguments are relative to whatever the runner chdir'd into (`pnpm --filter api exec vitest run src/{module}/http/` is `apps/api`-relative), so a token that fails to resolve under the radius at repo root is evidence of nothing. Real false-alarm risk; dropped.

A lint that cries wolf gets ignored, which would cost more than the checks are worth.

## False-alarm evidence

Both shipped cores load, validate and lint **clean** — and `scripts/check.mjs` now fails on any warning for them, so that stays true. Reproduction cases pin the shapes that must stay silent: a whole-suite command, an ancestor path argument, and no declared radius all produce zero warnings.

## Wiring

- `hedgehog status` — the command every session starts with — prints a `CORE WARNINGS` block, and renders a `validateCore` failure as a one-line `CORE … is invalid:` message instead of dying with a stack trace.
- `scripts/check.mjs` §5 lints both shipped cores as a release gate.
- `globPrefix` is now exported from `conflict.mjs`, so the lint reasons in the scheduler's own glob algebra rather than a drifting copy of it.
- `src/db/verify.mjs` and `src/db/plan.mjs` are untouched.

## The authoring rule

A new Step 5 constraint in `hedgehog-core-design`, answerable yes or no, stating the consequence concretely: a task that breaks a neighbour and still passes. Plus a two-sentence forward pointer at the end of Step 4b, where the radius is first chosen.

## What remains unenforceable, stated plainly

Whether a command *actually reads* its declared radius is undecidable in general. The lint sees only path arguments; a filter expressed as a flag (`--testPathPattern={module}`, `-t <name>`, `--project x`) is invisible to it.

**Worth flagging:** full-stack-app's own `schema` and `hook` layers are structurally this exact shape — a package-wide radius with a flag-narrowed test run — and the lint deliberately abstains on them. Shipped golden-core verify commands were not changed here, because that alters what every full-stack-app project runs at each commit and is a product decision rather than a side effect of this fix. The Step 5 rule is what covers that residue.

## Evidence

`repro/radius-covers-scope.mjs` — before: 2 failures (a narrow radius and an empty radius both "loaded clean", printing the accepted value). `repro/verify-covers-radius.mjs` — before: 1 failure (`no such export (exports: loadCore, parseCoreYaml, validateCore)`). Both exit 1 before, 0 after. `node scripts/check.mjs` passes.

## Conflicts

Textual conflict with **#22** is expected in `hedgehog-core-design/SKILL.md`: the new bullet appends to the same Step 5 constraint list #22 adds to, and the Step 4b pointer sits adjacent to where #22 inserts Step 4c. **#24**'s `requires:` field lands in `core.mjs`'s parser and `validateCore`, which this also edits — adjacent, not overlapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
