### PR TITLE
docs(contributing): point at open help-wanted issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,9 @@ one file. The `hedgehog-contributing` skill
 committing, and opening a PR for either kind, and `tweaker` offers it
 directly at the end of a build.
 
+You're also welcome to pick up any open issue labeled
+[`help wanted`](https://github.com/skyf0xx/hedgehog/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+
 ## Before you start
 
 Read `CLAUDE.md` at the repo root. It defines the rules this content has to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary
- Adds a note in CONTRIBUTING.md pointing first-time contributors at the open `help wanted` issues, alongside the existing ROADMAP.md pointer.
- Bumps package version to 4.0.6.

## Test plan
- [x] Docs-only change, link verified against the live issues query.