### PR TITLE
docs(contributing): plain-English guidance for issues and PRs

### DIFF
--- a/.claude/skills/inbound-triage/SKILL.md
+++ b/.claude/skills/inbound-triage/SKILL.md
@@ -263,6 +263,11 @@ hand-written.
 
 ## Comment style
 
+Same register as the "Writing the issue or PR" section of
+`hedgehog-contributing` — plain technical English, one claim per
+sentence, citations over assertions. That skill covers how a contributor
+writes the item; this section covers how you write the reply.
+
 **Short.** A human reads this, not the maintainer's assistant. Target
 4-8 lines total, attribution block excluded. If a comment runs past
 that, cut — don't add a second finding to justify the length.

--- a/src/skills/hedgehog-contributing/SKILL.md
+++ b/src/skills/hedgehog-contributing/SKILL.md
@@ -38,6 +38,35 @@ editing those files changes nothing upstream. Ask the user:
 Do this in a separate directory from the user's own project — never inside
 it.
 
+## Writing the issue or PR
+
+Most of Hedgehog's inbound queue is read first by `inbound-triage`, an
+agent, before a human ever sees it. Write for both readers at once, not
+for one at the expense of the other:
+
+- Plain technical English. Short sentences, one claim each. No hedging
+  ("might possibly", "it seems like"), no filler ("just wanted to
+  mention"), no marketing language ("massively improves").
+- Lead with the concrete fact, not the framing. "`hedgehog init` writes
+  `.claude/agents/` twice on Windows" beats "I noticed there might be an
+  issue with how the installer handles paths."
+- State symptom, expected behavior, and exact repro steps as separate,
+  labeled facts — the bug report template's fields exist so a reader
+  (human or agent) can find each without parsing prose. Fill every field
+  the template asks for; don't collapse them into one paragraph.
+- Cite `file:line` for anything about existing behavior. A claim without
+  a citation is a hypothesis, and both readers have to go re-derive it.
+- One issue, one problem. One PR, one change. A bundle forces the reader
+  to split it back apart before they can judge any piece of it.
+- Say what you verified, not what you assume. "Ran `node bin/cli.mjs
+  init` in a scratch dir, `.claude/skills/` is missing the new
+  directory" beats "this probably breaks the install."
+
+This is the same register `inbound-triage` uses when it comments back —
+see that skill's "Comment style" section. Writing this way isn't just
+politeness; it's what makes an item triageable in one pass instead of a
+back-and-forth to extract the facts.
+
 ## Workflow
 
 1. **Read `CONTRIBUTING.md`** at the Hedgehog repo root before touching


### PR DESCRIPTION
## What does this change?

Adds a "Writing the issue or PR" section to `hedgehog-contributing`
(the skill contributors go through to open work against Hedgehog):
plain technical English, lead with the concrete fact, cite `file:line`,
one issue/one problem per PR, state what was verified vs. assumed.
Cross-references it from `inbound-triage`'s existing "Comment style"
section so both sides of the conversation use the same register.

## Why?

Hedgehog's inbound queue is increasingly opened by agents on the
authoring side and read first by `inbound-triage`, an agent, on the
maintainer side. Neither `CONTRIBUTING.md` nor `hedgehog-contributing`
said anything about wording — only about process (branching, commits,
PR checklist). Without a shared register, issues/PRs vary between
terse and padded, which costs a triage pass to normalize before the
actual content can be judged.

## Checklist

- [x] PR title follows Conventional Commits (`docs:`)
- [x] No direct edits to `vendor-skills/BMAD/`
- [ ] `npm run check` passes locally (docs-only change, no payload shape change)