### PR TITLE
ci(release): auto-tag master when package.json version changes

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,36 @@
+name: Tag release
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - package.json
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    if: github.repository == 'skyf0xx/hedgehog'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+
+      - id: version
+        run: |
+          before=$(git show HEAD^:package.json | node -p 'JSON.parse(require("fs").readFileSync(0, "utf8")).version' 2>/dev/null || echo "")
+          after=$(node -p 'require("./package.json").version')
+          echo "before=$before" >> "$GITHUB_OUTPUT"
+          echo "after=$after" >> "$GITHUB_OUTPUT"
+
+      - if: steps.version.outputs.before != steps.version.outputs.after
+        env:
+          TAG: v${{ steps.version.outputs.after }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$TAG"
+          git push origin "$TAG"


### PR DESCRIPTION
## Summary
- `publish.yml` only triggers on a pushed `vX.Y.Z` tag, but nothing in CI creates that tag — every release so far needed someone to manually `git tag` + push after merging a version bump. That's why merging #44 (which bumped to 4.0.7) didn't trigger a publish.
- Adds `tag-release.yml`: on push to `master` touching `package.json`, compares the version before/after the pushed commit(s) and, if it changed, creates and pushes the matching `vX.Y.Z` tag — which then triggers the existing `publish.yml` on its own.
- Manually tagged and pushed `v4.0.7` separately to publish the release that was already merged in #44.

## Test plan
- [x] `v4.0.7` pushed manually, should trigger `publish.yml` for the already-merged release
- [ ] Next PR that bumps `package.json`'s version and merges to `master` should auto-tag and auto-publish with no manual step