### PR TITLE
feat(overrides): committed, additive-only per-task scope exceptions

### DIFF
--- a/.claude/skills/inbound-triage/SKILL.md
+++ b/.claude/skills/inbound-triage/SKILL.md
@@ -193,6 +193,14 @@ Two checks that catch most mistakes here:
 An issue with a companion PR is one unit of work. Judge them together
 and resolve them together.
 
+**A `real` issue can split.** Fix the part that's genuinely small and
+simple; for a part that needs real machinery to enforce in general, say
+so and close it (already covered elsewhere) or `edge-case` it rather than
+leaving the whole issue open on unbuilt complexity. Don't grow a small
+fix to cover a case that needed a bigger mechanism — a narrow fix plus an
+honest scope comment beats either overbuilding or an issue left open past
+its actionable part.
+
 ### 4. Act
 
 Take the action the verdict implies.
@@ -202,6 +210,7 @@ Take the action the verdict implies.
 | `malicious` | Leave open. Report to maintainer. No comment, no close. |
 | `real`, fix is small and clear | Fix on a branch, open a PR, comment with the link, close the issue once merged. |
 | `real`, fix is large or design-level | Comment with the confirmed analysis, label, leave open. Do not close a real bug for being inconvenient. |
+| `real`, part small and clear, rest would need real machinery | Fix and PR the small part. Comment naming what's fixed, what's out of scope and why (already covered elsewhere, or a genuine gap not worth the mechanism), close. |
 | `edge-case` | Comment with the reasoning and the condition it needs. Close. |
 | `spurious` | Comment with the evidence that disproves it. Close. |
 | `out-of-scope` | Comment with where it does belong. Close. |

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -47,6 +47,7 @@ import { whyPath, formatWhy } from '../src/db/why.mjs';
 import { addFriction, listFriction } from '../src/db/friction.mjs';
 import { addDebt, listDebt } from '../src/db/debt.mjs';
 import { rebuildDb } from '../src/db/rebuild.mjs';
+import { loadOverrides, addOverride, orphanedOverrides, OVERRIDES_DIR } from '../src/db/overrides.mjs';
 import { HOSTS, HOST_FLAGS, DEFAULT_HOST, availableHosts } from '../src/hosts/index.mjs';
 import { recordHosts, installedHosts } from '../src/hosts/installed.mjs';
 
@@ -359,6 +360,9 @@ ${bold('Usage')}
   npx @skyf0xx/hedgehog plan --open               also start the graph server and open it, if anything compiled
   npx @skyf0xx/hedgehog plan --recompile          rewrite core.yaml-derived fields on not-started tasks
                                                    [--dry-run] [--include-blocked] [--strict]
+  npx @skyf0xx/hedgehog override add <task-id> --scope <glob> [--scope <glob>...] --reason "<why>"
+                                                   record a committed, additive-only scope exception for one task
+  npx @skyf0xx/hedgehog override list             list recorded scope overrides
   npx @skyf0xx/hedgehog intent add [flags]        add an intent (rules/requirements/dependencies)
   npx @skyf0xx/hedgehog intent add --file <path>  add an intent from a JSON file
   npx @skyf0xx/hedgehog next                      print the task packet for one ready task
@@ -666,11 +670,12 @@ async function planRecompileCommand(args, { core, corePath }) {
   const includeBlocked = args.includes('--include-blocked');
   const dryRun = args.includes('--dry-run');
   const strict = args.includes('--strict');
+  const overrides = await loadOverrides();
 
   const db = openDb();
   let result;
   try {
-    result = recompileTasks(db, core, { includeBlocked, dryRun });
+    result = recompileTasks(db, core, { includeBlocked, dryRun, overrides });
   } finally {
     db.close();
   }
@@ -749,10 +754,11 @@ async function planCommand(args = []) {
     return;
   }
 
+  const overrides = await loadOverrides();
   const db = openDb();
   let result;
   try {
-    result = planTasks(db, core);
+    result = planTasks(db, core, overrides);
   } finally {
     db.close();
   }
@@ -778,7 +784,7 @@ async function planCommand(args = []) {
   const driftDb = openDb({ readOnly: true });
   let drifted;
   try {
-    drifted = detectDrift(driftDb, core);
+    drifted = detectDrift(driftDb, core, { overrides });
   } finally {
     driftDb.close();
   }
@@ -1500,10 +1506,11 @@ async function statusCommand() {
     }
   }
 
+  const overrides = core ? await loadOverrides() : new Map();
   const db = openDb();
   let result;
   try {
-    result = graphStatus(db, { core });
+    result = graphStatus(db, { core, overrides });
   } finally {
     db.close();
   }
@@ -1900,6 +1907,122 @@ async function frictionCommand(args) {
   process.exitCode = 1;
 }
 
+// `hedgehog override add <task-id> --scope <glob> [--scope <glob>...]
+// --reason "<why>"` / `hedgehog override list` — per-task scope
+// exceptions (see src/db/overrides.mjs). Writes
+// .hedgehog/overrides/<task-id>.json; the next `hedgehog plan` (for a
+// not-yet-compiled task) or `hedgehog plan --recompile` (for one already
+// compiled) is what actually widens the task's scope_globs — this command
+// only records the committed intent to do so.
+async function overrideCommand(args) {
+  await ensureDb();
+
+  const sub = args[0];
+
+  if (sub === 'add') {
+    const taskId = args[1];
+    const rest = args.slice(2);
+    const scopeAdd = [];
+    let reason;
+    for (let i = 0; i < rest.length; i++) {
+      const flag = rest[i];
+      const value = rest[i + 1];
+      if (flag === '--scope') {
+        if (!value) {
+          console.error(`${red('--scope requires a glob')}\n`);
+          process.exitCode = 1;
+          return;
+        }
+        scopeAdd.push(value);
+        i++;
+      } else if (flag === '--reason') {
+        if (!value) {
+          console.error(`${red('--reason requires text')}\n`);
+          process.exitCode = 1;
+          return;
+        }
+        reason = value;
+        i++;
+      } else {
+        console.error(`${red('Unknown override flag:')} ${flag}\n`);
+        process.exitCode = 1;
+        return;
+      }
+    }
+
+    if (!taskId || scopeAdd.length === 0 || !reason) {
+      console.error(
+        `${red('Usage:')} hedgehog override add <task-id> --scope <glob> [--scope <glob>...] --reason "<why>"\n`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    let record;
+    try {
+      record = await addOverride({ task: taskId, scope_add: scopeAdd, reason });
+    } catch (err) {
+      console.error(`${red('Failed to add override:')} ${err.message}\n`);
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log(`  ${green('added')}  ${OVERRIDES_DIR}/${record.task.toLowerCase()}.json`);
+    for (const glob of record.scope_add) console.log(`    + ${glob}`);
+    console.log(
+      `  ${dim(`run \`hedgehog plan --recompile\` to widen ${record.task} now, if it's already compiled`)}\n`,
+    );
+    return;
+  }
+
+  if (sub === 'list') {
+    const overrides = await loadOverrides();
+    if (overrides.size === 0) {
+      console.log(`${dim('No overrides recorded.')}\n`);
+      return;
+    }
+
+    // Best-effort: an override file can legitimately exist before `db
+    // init`/`plan` has ever run (e.g. written ahead of the intent it
+    // targets), so a missing DB just skips the orphan check rather than
+    // failing the whole listing.
+    let orphaned = [];
+    if (await exists(DB_PATH)) {
+      const db = openDb({ readOnly: true });
+      try {
+        orphaned = orphanedOverrides(db, overrides);
+      } finally {
+        db.close();
+      }
+    }
+
+    for (const [taskId, records] of overrides) {
+      for (const record of records) {
+        console.log(`${bold(taskId)}`);
+        console.log(`  ${dim(record.reason)}`);
+        for (const glob of record.scope_add) console.log(`  + ${glob}`);
+        console.log('');
+      }
+    }
+
+    if (orphaned.length > 0) {
+      console.log(
+        `${yellow(bold('Orphaned:'))} ${orphaned.join(', ')} — no task with this id exists in the\n` +
+          `build graph yet. A typo'd id, a renamed layer/module, or an intent that hasn't\n` +
+          `compiled yet all look like this; it silently widens nothing until the id matches.\n`,
+      );
+    }
+    return;
+  }
+
+  console.error(
+    `${red('Unknown override subcommand:')} ${sub ?? '(none)'}\n\n` +
+      `Usage: hedgehog override add <task-id> --scope <glob> [--scope <glob>...] --reason "<why>"\n` +
+      `   or: hedgehog override list\n`,
+  );
+  process.exitCode = 1;
+}
+
 // `hedgehog debt add <task-id> "<note>"` / `hedgehog debt list [<task-id>]`
 // — declared debt between tasks. A note recorded against a task is
 // rendered into the INHERITED DEBT section of the packet of every task
@@ -2118,6 +2241,11 @@ async function main() {
 
   if (cmd === 'debt') {
     await debtCommand(args.slice(1));
+    return;
+  }
+
+  if (cmd === 'override') {
+    await overrideCommand(args.slice(1));
     return;
   }
 

--- a/src/db/drift.mjs
+++ b/src/db/drift.mjs
@@ -31,6 +31,7 @@ import {
   taskId,
   CORE_MODULE,
 } from './plan.mjs';
+import { loadOverrides } from './overrides.mjs';
 
 // Statuses a field rewrite is safe on: nothing has been built, leased,
 // committed, or failed against these rows yet, so moving their ALLOWED
@@ -109,7 +110,13 @@ function recordedParents(db, task) {
 // than layerTaskFields — using the per-intent path here would compare
 // every once-task against a substitution that never happened and report
 // permanent, unfixable drift on every one.
-export function taskDrift(db, task, core) {
+//
+// `overrides` (overrides.mjs#loadOverrides) has to compose into `expected`
+// here too, or an overridden task's core.yaml-derived scope_globs would
+// never match its widened row and every overridden task would report
+// permanent drift — false positives severe enough to train people to
+// ignore the whole DRIFT section.
+export function taskDrift(db, task, core, overrides = new Map()) {
   const layer = core.layers.find((l) => l.id === task.layer);
   if (!layer) {
     return {
@@ -123,7 +130,9 @@ export function taskDrift(db, task, core) {
   }
 
   const isOnce = task.module === CORE_MODULE;
-  const expected = isOnce ? onceLayerTaskFields(layer) : layerTaskFields(layer, task.module);
+  const expected = isOnce
+    ? onceLayerTaskFields(layer, overrides)
+    : layerTaskFields(layer, task.module, overrides);
   const fields = [];
   for (const field of LAYER_DERIVED_FIELDS) {
     const want = normalize(expected[field]);
@@ -184,10 +193,10 @@ export function isRecompilable(status, { includeBlocked = false } = {}) {
 }
 
 // Every drifted task, in `priority, id` order. Read-only.
-export function detectDrift(db, core, { includeBlocked = false } = {}) {
+export function detectDrift(db, core, { includeBlocked = false, overrides = new Map() } = {}) {
   const drifted = [];
   for (const task of loadTasks(db)) {
-    const drift = taskDrift(db, task, core);
+    const drift = taskDrift(db, task, core, overrides);
     if (!drift) continue;
     drift.recompilable =
       drift.fields.length > 0 && !drift.missingLayer && isRecompilable(task.status, { includeBlocked });
@@ -220,8 +229,18 @@ const UPDATE_SQL = `
 // field list), `skipped` the drifted tasks left alone (with the reason
 // and the fields that stay stale). `dryRun` computes both without
 // writing.
-export function recompileTasks(db, core, { includeBlocked = false, dryRun = false } = {}) {
-  const drifted = detectDrift(db, core, { includeBlocked });
+//
+// `overrides` composes into the rewritten fields the same as it does in
+// detectDrift, so `--recompile` never rewrites an overridden task's
+// scope_globs back down to core.yaml's bare layer scope — that would be
+// exactly the silent-shrink-on-rebuild bug overrides.mjs exists to end,
+// just triggered by `--recompile` instead of `db rebuild`.
+export function recompileTasks(
+  db,
+  core,
+  { includeBlocked = false, dryRun = false, overrides = new Map() } = {},
+) {
+  const drifted = detectDrift(db, core, { includeBlocked, overrides });
   const updated = drifted.filter((d) => d.recompilable);
   const skipped = drifted.filter((d) => !d.recompilable);
 
@@ -241,7 +260,10 @@ export function recompileTasks(db, core, { includeBlocked = false, dryRun = fals
         continue;
       }
       const layer = core.layers.find((l) => l.id === task.layer);
-      const fields = layerTaskFields(layer, task.module);
+      const fields =
+        task.module === CORE_MODULE
+          ? onceLayerTaskFields(layer, overrides)
+          : layerTaskFields(layer, task.module, overrides);
       run.run(
         fields.objective,
         fields.scope_globs,

--- a/src/db/overrides.mjs
+++ b/src/db/overrides.mjs
@@ -1,0 +1,216 @@
+// `.hedgehog/overrides/*.json` — per-task scope exceptions.
+//
+// A module-axis core's layer scope is a template applied to every module
+// alike (`apps/api/src/{module}/http/**`), and core.mjs#validateCore
+// requires every layer to carry `{module}` on such a core specifically so
+// no layer can special-case one module over another. That uniformity is
+// the point — a scope widened in the layer definition grants the same
+// extra reach to every module's task, not just the one that needs it.
+//
+// Real builds still hit tasks that need to touch one file outside their
+// module: a composition seam nobody's layer owns (binding a port the
+// module declared, registering a route in a shared router). Before this,
+// the only move was a direct `UPDATE tasks SET scope_globs = ...` in
+// SQLite — invisible to `git diff`, absent from the permanent record
+// (`.hedgehog/intents/*.json`, `core.yaml`, the commit history), and
+// silently dropped by `hedgehog db rebuild`, which re-derives scope_globs
+// from core.yaml alone and has no idea the hand-edit ever existed.
+//
+// An override file closes that gap the same way `.hedgehog/intents/*.json`
+// already does for intents: committed, plain text, replayed by both
+// `planTasks` (at compile time) and `rebuildDb` (on every rebuild) through
+// the same `composeScope` this module exports. `detectDrift` reads through
+// it too — an overridden task's expected scope is core.yaml's layer
+// composed with its override, not core.yaml's layer alone, or every
+// overridden task would report permanent, unfixable drift.
+//
+// Three constraints, load-bearing rather than incidental:
+//   - additive only: `scope_add`, never a replace or a shrink. An
+//     override widens what a task may touch; it can never narrow the
+//     gate `core.yaml` already set.
+//   - one task, not a layer or a module. A per-layer override is a layer
+//     edit wearing a disguise and reintroduces the "widens for all six
+//     modules" problem this exists to avoid.
+//   - no `verify` overrides. Weakening a layer's verify command is the
+//     one thing the discipline forbids outright, override file or not — a
+//     wrong verify command belongs in core.yaml, corrected through
+//     `hedgehog plan --recompile`.
+
+import { readdir, readFile, mkdir, writeFile, rename, rm } from 'node:fs/promises';
+
+export const OVERRIDES_DIR = '.hedgehog/overrides';
+
+function overrideFilePath(taskId, overridesDir = OVERRIDES_DIR) {
+  return `${overridesDir}/${taskId.toLowerCase()}.json`;
+}
+
+// Validates one parsed override record. Throws with the offending file's
+// path in the message — this runs at load time, over every file in the
+// directory, so a bad record has to name itself to be findable.
+function validateOverride(record, path) {
+  if (record === null || typeof record !== 'object') {
+    throw new Error(`${path}: override must be a JSON object`);
+  }
+  let { task } = record;
+  const { scope_add: scopeAdd, reason } = record;
+
+  if (!task || typeof task !== 'string') {
+    throw new Error(`${path}: override requires a "task" id (string)`);
+  }
+  // plan.mjs#taskId / #onceTaskId always upper-case the id they compile a
+  // task under, and composeScope looks up this Map by that exact string —
+  // so a lower- or mixed-case "task" here (e.g. the CLI's own convention
+  // of lowercase-with-dashes elsewhere, "orders-api") would key a Map
+  // entry composeScope can never match, silently no-op-ing the override at
+  // every call site (plan/recompile/rebuild/detectDrift) with no error.
+  // Normalizing here, once, is what keeps the Map key space exact-match
+  // everywhere else.
+  task = task.toUpperCase();
+  if (!Array.isArray(scopeAdd) || scopeAdd.length === 0) {
+    throw new Error(`${path}: override "${task}" requires a non-empty "scope_add" array`);
+  }
+  for (const glob of scopeAdd) {
+    if (typeof glob !== 'string' || glob.trim() === '') {
+      throw new Error(`${path}: override "${task}" has a non-string or empty entry in scope_add`);
+    }
+  }
+  if (!reason || typeof reason !== 'string') {
+    throw new Error(
+      `${path}: override "${task}" requires a "reason" (string) — this is the permanent record of why the task's scope was widened`,
+    );
+  }
+
+  // Reject the two shapes the issue's design explicitly rules out, rather
+  // than silently ignoring the fields: a typo'd attempt at either is much
+  // more likely than a deliberate probe of the boundary, and failing loud
+  // surfaces it at load time instead of at "why did this task's verify
+  // command change".
+  if ('scope_replace' in record) {
+    throw new Error(
+      `${path}: override "${task}" has "scope_replace", which this file format does not support — overrides are additive only (scope_add)`,
+    );
+  }
+  if ('verify' in record || 'verify_command' in record) {
+    throw new Error(
+      `${path}: override "${task}" attempts to override verify — not permitted. A wrong verify command belongs in core.yaml, reconciled via "hedgehog plan --recompile"`,
+    );
+  }
+
+  return { task, scope_add: [...scopeAdd], reason };
+}
+
+// Reads every *.json file in `overridesDir`, validates each, and returns
+// a Map from task id to its list of override records (a task could in
+// principle be widened more than once, by separate files with separate
+// reasons — each stays a distinct, individually-reviewable entry rather
+// than being merged into one).
+//
+// Absent directory reads as "no overrides", the same way
+// rebuild.mjs#loadIntentFiles treats a missing .hedgehog/intents/.
+export async function loadOverrides(overridesDir = OVERRIDES_DIR) {
+  let entries;
+  try {
+    entries = await readdir(overridesDir);
+  } catch {
+    return new Map();
+  }
+
+  const byTask = new Map();
+  for (const name of entries.filter((n) => n.endsWith('.json')).sort()) {
+    const path = `${overridesDir}/${name}`;
+    let parsed;
+    try {
+      parsed = JSON.parse(await readFile(path, 'utf8'));
+    } catch (err) {
+      throw new Error(`could not read override file ${path}: ${err.message}`);
+    }
+    const record = validateOverride(parsed, path);
+    if (!byTask.has(record.task)) byTask.set(record.task, []);
+    byTask.get(record.task).push(record);
+  }
+  return byTask;
+}
+
+// Every scope_add glob recorded for `taskId`, flattened across however
+// many override files name it, in file order (loadOverrides sorts by
+// filename, so this is deterministic across machines and runs).
+export function scopeAddFor(overrides, taskId) {
+  const records = overrides.get(taskId) ?? [];
+  return records.flatMap((r) => r.scope_add);
+}
+
+// Override task ids that never match a row in `tasks` — a typo'd id, a
+// task from a renamed module/layer, or a legitimately future one (the
+// intent it belongs to hasn't compiled yet). validateOverride only checks
+// shape, not whether the id is real, because it runs before a DB
+// connection is available (`hedgehog override add` writes a file; it
+// doesn't compile anything) — this is the read side that closes the gap,
+// so a dead override has *some* discovery path instead of silently
+// widening nothing forever with no error and no drift signal (composeScope
+// composing a non-matching key is a no-op, not a throw).
+export function orphanedOverrides(db, overrides) {
+  const known = new Set(db.prepare('SELECT id FROM tasks').all().map((r) => r.id));
+  return [...overrides.keys()].filter((taskId) => !known.has(taskId)).sort();
+}
+
+// Composes a task-fields object (as produced by plan.mjs's
+// layerTaskFields/onceLayerTaskFields) with its overrides — the single
+// place `scope_globs` is widened, shared by planTasks, recompileTasks and
+// detectDrift so the three can never compute a different "expected scope"
+// for the same task. Additive only: the result's scope_globs is always a
+// superset of `fields.scope_globs`, glob-for-glob, in core.yaml's order
+// followed by scope_add's.
+export function composeScope(fields, taskId, overrides) {
+  const add = scopeAddFor(overrides, taskId);
+  if (add.length === 0) return fields;
+
+  const base = JSON.parse(fields.scope_globs);
+  const merged = [...base];
+  for (const glob of add) {
+    if (!merged.includes(glob)) merged.push(glob);
+  }
+  return { ...fields, scope_globs: JSON.stringify(merged) };
+}
+
+// Writes one override record to OVERRIDES_DIR/<task-id-lowercased>.json,
+// via temp-file + rename so a crash mid-write can never leave a
+// half-written file for loadOverrides to trip on — the same pattern
+// intent.mjs#writeIntentFile uses for the same reason.
+//
+// Refuses to overwrite an existing file silently: a second `hedgehog
+// override add` for the same task is far more likely to be a mistake
+// (wrong task id, forgot it was already done) than an intentional
+// replacement, and unlike scope_add's own merge, a second file for the
+// same task is the supported way to add a second, separately-reasoned
+// exception rather than to edit the first one.
+export async function writeOverrideFile(record, overridesDir = OVERRIDES_DIR) {
+  const path = overrideFilePath(record.task, overridesDir);
+  try {
+    await readFile(path, 'utf8');
+    throw new Error(
+      `${path} already exists — edit it directly, or pick a different filename, rather than re-running "hedgehog override add" for the same task`,
+    );
+  } catch (err) {
+    if (!err || err.code !== 'ENOENT') throw err;
+  }
+
+  await mkdir(overridesDir, { recursive: true });
+  const tempPath = `${path}.tmp-${process.pid}`;
+  try {
+    await writeFile(tempPath, JSON.stringify(record, null, 2));
+    await rename(tempPath, path);
+  } catch (err) {
+    await rm(tempPath, { force: true }).catch(() => {});
+    throw err;
+  }
+  return record;
+}
+
+// Validates and writes a new override in one step — the `hedgehog
+// override add` entry point. Validates against the same rules
+// loadOverrides enforces, so a record this function accepts is guaranteed
+// loadable.
+export async function addOverride({ task, scope_add: scopeAdd, reason }, overridesDir = OVERRIDES_DIR) {
+  const record = validateOverride({ task, scope_add: scopeAdd, reason }, '(new override)');
+  return writeOverrideFile(record, overridesDir);
+}

--- a/src/db/plan.mjs
+++ b/src/db/plan.mjs
@@ -18,6 +18,8 @@
 // graph holds. Without it such a layer compiles once per intent and
 // every copy but the first is a replay of the same command.
 
+import { composeScope, loadOverrides } from './overrides.mjs';
+
 export function fillModule(template, module) {
   return template.replaceAll('{module}', module);
 }
@@ -42,8 +44,15 @@ export function onceTaskId(layerId) {
 // rejects one that names {module}) — so this can't share
 // layerTaskFields's body, only its role as the one place drift.mjs and
 // the compiler both read from.
-export function onceLayerTaskFields(layer) {
-  return {
+//
+// `overrides` (a Map from overrides.mjs#loadOverrides, keyed by task id —
+// here always onceTaskId(layer.id)) is composed in last, via
+// composeScope, so a hand-authored .hedgehog/overrides/*.json entry
+// widens scope_globs the same way for a once-task as for a per-intent
+// one. Defaults to an empty Map so every existing caller that doesn't
+// pass one keeps computing the un-widened fields.
+export function onceLayerTaskFields(layer, overrides = new Map()) {
+  const fields = {
     objective: `${layer.id} for the whole build`,
     scope_globs: JSON.stringify(layer.scope),
     verify_command: layer.verify,
@@ -51,6 +60,7 @@ export function onceLayerTaskFields(layer) {
     exclusive: layer.exclusive ? 1 : 0,
     verify_radius: layer.verify_radius === null ? null : JSON.stringify(layer.verify_radius),
   };
+  return composeScope(fields, onceTaskId(layer.id), overrides);
 }
 
 // `tasks.intent_id` is NOT NULL and a foreign key into `intents`, so a
@@ -97,7 +107,7 @@ function layerById(core) {
 // cardinality boundary in either direction are per-intent and belong to
 // compileIntentTasks. Independent of the intent set entirely, which is
 // what makes the result identical on every run.
-function compileOnceTasks(core) {
+function compileOnceTasks(core, overrides) {
   const byId = layerById(core);
   const onceLayers = core.layers.filter((layer) => layer.once);
 
@@ -107,7 +117,7 @@ function compileOnceTasks(core) {
     module: CORE_MODULE,
     layer: layer.id,
     priority: CORE_INTENT_PRIORITY,
-    ...onceLayerTaskFields(layer),
+    ...onceLayerTaskFields(layer, overrides),
   }));
 
   const dependencies = [];
@@ -159,8 +169,13 @@ export const LAYER_DERIVED_FIELDS = [
 
 // The single definition of "what a layer contributes to a task row",
 // shared by the compiler (below) and the drift check (drift.mjs).
-export function layerTaskFields(layer, module) {
-  return {
+//
+// `overrides` mirrors onceLayerTaskFields's parameter: composed in last
+// via composeScope, keyed on taskId(module, layer.id) — for a per-intent
+// task `module` IS the intent id, so this is exactly the id the task row
+// is inserted under.
+export function layerTaskFields(layer, module, overrides = new Map()) {
+  const fields = {
     objective: `${layer.id} for ${module}`,
     scope_globs: JSON.stringify(layer.scope.map((g) => fillModule(g, module))),
     verify_command: fillModule(layer.verify, module),
@@ -171,11 +186,12 @@ export function layerTaskFields(layer, module) {
         ? null
         : JSON.stringify(layer.verify_radius.map((g) => fillModule(g, module))),
   };
+  return composeScope(fields, taskId(module, layer.id), overrides);
 }
 
 // Compiles one intent's tasks + intra-intent dependencies (mirroring the
 // core definition's layer order) without touching the database.
-function compileIntentTasks(intent, core) {
+function compileIntentTasks(intent, core, overrides) {
   const module = intent.id;
   const byId = layerById(core);
   const perIntentLayers = core.layers.filter((layer) => !layer.once);
@@ -186,7 +202,7 @@ function compileIntentTasks(intent, core) {
     module,
     layer: layer.id,
     priority: intent.priority,
-    ...layerTaskFields(layer, module),
+    ...layerTaskFields(layer, module, overrides),
   }));
 
   const dependencies = [];
@@ -422,7 +438,15 @@ const insertTaskRequirement = (db) =>
 // already-compiled intents are skipped and so contribute no edges to the
 // new once-layer. Delete `.hedgehog/hedgehog.db` and `hedgehog db
 // rebuild` to recompile the whole graph against the new definition.
-export function planTasks(db, core) {
+//
+// `overrides` (from overrides.mjs#loadOverrides) is composed into every
+// task's scope_globs at the moment it's compiled, via layerTaskFields /
+// onceLayerTaskFields. A task compiled before its override file existed
+// does NOT pick it up here — planTasks only ever INSERTs — so an
+// override written after the fact needs `hedgehog plan --recompile`
+// (drift.mjs composes the same overrides Map) the same as any other
+// core.yaml-derived field would.
+export function planTasks(db, core, overrides = new Map()) {
   const intents = loadPendingIntents(db);
   const intentDependencies = loadIntentDependencies(db);
   const ordered = orderIntents(intents, intentDependencies);
@@ -459,7 +483,7 @@ export function planTasks(db, core) {
   try {
     if (onceTaskIds.size > 0 && countRealIntents(db) > 0) {
       ensureCoreIntent(db, core);
-      const { tasks, dependencies } = compileOnceTasks(core);
+      const { tasks, dependencies } = compileOnceTasks(core, overrides);
       for (const t of tasks) {
         if (taskExists(db, t.id)) continue;
         runInsert.run(
@@ -489,7 +513,7 @@ export function planTasks(db, core) {
         continue;
       }
 
-      const { tasks, dependencies } = compileIntentTasks(intent, core);
+      const { tasks, dependencies } = compileIntentTasks(intent, core, overrides);
       const requirementIds = loadIntentRequirements(db, intent.id).map((r) => r.id);
       for (const t of tasks) {
         // <INTENT>-<LAYER> colliding with a bare once-layer id would

--- a/src/db/rebuild.mjs
+++ b/src/db/rebuild.mjs
@@ -22,6 +22,7 @@ import { normalizeIntent, insertIntentRows, INTENTS_DIR } from './intent.mjs';
 import { planTasks, CORE_MODULE } from './plan.mjs';
 import { loadCore } from './core.mjs';
 import { detectDrift } from './drift.mjs';
+import { loadOverrides, OVERRIDES_DIR } from './overrides.mjs';
 
 // Alphabetical by filename, purely to make the *tie-break* deterministic
 // across machines and runs. It is NOT the replay order — see
@@ -252,27 +253,31 @@ function markCompletedTasks(db, commitSubjects) {
 //
 // `drift` in the return is the honest disclosure this rebuild owes its
 // caller. A rebuild re-derives every task's layer-derived fields from
-// the *current* core.yaml, and the intent files it replays carry no
-// task-level detail at all — so any hand-edit made directly to a task
-// row (the widened scope glob, the patched verify command) has no
-// committed source to replay from and does not survive. Rows that
-// predate this rebuild are left as they are, which is the other half of
-// the same problem: they can be stale against core.yaml and nothing
-// would otherwise say so. Reporting the divergence is what turns both
-// into something the operator sees instead of something they discover
-// three layers later.
-export async function rebuildDb(db, { corePath, intentsDir = INTENTS_DIR } = {}) {
+// the *current* core.yaml (composed with `.hedgehog/overrides/*.json`,
+// which — unlike a hand-edited task row — IS a committed source and so
+// DOES survive), so any hand-edit made directly to a task row that never
+// got written as an override file has no committed source to replay from
+// and does not survive. Rows that predate this rebuild are left as they
+// are, which is the other half of the same problem: they can be stale
+// against core.yaml and nothing would otherwise say so. Reporting the
+// divergence is what turns both into something the operator sees instead
+// of something they discover three layers later.
+export async function rebuildDb(
+  db,
+  { corePath, intentsDir = INTENTS_DIR, overridesDir = OVERRIDES_DIR } = {},
+) {
   applySchema(db);
 
   const intentsReplayed = await replayIntents(db, intentsDir);
 
   const core = await loadCore(corePath);
-  planTasks(db, core);
+  const overrides = await loadOverrides(overridesDir);
+  planTasks(db, core, overrides);
 
   const commitSubjects = loadCommitSubjects();
   const tasksMarkedComplete = markCompletedTasks(db, commitSubjects);
 
-  const drift = detectDrift(db, core);
+  const drift = detectDrift(db, core, { overrides });
 
   return { intentsReplayed, tasksMarkedComplete, drift };
 }

--- a/src/db/status.mjs
+++ b/src/db/status.mjs
@@ -92,12 +92,17 @@ function loadAttentionTasks(db) {
 // parameter rather than a lookup because status.mjs has no business
 // resolving the project's core path — the CLI already does that, and
 // a project mid-install may not have a core definition at all.
-export function graphStatus(db, { core = null } = {}) {
+//
+// `overrides` (overrides.mjs#loadOverrides) is likewise the CLI's to
+// resolve and pass in — detectDrift needs it composed against `core` or
+// every task widened by `.hedgehog/overrides/*.json` reports permanent,
+// spurious drift here.
+export function graphStatus(db, { core = null, overrides = new Map() } = {}) {
   const counts = countTasksByStatus(db);
   const ready = loadReadyTasks(db);
   const inFlight = loadInFlightTasks(db);
   const attention = loadAttentionTasks(db);
-  const drift = core ? detectDrift(db, core) : [];
+  const drift = core ? detectDrift(db, core, { overrides }) : [];
   const total = Object.values(counts).reduce((a, b) => a + b, 0);
   return { counts, ready, inFlight, attention, drift, total };
 }


### PR DESCRIPTION
## Summary

Closes #26. A module-axis core's layer scope is a `{module}` template applied uniformly to every module (`validateCore` requires it), so a task needing to touch one file outside its module — a composition seam nobody's layer owns — had no way to express that exception without a direct SQLite `UPDATE`: invisible to `git diff`, absent from the permanent record, and silently dropped by `hedgehog db rebuild`.

`.hedgehog/overrides/*.json` closes the gap the same way `.hedgehog/intents/*.json` already does for intents: committed, plain text, composed into `scope_globs` by `planTasks` and `rebuildDb`, and read by `detectDrift` so an overridden task's expected scope is core.yaml **composed with** its override rather than core.yaml alone — otherwise every overridden task would report permanent, unfixable drift (the coupling the issue itself flagged as the reason not to implement this speculatively, now that #17's drift detection has landed).

The three constraints from the issue are enforced structurally:
- **Additive only** — `validateOverride` rejects a `scope_replace` key outright; `composeScope` only ever appends globs.
- **Per-task, never per-layer/module** — the override's `task` field is used as an exact Map key; no wildcard/pattern matching exists anywhere in the lookup path.
- **No `verify` overrides** — `validateOverride` rejects `verify`/`verify_command` keys outright.

New CLI surface: `hedgehog override add <task-id> --scope <glob> [--scope <glob>...] --reason "<why>"` and `hedgehog override list` (which also flags overrides whose task id never matched a compiled task — a typo or stale id otherwise silently widens nothing with no error anywhere).

Also fixes a latent bug in `drift.mjs#recompileTasks` found while wiring this up: it always rewrote a drifted task's fields via `layerTaskFields`, including once-layer tasks, which would incorrectly substitute `{module}` into fields a once-layer never takes it in. It now branches to `onceLayerTaskFields` the same way `taskDrift` already did.

## Test plan

- [x] Verified end-to-end via direct module calls and the real CLI against a scratch git repo: override applies at `plan` time, `detectDrift` shows no false positive when composed (and correctly *would* show drift if omitted — sanity check), override survives a full `db rebuild` from scratch, and all three validation guards throw correctly.
- [x] Independent reviewer pass caught a real bug (override task ids weren't case-normalized against `taskId()`/`onceTaskId()`'s uppercase convention, so a lowercase `--task` would silently no-op forever) — fixed and re-verified.
- [x] Added orphaned-override detection (`orphanedOverrides`) surfaced in `override list`, verified it appears before the task compiles and clears after.
- [x] `node --check` on every touched file.