### PR TITLE
fix(planning-intake): check uv is on PATH before running the BMAD shelf

### DIFF
--- a/src/skills/hedgehog-planning-intake/SKILL.md
+++ b/src/skills/hedgehog-planning-intake/SKILL.md
@@ -33,6 +33,19 @@ graph holds no intents yet. When the graph already holds intents, run the
 **Re-entry pass** at the end of this file instead; the shelf does not run
 twice on one project.
 
+Check `uv` is on PATH before anything else — every skill in the shelf
+below shells out to it (`uv run {bmad-root}/scripts/*.py`) for its
+memlog, customization resolution, and research tooling, so its absence
+mid-shelf strands a run partway through rather than failing at the one
+point where the whole shelf is still skippable. Run `uv --version`; if
+it fails (not found, or exits non-zero), stop before running any BMAD
+skill and tell the user plainly: `uv` is required by the vendored BMAD
+planning shelf and isn't on PATH — install it
+(https://docs.astral.sh/uv/getting-started/installation/) and re-run.
+Don't fall back to a reduced or headless shelf run on this failure;
+that's a silent behavior change of exactly the kind this check exists
+to prevent.
+
 State the BMAD attribution, then run the vendored shelf in full
 sequence — on a first run there is no per-project skip logic and no
 reduced default set:


### PR DESCRIPTION
## Summary
- Landing the separable piece of #21: the vendored BMAD planning shelf (`vendor-skills/BMAD/`) depends on `uv` for every skill's memlog, customization resolution, and research tooling (`uv run {bmad-root}/scripts/*.py`), but nothing checked for it before this — its absence just silently changed what the shelf did partway through a run.
- Adds a check at the top of `hedgehog-planning-intake`'s Phase 0 (which `hedgehog-landing-loop` also runs in full, so both cores that invoke BMAD are covered): run `uv --version` before any BMAD skill runs, and fail loudly with an install pointer if it's missing, rather than falling back to a reduced/headless run.
- This is a prose-level instruction in the skill markdown, not the `requires:`/`core.mjs` binary-declaration mechanism — that mechanism is scoped to `core.yaml` layer `verify` commands and BMAD isn't a core layer, so there's no `core.yaml` field for it to hook into.

Does **not** attempt the larger architecture question in #21 (a subagent's structural inability to hold BMAD's multi-turn elicitation) — that's confirmed still open per the maintainer's comment on the issue, and needs a real design decision this PR doesn't make.

## Test plan
- [x] `pnpm check` passes
- [x] Confirmed `uv` is referenced by every BMAD shelf skill (`grep -rn "uv run" vendor-skills/BMAD`) so the check point (before Phase 0 starts) covers all of them
- [x] Confirmed `hedgehog-landing-loop`'s planning intake reuses `hedgehog-planning-intake`'s Phase 0 in full, so the check applies there too without duplication