### PR TITLE
fix(core): warn when a per-module layer's verify has no module signal

### DIFF
--- a/repro/verify-has-module-token.mjs
+++ b/repro/verify-has-module-token.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+// Repro: a per-module layer's verify command can carry no {module} token
+// and no module-scoped path argument, and nothing says so.
+//
+// validateCore already requires {module} in a per-module layer's scope —
+// that's file-level isolation, a certainty the compiler depends on. This
+// is the weaker, verify-side half: a layer whose scope isolates by
+// module can still declare a verify with no evidence it distinguishes
+// one module's run from another's. Observed for real — a six-module
+// `deploy` layer's verify was a fixed `kubectl apply -f k8s/` with no
+// {module} anywhere and no verify_radius declared. It compiled
+// byte-identical across all six modules and could not tell deployed from
+// reverted from never-built (upstream #9).
+//
+// Expected after the fix: lintCore() warns on the no-evidence case,
+// stays silent the moment either {module} or a path argument shows up,
+// stays silent on a layer that declares verify_radius (that's a
+// different, already-checked claim — see verify-covers-radius.mjs), and
+// reports nothing on either shipped core.
+//
+// No build graph, no sqlite — this is a core-definition-level defect.
+// Run: node repro/verify-has-module-token.mjs
+
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadCore, parseCoreYaml, lintCore } from '../src/db/core.mjs';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const failures = [];
+
+function warn(text) {
+  return lintCore(parseCoreYaml(text));
+}
+
+// A — the observed defect: scope isolates by module, verify is a fixed
+//     command with no {module} and no module-scoped path.
+const NO_EVIDENCE = `
+id: repro-no-evidence
+layers:
+  - id: deploy
+    scope: ["k8s/{module}/**"]
+    verify: "kubectl apply -f k8s/ && kubectl rollout status deployment/app"
+    commit: "chore({module}): deploy"
+`;
+
+// B — correct: {module} appears literally in verify.
+const MODULE_TOKEN = `
+id: repro-module-token
+layers:
+  - id: deploy
+    scope: ["k8s/{module}/**"]
+    verify: "kubectl apply -f k8s/{module}/ && kubectl rollout status deployment/{module}"
+    commit: "chore({module}): deploy"
+`;
+
+// C — correct: no {module} literal, but a path argument anchors the
+//     command to the module (pathArguments sees it even without the
+//     literal placeholder string, since the compiler already substituted
+//     it — this models a hand-authored verify that references a module
+//     path directly).
+const PATH_ARGUMENT = `
+id: repro-path-argument
+layers:
+  - id: deploy
+    scope: ["k8s/{module}/**"]
+    verify: "kubectl apply -f k8s/{module}/manifests/"
+    commit: "chore({module}): deploy"
+`;
+
+// D — correct: verify_radius declared, so the layer is on record as
+//     deliberately reading wider than its own module — the same
+//     exemption verify-covers-radius.mjs's WHOLE_SUITE case relies on.
+const RADIUS_DECLARED = `
+id: repro-radius-declared
+layers:
+  - id: deploy
+    scope: ["k8s/{module}/**"]
+    verify: "kubectl apply -f k8s/ && pnpm test"
+    verify_radius: ["k8s/**"]
+    commit: "chore({module}): deploy"
+`;
+
+// E — exempt: once: true carries no {module} anywhere by construction.
+const ONCE_LAYER = `
+id: repro-once
+layers:
+  - id: bootstrap
+    scope: ["terraform/**"]
+    verify: "terraform apply -auto-approve"
+    once: true
+    commit: "chore(infra): bootstrap"
+  - id: deploy
+    depends_on: bootstrap
+    scope: ["k8s/{module}/**"]
+    verify: "kubectl apply -f k8s/{module}/"
+    commit: "chore({module}): deploy"
+`;
+
+// F — exempt: exclusive: true is a declared join/integration layer, no
+//     per-module scope to distinguish.
+const EXCLUSIVE_LAYER = `
+id: repro-exclusive
+layers:
+  - id: deploy
+    scope: ["k8s/{module}/**"]
+    verify: "kubectl apply -f k8s/{module}/"
+    commit: "chore({module}): deploy"
+  - id: join
+    depends_on: deploy
+    scope: ["**"]
+    verify: "kubectl apply -f k8s/"
+    exclusive: true
+    commit: "chore(infra): join"
+`;
+
+// G — not module-axis at all: no layer's scope carries {module}, so the
+//     check has nothing to apply to.
+const LINEAR_CHAIN = `
+id: repro-linear
+layers:
+  - id: deploy
+    scope: ["k8s/**"]
+    verify: "kubectl apply -f k8s/"
+    commit: "chore(infra): deploy"
+`;
+
+// ── 1. The defect is reported. ──────────────────────────────────────────
+{
+  const warnings = warn(NO_EVIDENCE);
+  if (warnings.length !== 1) {
+    failures.push(
+      'repro-no-evidence: a deploy layer with no {module} and no path argument\n' +
+        '      expected: 1 warning\n' +
+        `      actual:   ${warnings.length} — ${JSON.stringify(warnings, null, 2)}`,
+    );
+  } else if (!warnings[0].includes('"deploy"') || !warnings[0].includes('{module}')) {
+    failures.push(`repro-no-evidence: warning doesn't name the layer or {module}\n      actual: ${warnings[0]}`);
+  }
+}
+
+// ── 2-7. No false alarms on the correct/exempt shapes. ──────────────────
+for (const [label, text] of [
+  ['repro-module-token ({module} literal in verify)', MODULE_TOKEN],
+  ['repro-path-argument (module-scoped path argument)', PATH_ARGUMENT],
+  ['repro-radius-declared (verify_radius on record)', RADIUS_DECLARED],
+  ['repro-once (once: true layer)', ONCE_LAYER],
+  ['repro-exclusive (exclusive: true layer)', EXCLUSIVE_LAYER],
+  ['repro-linear (not module-axis)', LINEAR_CHAIN],
+]) {
+  const warnings = warn(text);
+  if (warnings.length !== 0) {
+    failures.push(
+      `${label}\n` +
+        '      expected: 0 warnings\n' +
+        `      actual:   ${warnings.length} — ${JSON.stringify(warnings, null, 2)}`,
+    );
+  }
+}
+
+// ── 8. No false alarms on either shipped core. ──────────────────────────
+for (const name of ['full-stack-app', 'landing-page']) {
+  const core = await loadCore(join(ROOT, 'src/golden-cores', name, 'core.yaml'));
+  const warnings = lintCore(core);
+  if (warnings.length !== 0) {
+    failures.push(
+      `shipped core "${name}"\n` +
+        '      expected: 0 warnings\n' +
+        `      actual:   ${warnings.length} — ${JSON.stringify(warnings, null, 2)}`,
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`\nverify-has-module-token: ${failures.length} failure(s)\n`);
+  for (const f of failures) console.error(`  ✗ ${f}\n`);
+  process.exit(1);
+}
+console.log(
+  'verify-has-module-token: ok — no-evidence deploy layer warned, module-token/path-argument/radius/once/exclusive/linear cases silent, both shipped cores clean',
+);

--- a/src/db/core.mjs
+++ b/src/db/core.mjs
@@ -622,12 +622,30 @@ export function validateCore(core) {
 // owns the certainties). Returns a list of human-readable strings; empty
 // means nothing detectable is wrong.
 //
-// Two checks. The first is the other half of validateCore's radius rule:
-// where containment between the radius and the scope can be neither
-// proven nor disproven, the author is told to check it rather than the
-// core being rejected on a guess.
+// Three checks. The first is a per-module layer's verify with no
+// evidence it varies by module at all: no {module} token, and no path
+// argument (pathArguments, below) that lands inside the layer's own
+// module-scoped glob (tokenInsideGlob, the same test the radius check
+// below uses). validateCore already requires {module} in a per-module
+// layer's scope (file-level isolation, a certainty); a verify with
+// neither signal is weaker — a command can legitimately vary by module
+// through a flag pathArguments can't see (--filter, -t), so it's a
+// warning, not a throw. A layer that declares verify_radius is exempt:
+// declaring one is the author's on-record statement that this command
+// deliberately reads wider than its own module's scope, a different and
+// already-checked claim from the one this warning is about. Upstream #9:
+// a six-module deploy layer with no verify_radius and a verify of a
+// fixed `kubectl apply -f k8s/` — no {module}, and its only path
+// arguments (`k8s/`, `deployment/app`) sat outside the module's own
+// scope glob — ran byte-identical six times and could not tell deployed
+// from reverted from never-built.
 //
-// The second is the verify-command-versus-verify_radius axis. A
+// The second is the other half of validateCore's radius rule: where
+// containment between the radius and the scope can be neither proven nor
+// disproven, the author is told to check it rather than the core being
+// rejected on a guess.
+//
+// The third is the verify-command-versus-verify_radius axis. A
 // layer's radius is its claim that its verify command reads that whole
 // set, and the scheduler serializes other tasks against the claim. When
 // the command's only path arguments sit inside the layer's own `scope`,
@@ -644,6 +662,26 @@ export function validateCore(core) {
 // hedgehog-core-design carries the question as an authoring rule too.
 export function lintCore(core) {
   const warnings = [];
+  const isModuleAxis = core.layers.some((layer) =>
+    layer.scope.join('').includes('{module}'),
+  );
+  if (isModuleAxis) {
+    for (const layer of core.layers) {
+      if (layer.exclusive || layer.once) continue;
+      if (!layer.scope.join('').includes('{module}')) continue; // validateCore already rejects this
+      if (layer.verify_radius !== null && layer.verify_radius !== undefined) continue;
+      if (layer.verify.includes('{module}')) continue;
+      const paths = pathArguments(layer.verify);
+      const anchored = paths.some((path) =>
+        layer.scope.some((glob) => tokenInsideGlob(path, glob)),
+      );
+      if (anchored) continue;
+      warnings.push(
+        `layer "${layer.id}": scope carries {module} but verify has no {module} token and no path argument inside that scope — this command compiles byte-identical across every module and there's no evidence it distinguishes one module's build from another's.`,
+      );
+    }
+  }
+
   for (const layer of core.layers) {
     if (layer.verify_radius === null || layer.verify_radius === undefined) continue;
 

--- a/src/skills/hedgehog-core-design/SKILL.md
+++ b/src/skills/hedgehog-core-design/SKILL.md
@@ -459,6 +459,21 @@ if missed:
   `scope` — but a filter expressed as a flag rather than a path
   (`--testPathPattern={module}`, `-t <name>`) is invisible to it, so on
   those the answer is yours, not the linter's.
+- **A per-module layer's `verify` must distinguish the module it runs
+  for.** A layer whose `scope` carries `{module}` but whose `verify`
+  neither contains a `{module}` token nor a path argument inside that
+  module's own scope compiles byte-identical across every module — it
+  cannot tell one module's build from another's, let alone from a module
+  never built at all. `lintCore` (`src/db/core.mjs`, surfaced by
+  `hedgehog status`) warns on this, and abstains the moment a `{module}`
+  token or a module-scoped path argument shows up, or when the layer
+  declares `verify_radius` — that declaration is already on record as
+  this layer reading wider than its own module on purpose. Sharpest on a
+  `deploy` layer applying manifests or running a rollout check against a
+  fixed path: `kubectl apply -f k8s/` and `kubectl rollout status
+  deployment/app` read the same thing regardless of which module's task
+  is running, so six modules' deploy tasks assert the identical claim six
+  times rather than each module's own deployment.
 - **Declare the binaries `verify` needs, in `requires`.** Optional, an
   inline list alongside `scope`/`verify`/`commit`
   (`requires: ["terraform", "kubectl"]`), and only for tools that come


### PR DESCRIPTION
## Summary
- `lintCore` now warns when a per-module layer's `verify` command carries neither a `{module}` token nor a path argument inside its own scope — such a command compiles byte-identical across every module and can't tell one module's build from another's.
- Adds a matching authoring rule to `hedgehog-core-design`'s Step 5 constraints, in the same style as the existing filter-token and `verify_radius` rules.
- The check abstains whenever there's real ambiguity: a declared `verify_radius` (already an on-record claim of reading wider), a flag-based filter it can't see into, or `once`/`exclusive` layers.

Closes the most actionable finding in #9 — a six-module `deploy` layer with a fixed `kubectl apply -f k8s/` verify passed the same check six times over five modules that were never actually deployed. The issue's other three suggested rules (non-empty-aggregate assertions, forced refresh on cached controller status, "prefer effect over report" generally) aren't mechanically checkable without much larger, riskier machinery, and are already covered as prose guidance in Step 4c.

## Test plan
- [x] New repro test `repro/verify-has-module-token.mjs` — warns on the no-evidence case, stays silent on `{module}` token / module-scoped path / declared `verify_radius` / `once` / `exclusive` / non-module-axis cores, clean on both shipped cores
- [x] Existing `repro/verify-covers-radius.mjs` and `repro/radius-covers-scope.mjs` still pass unchanged
- [x] `pnpm check` passes (18 agents, 24 skills, 2 cores, tarball, CLI)