### PR TITLE
feat(core-design): add a reachability gate for arbitrated surfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "4.0.14",
+  "version": "4.0.15",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/src/skills/hedgehog-core-design/SKILL.md
+++ b/src/skills/hedgehog-core-design/SKILL.md
@@ -358,6 +358,61 @@ expressible: it requires a commit before the verify that gates the
 commit. Choose a model that applies directly rather than designing a
 layer around it.
 
+## Step 4d — make the product's own surface reachable
+
+Skip this only if nothing the project publishes is reached through an
+**arbitrator**: an ingress, a router, a gateway, a reverse proxy, a
+process supervisor — anything that decides which backend answers a
+request, and that no layer publishing a surface owns. For every core
+with one, add a `once: true` **reachability layer** at the tail,
+`depends_on` the last per-module layer, whose `verify` makes a real
+request to each intent's primary surface and asserts something specific
+about the answer.
+
+Every other check in this skill judges one layer against its own claim.
+This one exists because the defect it catches belongs to no layer. On a
+module axis each layer's `scope` is a disjoint per-module subtree, so an
+API layer choosing a route and a web layer choosing a screen path make
+independent choices that only ever meet in the arbitrator's config —
+owned by a third layer that knows neither. Each layer is individually
+correct, each verify passes in isolation, and the request 404s. That is
+a whole-graph property, and only a task that runs after the whole graph
+can hold it.
+
+What the layer asserts is the intent's `outcome` read back from outside:
+the route answers, with a status and a body that could not come from the
+wrong backend. Assert something the *other* side of the arbitrator
+cannot produce — a JSON shape, a header, a field the API returns and the
+web app does not. A bare 200 is satisfied by the fall-through app's own
+200, which is the exact confusion this layer exists to detect.
+
+The tail position is doing real work here, and the same three properties
+that make `once: true` right for a composition seam (Step 4) make it
+right here:
+
+- **One task, after everything.** `depends_on` the last per-module layer
+  makes it wait on *every* module's copy, so it runs once, with the
+  whole product standing up.
+- **Re-entrant by construction.** When `planner`'s Re-entry pass adds a
+  module to a finished build, that module's task becomes a prerequisite
+  of this already-complete layer, so `hedgehog plan` reopens it — a new
+  module's surface gets checked for reachability without anyone
+  remembering to ask.
+- **It closes the graph's own claim.** Without it, "every task complete"
+  is a statement about tasks. With it, the last task completing means
+  the product answers.
+
+Two failure modes to design out. The layer must carry no `{module}`
+anywhere — `validateCore` rejects a `once` layer that does — so it
+enumerates the surfaces it checks in one command rather than
+substituting a module in. And it needs the arbitrator's routing to
+already be applied, which makes it strictly later than the deploy layer,
+never merged into it: a deploy layer verifies its own manifests landed,
+which is what six green deploy layers over a 404 already looked like.
+
+Record in `core-design.md` which layer is the reachability gate and what
+each surface it checks is asserting.
+
 ## Step 5 — write `.hedgehog/core.yaml`
 
 The loader parses `id` plus a `layers` list of flat maps. Every layer
@@ -487,6 +542,16 @@ if missed:
   deployment/app` read the same thing regardless of which module's task
   is running, so six modules' deploy tasks assert the identical claim six
   times rather than each module's own deployment.
+- **A reachability layer's `verify` asserts the product answers, not
+  that a layer deployed.** The tail `once: true` layer Step 4d calls for
+  is the one place a `verify` command is about the whole build rather
+  than its own scope, so the usual scope/filter cross-checks above have
+  nothing to say about it. Its command makes a real request through the
+  arbitrator to each intent's primary surface and asserts a response
+  only the intended backend could produce. Its `scope` is whatever
+  fixture or script the check itself lives in — a layer that writes
+  nothing still needs a scope glob it may write, since `hedgehog verify`
+  rejects writes outside it.
 - **Declare the binaries `verify` needs, in `requires`.** Optional, an
   inline list alongside `scope`/`verify`/`commit`
   (`requires: ["terraform", "kubectl"]`), and only for tools that come
@@ -549,6 +614,9 @@ to change only until the file lands. Hard stop.
   (intents × layers tasks, or one task per layer).
 - For any layer that deploys or publishes: where the push happens
   relative to that layer's commit (Step 4c) — or that no layer deploys.
+- Which layer is the reachability gate and what each surface it checks
+  asserts (Step 4d) — or that nothing published is reached through an
+  arbitrator.
 - That this is an authored core: the sequence was designed for this
   project, not battle-tested across many, and it carries the same
   enforcement as a Golden Core but a weaker guarantee.


### PR DESCRIPTION
Closes #10.

## The defect

On a module axis every layer's `scope` is a disjoint per-module subtree, forced
by `validateCore`. So an `api` layer choosing a route and a `ui` layer choosing
a screen path make independent public-surface choices that meet only in the
arbitrator's config — an ingress, owned by a third layer that knows neither.

Each layer is individually correct. Each `verify` passes in isolation. The
request 404s. In the reported build the graph read 36/36 complete and ArgoCD
read `Synced`/`Healthy` at the right SHA while the product's headline feature —
the first clause of its intent's own `outcome` — was unreachable. It was found
by hand, with `curl`, after the build was declared done.

This is a whole-graph property, so only a task that runs after the whole graph
can hold it.

## The fix

Step 4d requires a `once: true` **reachability layer** at the tail,
`depends_on` the last per-module layer, whose `verify` makes a real request to
each intent's primary surface and asserts a response only the intended backend
could produce.

Three properties come from the tail `once: true` position, the same mechanism
#8 shipped in 40c9a6b for composition seams:

- one task, after every module's copy of every layer has landed;
- re-entrant by construction — `planner`'s Re-entry pass reopens it when a new
  module arrives, so a new surface gets checked without anyone remembering to
  ask;
- "every task complete" becomes a claim about the product answering, not about
  tasks.

The section also names the two ways to get it wrong: a bare 200 is satisfied by
the fall-through app's own 200, and merging the check into the deploy layer
reproduces exactly the six green deploy layers over a 404 that this came from.

## Why not the declared surface registry the issue suggested

Suggestions (1) and (2) — a `publishes:` field plus plan-time collision
detection — don't survive contact with `plan.mjs`. It fills every layer field
from the same module name, so on a module axis both layers' declarations
template to `/{module}/**` and compare equal: the check goes green on the exact
build that motivated it. Catching the real case needs concrete enumerated
routes, which puts a hand-maintained list of every URL in the product into
`core.yaml`, drifting from the code the moment anyone adds a route.

A `lintCore` warning was considered and rejected for the same reason: nothing
in the YAML says a core publishes through an arbitrator, so the warning would
have to pattern-match `kubectl` in a verify string — false-positive on workers
with no HTTP surface, false-negative on any non-Kubernetes arbitrator. A
warning that fires on the wrong cores gets ignored.

Consistent with how #9 closed: mechanize what's decidable from the core
definition, keep "assert effect, not report" as authoring discipline.

## Verification

- `npm run check` — ok, 18 agents, 24 skills, 2 cores, tarball, CLI
- `npm run repro` — 51/52; `plan-no-open.mjs` fails identically on `master`
  (a graph-server URL-printing check, unrelated and pre-existing)
- Loaded a four-layer core with a reachability tail through `loadCore` +
  `lintCore`: parses clean, lints clean, `once`/`depends_on`/`requires` land as
  intended

## Follow-up left undone

Once a core *has* a `once: true` tail layer, `lintCore` could check it
`depends_on` the last per-module layer rather than dangling mid-chain — that
much is decidable from the YAML. It catches miswiring, not omission, so it
doesn't replace the authoring rule and isn't in this PR.