### PR TITLE
fix(planner): run first-run planning intake inline, not as a subagent

### DIFF
--- a/src/agents/planner.md
+++ b/src/agents/planner.md
@@ -40,6 +40,16 @@ asks for something that's new scope rather than a tweak (routed here by
 `tweaker`), or before a large refactor that might cross module boundaries
 (full-stack-app).
 
+**First run stays inline, not a detached subagent dispatch.** Phase 0's
+BMAD shelf holds a live, multi-turn conversation with the user
+(Facilitator/Creative Partner mode); a subagent has no channel back to
+them mid-run. The root `CLAUDE.md`'s fresh-install greeting follows this
+file directly in the session already talking to the user, through
+Confirm & Lock and the `bootstrap` handoff — only that handoff and what
+follows delegates normally. Re-entry stays a subagent dispatch: its
+questions are short, scoped, and answer-shaped, not a facilitated
+session.
+
 ## Phase 0 — which core applies
 
 Before invoking any planning-intake skill, on a first run only (Workflow

--- a/src/skills/hedgehog-planning-intake/SKILL.md
+++ b/src/skills/hedgehog-planning-intake/SKILL.md
@@ -33,6 +33,13 @@ graph holds no intents yet. When the graph already holds intents, run the
 **Re-entry pass** at the end of this file instead; the shelf does not run
 twice on one project.
 
+Run Phase 0 in the session already talking to the user, never as a
+detached subagent — every skill below can drop into Facilitator or
+Creative Partner mode, a live multi-turn conversation a subagent has no
+channel to hold (`planner.md` states the same constraint). Applies
+regardless of which core invoked this Phase — `hedgehog-landing-loop`
+runs it in full too.
+
 Check `uv` is on PATH before anything else — every skill in the shelf
 below shells out to it (`uv run {bmad-root}/scripts/*.py`) for its
 memlog, customization resolution, and research tooling, so its absence

--- a/src/templates/CLAUDE.md
+++ b/src/templates/CLAUDE.md
@@ -29,11 +29,14 @@ build stays mechanically correct. Follow them exactly.
 If `{{PROJECT_SUMMARY}}` above is still an unfilled placeholder, this is a
 brand-new install and nothing has been built yet. Open with something
 short and warm — 🦔 plus one line asking what the user wants to build —
-then hand straight to `planner`, which decides which Hedgehog core
-applies and runs that core's planning intake. Don't re-explain the
-discipline or summarize this file; the greeting is one line, not a tour.
-Skip this entirely once the placeholder is filled in — every later
-session starts with `hedgehog status`, not a greeting.
+then follow `planner` in this thread, not as a subagent dispatch —
+Phase 0's BMAD elicitation is a live, multi-turn conversation the user
+needs a direct channel for. Read `planner.md` and run it here through
+Confirm & Lock and the `bootstrap` handoff; that handoff and everything
+after it delegates normally. Don't re-explain the discipline or
+summarize this file; the greeting is one line, not a tour. Skip this
+entirely once the placeholder is filled
+in — every later session starts with `hedgehog status`, not a greeting.
 
 ## How to work here
 
@@ -192,9 +195,12 @@ context small:
   where the build is, what's next and why, what's in flight, what's
   blocked — derived from the graph, so no session hands a summary to the
   next one.
-- **Delegate heavy work to agents.** Planning intake, scaffolding, and
-  every build step each run in their own isolated context — so that work
-  doesn't pile up in the main thread.
+- **Delegate heavy work to agents.** Scaffolding and every build step
+  run in their own isolated context, so work doesn't pile up in the
+  main thread. Planning intake's BMAD Phase 0 is the exception — see
+  **First message in a fresh install** above — and stays here through
+  Confirm & Lock; the mining, `bootstrap`, and per-module steps after it
+  delegate as usual.
 - **Don't paste large context back in.** If you find yourself
   re-explaining the architecture, stop — it's fixed and stated in this
   file's core section, not something to reconstruct. If you need a


### PR DESCRIPTION
## Summary

Resolves the architecture question left open in #21 (the `uv` check itself already shipped in #40).

- Root cause: `planner`'s first-run path (Phase 0's vendored BMAD shelf) was dispatched as a detached subagent Task by default — `CLAUDE.md` told the fresh-install greeting to "hand straight to `planner`" and separately said "Delegate heavy work to agents. Planning intake, scaffolding, and every build step each run in their own isolated context." A detached subagent has no channel back to the user mid-run, so BMAD's Facilitator/Creative Partner modes — which need a live, multi-turn back-and-forth — silently degraded to Headless Mode every time, with nothing flagging it. This matches the prior triage comment's read: #2/#6 needed a subagent to *accept* a relayed answer (fixable by relaxing a gate); this needs a subagent to *hold a conversation*, which no gate wording can relay.
- Fix: `planner`'s first-run path now runs inline, in the same thread already talking to the user, through Confirm & Lock and the `bootstrap` handoff — the same pattern `tweaker` already uses for its own user-facing work. Only the mechanical work after that handoff (mining, `bootstrap`, per-module build steps) still delegates to isolated-context subagents, unchanged.
- Re-entry (new scope on an existing project) is explicitly unaffected — its questions are short, scoped, and answer-shaped, not a facilitated multi-turn session, so a subagent dispatch stays fine there (same shape as #2/#6).

Changed:
- `src/templates/CLAUDE.md` — fresh-install greeting now says to follow `planner` inline through Confirm & Lock, and the "Delegate heavy work" bullet carves out this one exception.
- `src/agents/planner.md` — states the inline-dispatch constraint for its own first-run path, and confirms Re-entry keeps delegating.
- `src/skills/hedgehog-planning-intake/SKILL.md` — states the same constraint at the top of Phase 0, since `hedgehog-landing-loop` also runs this Phase 0 in full and needs it too.

## Test plan
- [x] `pnpm check` passes
- [x] Confirmed `bootstrap.md` (what Phase 0 hands off to) re-derives all state from disk (`.hedgehog/addons.yaml`, commit log, `core.yaml`) rather than assuming anything about the conversational context it was invoked from, so it's unaffected by whether `planner` ran inline or as a subagent before it
- [x] Confirmed `hedgehog-landing-loop` runs `hedgehog-planning-intake`'s Phase 0 "in full," so the constraint stated there covers both cores that invoke BMAD without duplicating it