### PR TITLE
fix: build graph claim/status fixes and version bump to 4.1.0

### DIFF
--- a/BUILD_GRAPH.md
+++ b/BUILD_GRAPH.md
@@ -148,6 +148,8 @@ If verification fails, the task is blocked.
 
 If everything passes, Hedgehog commits the allowed changes and marks the task complete.
 
+While any task in the graph is blocked, `hedgehog claim` refuses to hand out any fresh work. `hedgehog next` and `hedgehog status` both report blocked tasks directly.
+
 ## 6. Multiple agents can work at once
 
 The lease is what makes parallel work possible.
@@ -162,6 +164,13 @@ lease_expires_at
 Another agent cannot claim the same task while its lease is active.
 
 Because agents claim different ready tasks, several can work concurrently without a separate queue or lock server.
+
+All agents share one working tree. A changed file counts against a task when:
+
+1. It falls inside that task's own scope.
+2. It wasn't already touched before the task was claimed.
+
+A file inside another in-flight task's scope belongs to that task instead.
 
 ## 7. Artifacts and Git both record what was built
 

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -933,10 +933,10 @@ async function nextCommand() {
 
   const db = openDb();
   let packet;
-  let stalled = [];
+  let stalled;
   try {
     packet = nextTask(db);
-    if (!packet) stalled = stalledTasks(db);
+    stalled = stalledTasks(db);
   } finally {
     db.close();
   }
@@ -947,10 +947,7 @@ async function nextCommand() {
     // a failed verification.
     if (stalled.length > 0) {
       console.error(`${red(bold('No ready task, but the graph is blocked.'))}\n`);
-      for (const task of stalled) {
-        const reason = BLOCKED_REASON_LABELS[task.blocked_reason] ?? task.blocked_reason;
-        console.error(`  ${red('✗')} ${bold(task.id)}   ${task.layer}   ${dim(reason)}`);
-      }
+      printStalledTasks(stalled);
       // `verify` refuses anything that isn't `building` and leased to
       // the caller, so a blocked task has to go back through the queue
       // — retry, claim, then verify — rather than straight to verify.
@@ -964,7 +961,26 @@ async function nextCommand() {
     return;
   }
 
+  // A blocked task elsewhere in the graph doesn't stop this ready task
+  // from being handed out — leases are scoped to disjoint work, so an
+  // unrelated block is no reason to halt everything else. But it's easy
+  // to miss otherwise: the queue keeps producing ready tasks right up
+  // until it doesn't, and a block can sit unnoticed the whole time. This
+  // warns without withholding the packet.
+  if (stalled.length > 0) {
+    console.error(`${yellow(bold(`${stalled.length} task(s) blocked elsewhere in the graph:`))}`);
+    printStalledTasks(stalled);
+    console.error('');
+  }
+
   console.log(formatNext(packet));
+}
+
+function printStalledTasks(stalled) {
+  for (const task of stalled) {
+    const reason = BLOCKED_REASON_LABELS[task.blocked_reason] ?? task.blocked_reason;
+    console.error(`  ${red('✗')} ${bold(task.id)}   ${task.layer}   ${dim(reason)}`);
+  }
 }
 
 // Mirrors, read-only, the condition verifyTask's own Phase 0

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1201,11 +1201,28 @@ async function claimCommand(args) {
   }
 
   const db = openDb();
-  let claimed;
+  let claimed, blocked;
   try {
-    claimed = claimTasks(db, { owner, count });
+    ({ claimed, blocked } = claimTasks(db, { owner, count }));
   } finally {
     db.close();
+  }
+
+  // Stop-the-line: claimTasks refuses the whole batch, in any module,
+  // while any task anywhere is blocked — see its own comment in
+  // claim.mjs. A targeted `hedgehog claim <task-id>` is unaffected, which
+  // is how the blocked task itself gets reclaimed after `hedgehog retry`.
+  if (blocked.length > 0) {
+    console.error(`${red(bold('Claim refused.'))} ${blocked.length} task(s) blocked:\n`);
+    for (const task of blocked) {
+      const reason = BLOCKED_REASON_LABELS[task.blocked_reason] ?? task.blocked_reason;
+      console.error(`  ${red('✗')} ${bold(task.id)}   ${task.layer}   ${dim(reason)}`);
+    }
+    console.error(
+      `\nFix the work, then ${bold('hedgehog retry <task-id>')} before claiming more.\n`,
+    );
+    process.exitCode = 1;
+    return;
   }
 
   if (claimed.length === 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "4.0.15",
+  "version": "4.1.0",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/repro/claim-fanout-blocked-stop-the-line.mjs
+++ b/repro/claim-fanout-blocked-stop-the-line.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+// Repro: a fan-out claim refuses outright, across every module and any
+// owner, while any task anywhere in the graph is sitting `blocked` — but
+// a targeted claim by task id is exempt, which is how the blocked task
+// itself gets reclaimed right after `hedgehog retry` even while the
+// fan-out would otherwise still be stopped.
+//
+// See the stop-the-line comment above claimTasks in claim.mjs: a blocked
+// task is the loop's own signal that something needs a human/agent
+// decision, and claimTasks refuses to hand out any fresh work anywhere
+// until it's retried. claimTask (the targeted variant claimCommand uses
+// when given a task id) has no such check, so an operator can still work
+// around a block on one specific task while it's open — most
+// importantly, reclaim the blocked task itself the moment `hedgehog
+// retry` returns it to `planned`.
+//
+// Asserts:
+//   1. fan-out claim succeeds normally with nothing blocked;
+//   2. with GAMMA-INFRA blocked (scope_violation, seeded directly via
+//      SQL — a failed verification's own end state), a fan-out claim
+//      refuses: non-zero exit, names GAMMA-INFRA, and touches nothing
+//      else in the graph;
+//   3. a targeted claim on a different, claimable task (BETA-INFRA)
+//      still succeeds while the block is in place;
+//   4. after `hedgehog retry GAMMA-INFRA`, the fan-out claim succeeds
+//      again.
+//
+// The build graph is read through node:sqlite (node --experimental-sqlite),
+// never a sqlite3 binary.
+//
+// Run: node repro/claim-fanout-blocked-stop-the-line.mjs
+
+import { DatabaseSync } from 'node:sqlite';
+import { join } from 'node:path';
+import { check, checkContains, cleanup, commitAll, finish, hedgehog, makeProject } from './papercuts-lib.mjs';
+
+// Three independent modules under one layer, so ALPHA/BETA/GAMMA never
+// conflict with each other on scope or verify radius.
+const CORE = `id: demo
+layers:
+  - id: infra
+    scope: ["infra/{module}/**"]
+    verify: "true"
+    commit: "feat(infra): {module}"
+`;
+
+const project = makeProject(CORE);
+const dbPath = join(project, '.hedgehog', 'hedgehog.db');
+
+function openGraph() {
+  const db = new DatabaseSync(dbPath);
+  db.exec('PRAGMA busy_timeout = 10000');
+  return db;
+}
+
+function taskRow(id) {
+  const db = openGraph();
+  try {
+    return db.prepare('SELECT id, status, blocked_reason, lease_owner FROM tasks WHERE id = ?').get(id);
+  } finally {
+    db.close();
+  }
+}
+
+function allTaskRows() {
+  const db = openGraph();
+  try {
+    return db.prepare('SELECT id, status, blocked_reason, lease_owner FROM tasks ORDER BY id').all();
+  } finally {
+    db.close();
+  }
+}
+
+try {
+  console.log(`repro: claim-fanout-blocked-stop-the-line   (${project})`);
+
+  hedgehog(project, ['intent', 'add', '--id', 'alpha', '--goal', 'g', '--outcome', 'o']);
+  hedgehog(project, ['intent', 'add', '--id', 'beta', '--goal', 'g', '--outcome', 'o']);
+  hedgehog(project, ['intent', 'add', '--id', 'gamma', '--goal', 'g', '--outcome', 'o']);
+  hedgehog(project, ['plan', '--no-open']);
+  commitAll(project, 'chore: plan');
+
+  // ── 1. fan-out claim succeeds normally when nothing is blocked ─────
+  const first = hedgehog(project, ['claim', '--owner', 'alice', '--count', '1']);
+  check('baseline: fan-out claim exits zero with nothing blocked', first.status === 0, {
+    expected: 'exit 0',
+    actual: `exit ${first.status}`,
+  });
+  checkContains('baseline: alice is handed ALPHA-INFRA', first.all, 'ALPHA-INFRA');
+
+  const alphaAfterBaseline = taskRow('ALPHA-INFRA');
+  check(
+    'baseline: ALPHA-INFRA is leased to alice',
+    alphaAfterBaseline?.status === 'building' && alphaAfterBaseline?.lease_owner === 'alice',
+    { expected: 'building / alice', actual: `${alphaAfterBaseline?.status} / ${alphaAfterBaseline?.lease_owner}` },
+  );
+
+  // Release it back to ready so it doesn't confound the rest of the
+  // repro — the point already made is that the fan-out worked at all.
+  hedgehog(project, ['release', 'ALPHA-INFRA', '--owner', 'alice']);
+
+  // ── seed a block: GAMMA-INFRA failed verification's scope gate ─────
+  // Seeded directly via SQL, matching a failed verification's own end
+  // state (`blocked` / `scope_violation`), rather than driving an actual
+  // scope violation through `hedgehog verify` — the fan-out's
+  // stop-the-line check reads only status and blocked_reason, so this is
+  // an equivalent and much simpler setup.
+  {
+    const db = openGraph();
+    try {
+      db.prepare(
+        `UPDATE tasks SET status = 'blocked', blocked_reason = 'scope_violation',
+           lease_owner = NULL, lease_expires_at = NULL, leased_at = NULL, claim_snapshot = NULL
+         WHERE id = ?`,
+      ).run('GAMMA-INFRA');
+    } finally {
+      db.close();
+    }
+  }
+
+  const gammaSeeded = taskRow('GAMMA-INFRA');
+  check(
+    'setup: GAMMA-INFRA is blocked/scope_violation',
+    gammaSeeded?.status === 'blocked' && gammaSeeded?.blocked_reason === 'scope_violation',
+    { expected: 'blocked / scope_violation', actual: `${gammaSeeded?.status} / ${gammaSeeded?.blocked_reason}` },
+  );
+
+  const snapshotBeforeRefusal = allTaskRows();
+
+  // ── 2. fan-out claim refuses the whole batch while GAMMA is blocked ─
+  const refused = hedgehog(project, ['claim', '--owner', 'bob', '--count', '1']);
+  check('refusal: fan-out claim exits non-zero', refused.status !== 0, {
+    expected: 'non-zero exit',
+    actual: `exit ${refused.status}`,
+  });
+  checkContains('refusal: names GAMMA-INFRA as the blocked task', refused.all, 'GAMMA-INFRA');
+  checkContains('refusal: says the claim was refused', refused.all, 'Claim refused');
+
+  const snapshotAfterRefusal = allTaskRows();
+  check(
+    'refusal: nothing in the graph changed status or lease owner',
+    JSON.stringify(snapshotAfterRefusal) === JSON.stringify(snapshotBeforeRefusal),
+    {
+      expected: JSON.stringify(snapshotBeforeRefusal),
+      actual: JSON.stringify(snapshotAfterRefusal),
+    },
+  );
+
+  // ── 3. a targeted claim on a different, claimable task still works ──
+  const targeted = hedgehog(project, ['claim', 'BETA-INFRA', '--owner', 'carol']);
+  check('targeted: claim on BETA-INFRA exits zero despite the block', targeted.status === 0, {
+    expected: 'exit 0',
+    actual: `exit ${targeted.status}`,
+  });
+  checkContains('targeted: carol is handed BETA-INFRA', targeted.all, 'BETA-INFRA');
+
+  const betaAfterTargeted = taskRow('BETA-INFRA');
+  check(
+    'targeted: BETA-INFRA is leased to carol',
+    betaAfterTargeted?.status === 'building' && betaAfterTargeted?.lease_owner === 'carol',
+    { expected: 'building / carol', actual: `${betaAfterTargeted?.status} / ${betaAfterTargeted?.lease_owner}` },
+  );
+
+  const gammaStillBlocked = taskRow('GAMMA-INFRA');
+  check(
+    'targeted: GAMMA-INFRA is untouched by the targeted claim',
+    gammaStillBlocked?.status === 'blocked' && gammaStillBlocked?.blocked_reason === 'scope_violation',
+    { expected: 'blocked / scope_violation', actual: `${gammaStillBlocked?.status} / ${gammaStillBlocked?.blocked_reason}` },
+  );
+
+  hedgehog(project, ['release', 'BETA-INFRA', '--owner', 'carol']);
+
+  // ── 4. after retry, the fan-out claim succeeds again ────────────────
+  const retried = hedgehog(project, ['retry', 'GAMMA-INFRA']);
+  check('retry: exits zero', retried.status === 0, {
+    expected: 'exit 0',
+    actual: `exit ${retried.status}`,
+  });
+
+  const gammaAfterRetry = taskRow('GAMMA-INFRA');
+  check(
+    'retry: GAMMA-INFRA is back to planned with no block',
+    gammaAfterRetry?.status === 'planned' && gammaAfterRetry?.blocked_reason === null,
+    { expected: 'planned / null', actual: `${gammaAfterRetry?.status} / ${gammaAfterRetry?.blocked_reason}` },
+  );
+
+  const restored = hedgehog(project, ['claim', '--owner', 'dave', '--count', '3']);
+  check('restored: fan-out claim exits zero once the block is cleared', restored.status === 0, {
+    expected: 'exit 0',
+    actual: `exit ${restored.status}`,
+  });
+  checkContains('restored: dave is handed claimable work', restored.all, 'Claimed');
+} finally {
+  cleanup(project);
+}
+
+finish('claim-fanout-blocked-stop-the-line');

--- a/repro/claim-self-reaped-lease.mjs
+++ b/repro/claim-self-reaped-lease.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+// Repro: a lease that expires on one module must not stop every other
+// module's fan-out claim from working at all.
+//
+// reapExpiredLeases runs lazily, as the first step inside claimTasks's
+// transaction — so the first `hedgehog claim` call from *anyone*, working
+// *any* module, after a lease lapses is the one that discovers it and
+// flips the task to `blocked`/`lease_expired`. claimTasks exempts a block
+// it just produced this way from its own stop-the-line refusal, so a dead
+// agent on ALPHA doesn't halt BETA's unrelated fan-out claim.
+//
+// Asserts: agent bob's fan-out claim, which happens to be the call that
+// reaps alice's long-dead lease on an unrelated module, still succeeds
+// and claims BETA's ready task. The reaped task still ends up
+// `blocked`/`lease_expired` and still shows up in `hedgehog status`'s
+// NEEDS ATTENTION, and a *subsequent* fan-out claim (with nothing left to
+// claim) still refuses, proving the stop-the-line check itself is intact
+// for a block that predates the call.
+//
+// The build graph is read through node:sqlite (node --experimental-sqlite),
+// never a sqlite3 binary.
+//
+// Run: node repro/claim-self-reaped-lease.mjs
+
+import { DatabaseSync } from 'node:sqlite';
+import { join } from 'node:path';
+import { check, checkContains, cleanup, commitAll, finish, hedgehog, makeProject } from './papercuts-lib.mjs';
+
+// Two independent modules under one layer, so ALPHA and BETA never
+// conflict on scope or verify radius and a fan-out claim of one is never
+// blocked by the other's being in flight.
+const CORE = `id: demo
+layers:
+  - id: infra
+    scope: ["infra/{module}/**"]
+    verify: "true"
+    commit: "feat(infra): {module}"
+`;
+
+const project = makeProject(CORE);
+const dbPath = join(project, '.hedgehog', 'hedgehog.db');
+
+function openGraph() {
+  const db = new DatabaseSync(dbPath);
+  db.exec('PRAGMA busy_timeout = 10000');
+  return db;
+}
+
+function taskRow(id) {
+  const db = openGraph();
+  try {
+    return db.prepare('SELECT id, status, blocked_reason, lease_owner FROM tasks WHERE id = ?').get(id);
+  } finally {
+    db.close();
+  }
+}
+
+try {
+  console.log(`repro: claim-self-reaped-lease   (${project})`);
+
+  hedgehog(project, ['intent', 'add', '--id', 'alpha', '--goal', 'g', '--outcome', 'o']);
+  hedgehog(project, ['intent', 'add', '--id', 'beta', '--goal', 'g', '--outcome', 'o']);
+  hedgehog(project, ['plan', '--no-open']);
+  commitAll(project, 'chore: plan');
+  hedgehog(project, ['claim', '--owner', 'alice', '--count', '1']);
+
+  const claimed = taskRow('ALPHA-INFRA');
+  check('setup: ALPHA-INFRA is leased to alice', claimed?.status === 'building' && claimed?.lease_owner === 'alice', {
+    expected: 'building / alice',
+    actual: `${claimed?.status} / ${claimed?.lease_owner}`,
+  });
+
+  // Simulate alice's session dying mid-build: backdate her lease the way
+  // wall-clock time would have, with nobody having called `claim` (and
+  // so nobody having reaped it) in the interim.
+  {
+    const db = openGraph();
+    try {
+      db.prepare("UPDATE tasks SET lease_expires_at = datetime('now', '-1 hour') WHERE id = ?").run('ALPHA-INFRA');
+    } finally {
+      db.close();
+    }
+  }
+
+  // bob has never touched ALPHA — he's working BETA. His fan-out claim is
+  // the one that happens to reap alice's dead lease as claimTasks's first
+  // step. It must still succeed and hand him BETA-INFRA, not refuse
+  // outright over a block it just produced itself.
+  const bob = hedgehog(project, ['claim', '--owner', 'bob', '--count', '1']);
+  check('bob: fan-out claim exits zero despite reaping a dead lease', bob.status === 0, {
+    expected: 'exit 0',
+    actual: `exit ${bob.status}`,
+  });
+  checkContains('bob: is handed BETA-INFRA', bob.all, 'BETA-INFRA');
+
+  const beta = taskRow('BETA-INFRA');
+  check('bob: BETA-INFRA is leased to bob', beta?.status === 'building' && beta?.lease_owner === 'bob', {
+    expected: 'building / bob',
+    actual: `${beta?.status} / ${beta?.lease_owner}`,
+  });
+
+  // The reap still happened and is still visible.
+  const alpha = taskRow('ALPHA-INFRA');
+  check(
+    'alpha: ALPHA-INFRA still lands in blocked/lease_expired',
+    alpha?.status === 'blocked' && alpha?.blocked_reason === 'lease_expired',
+    { expected: 'blocked / lease_expired', actual: `${alpha?.status} / ${alpha?.blocked_reason}` },
+  );
+
+  const status = hedgehog(project, ['status']);
+  checkContains('status: ALPHA-INFRA appears under NEEDS ATTENTION', status.all, 'ALPHA-INFRA');
+  checkContains('status: names the lease-expired reason', status.all, 'lease expired');
+
+  // Now that ALPHA-INFRA is sitting there blocked from a *prior* call,
+  // the stop-the-line check itself must still be intact: a further
+  // fan-out claim refuses, even though there's no more ready work either
+  // way (both tasks are now accounted for) — the refusal is what proves
+  // it, not the absence of claimable work.
+  const carol = hedgehog(project, ['claim', '--owner', 'carol', '--count', '1']);
+  check('carol: a later fan-out claim refuses over the pre-existing block', carol.status !== 0, {
+    expected: 'non-zero exit',
+    actual: `exit ${carol.status}`,
+  });
+  checkContains('carol: names the blocked task', carol.all, 'ALPHA-INFRA');
+} finally {
+  cleanup(project);
+}
+
+finish('claim-self-reaped-lease');

--- a/repro/verify-lease-precedence.mjs
+++ b/repro/verify-lease-precedence.mjs
@@ -161,7 +161,10 @@ try {
   });
 
   // ── control: a caller who does hold the lease still gets the gate ───
-  hedgehog(project, ['claim', '--owner', 'dave', '--count', '1']);
+  // A targeted claim by task id, not `--count` — claim.mjs's stop-the-line
+  // check only gates the fan-out, and ALPHA-INFRA sorts ahead of
+  // BETA-INFRA, so an untargeted claim could hand back the wrong task.
+  hedgehog(project, ['claim', 'BETA-INFRA', '--owner', 'dave']);
   const holder = taskRow('BETA-INFRA');
   check('setup: BETA-INFRA is leased to dave', holder?.status === 'building' && holder?.lease_owner === 'dave', {
     expected: 'building / dave',

--- a/src/db/claim.mjs
+++ b/src/db/claim.mjs
@@ -180,16 +180,25 @@ function loadTask(db, taskId) {
 // concurrent `claim` call in the interim would otherwise reach `verify`
 // with a technically-expired lease that still matches status/lease_owner
 // and sail through unreaped.
+//
+// Returns the ids it just flipped, as a Set — claimTasks's stop-the-line
+// check uses this to tell a block this very call produced from one that
+// was already sitting there, so a dead agent's lease lapsing doesn't
+// itself become the reason every other module's fan-out refuses.
 export function reapExpiredLeases(db) {
-  db.prepare(
-    `
+  const rows = db
+    .prepare(
+      `
     UPDATE tasks
     SET status = 'blocked', blocked_reason = 'lease_expired',
         lease_owner = NULL, lease_expires_at = NULL, leased_at = NULL,
         claim_snapshot = NULL
     WHERE status IN ('building', 'verifying') AND lease_expires_at < datetime('now')
+    RETURNING id
   `,
-  ).run();
+    )
+    .all();
+  return new Set(rows.map((r) => r.id));
 }
 
 // The atomic claim primitive: the WHERE clause re-checks status and
@@ -204,8 +213,38 @@ const claimOne = (db) =>
     RETURNING id
   `);
 
-// Claims up to `count` ready tasks for `owner`. `count` is a maximum, not
-// a promise — returns however many were actually claimed, possibly zero.
+// Every `blocked` task in the graph, regardless of module or reason —
+// the fan-out claim's stop-the-line check. Ordered the same as the
+// NEEDS ATTENTION list in status.mjs, so the two never disagree about
+// which tasks are outstanding.
+function findBlockedTasks(db) {
+  return db.prepare(`SELECT * FROM tasks WHERE status = 'blocked' ORDER BY priority, id`).all();
+}
+
+// Claims up to `count` ready tasks for `owner`, returning
+// `{ claimed, blocked }`. `count` is a maximum, not a promise — `claimed`
+// may hold fewer tasks than `count`, or none. `blocked` is non-empty only
+// on the stop-the-line refusal below, in which case `claimed` is always
+// empty.
+//
+// Stop-the-line: if any task anywhere in the graph was already `blocked`
+// before this call, the fan-out refuses to claim anything at all, in any
+// module — a blocked task needs a human/agent decision (retry after a
+// fix, or leave it), and handing out fresh work around it makes that easy
+// to ignore indefinitely. Deliberately stricter than dependency-based
+// blocking: an unrelated module isn't literally stuck on the blocked
+// task, but the fan-out stops anyway until it's retried. A targeted
+// `hedgehog claim <task-id>` (claimTask, below) is exempt — that's how
+// the blocked task itself gets reclaimed after `hedgehog retry`.
+//
+// "Already blocked" excludes a lease this same call's reapExpiredLeases
+// just flipped: a dead agent's lease can lapse on an unrelated module,
+// and the first `claim` call after that lapse is whichever one happens to
+// discover it. That call still claims normally; the reaped task still
+// lands in `blocked`/`lease_expired` and still needs `hedgehog retry`
+// before it's claimable — only this one call's refusal is skipped. Every
+// `claim` call after it sees the same task still blocked and stops as
+// usual.
 //
 // Fan-out keeps the batch mutually non-conflicting, and non-conflicting
 // with every task already in flight, per conflict.mjs's
@@ -229,7 +268,12 @@ export function claimTasks(db, { owner, count = 1, leaseMinutes = 45 }) {
   const claimSnapshot = snapshotWorkingTree();
 
   return inTransaction(db, () => {
-    reapExpiredLeases(db);
+    const justReaped = reapExpiredLeases(db);
+
+    const blocked = findBlockedTasks(db).filter((task) => !justReaped.has(task.id));
+    if (blocked.length > 0) {
+      return { claimed: [], blocked };
+    }
 
     const candidates = findClaimableTasks(db);
     const inFlight = findInFlightTasks(db);
@@ -245,7 +289,7 @@ export function claimTasks(db, { owner, count = 1, leaseMinutes = 45 }) {
       claimed.push(loadTask(db, candidate.id));
     }
 
-    return claimed;
+    return { claimed, blocked: [] };
   });
 }
 

--- a/src/db/ready.mjs
+++ b/src/db/ready.mjs
@@ -46,8 +46,10 @@ export function readyTasks(db) {
 // Renders one HELD BACK reason. `exclusive` splits on which side of the
 // pair is exclusive: the candidate itself (runs alone, full stop) vs. the
 // already-CLAIMABLE task it lost the slot to (named, so the reason points
-// at what's actually occupying the batch).
-function formatReason(candidate, conflict) {
+// at what's actually occupying the batch). Exported for status.mjs, which
+// annotates the same held-back tasks inline in its own READY section
+// rather than duplicating this formatting.
+export function heldBackReason(candidate, conflict) {
   const { with: other, kind } = conflict;
 
   if (kind === 'exclusive') {
@@ -86,7 +88,7 @@ export function formatReady({ claimable, heldBack }) {
     lines.push('');
     lines.push('HELD BACK');
     for (const { task, conflict } of heldBack) {
-      lines.push(`  ${task.id.padEnd(20)}${task.layer.padEnd(13)}${formatReason(task, conflict)}`);
+      lines.push(`  ${task.id.padEnd(20)}${task.layer.padEnd(13)}${heldBackReason(task, conflict)}`);
     }
   }
 

--- a/src/db/status.mjs
+++ b/src/db/status.mjs
@@ -13,6 +13,7 @@
 
 import { detectDrift, formatDrift } from './drift.mjs';
 import { formatMissingRequirements } from './requires.mjs';
+import { readyTasks, heldBackReason } from './ready.mjs';
 
 // The task lifecycle in order, matching the tasks CHECK constraint in
 // schema.mjs exactly — every status the engine can write, and no others.
@@ -81,11 +82,16 @@ function loadAttentionTasks(db) {
   return db.prepare(ATTENTION_TASKS_SQL).all();
 }
 
-// Returns { counts, ready, inFlight, attention, drift, total } — counts
-// keyed by every status in the tasks CHECK constraint (present even at
-// zero), ready the full list of currently-pickable tasks, inFlight the
-// tasks currently leased (building or verifying), attention the stalled
-// tasks needing a fix, total the sum across all statuses.
+// Returns { counts, ready, heldBack, inFlight, attention, drift, total } —
+// counts keyed by every status in the tasks CHECK constraint (present even
+// at zero), ready the full list of currently-pickable tasks, heldBack the
+// subset of those that `hedgehog claim` would skip over right now because
+// they conflict with in-flight work or another ready task ahead of them
+// (ready.mjs's own simulation, reused rather than reimplemented — without
+// this a task can sit in READY indefinitely with no visible reason, the
+// same invisible-stall shape blocked tasks had before `attention` existed),
+// inFlight the tasks currently leased (building or verifying), attention
+// the stalled tasks needing a fix, total the sum across all statuses.
 //
 // `core` is optional and, when given, adds `drift`: the tasks whose
 // layer-derived fields no longer match core.yaml (drift.mjs). It's a
@@ -100,11 +106,12 @@ function loadAttentionTasks(db) {
 export function graphStatus(db, { core = null, overrides = new Map() } = {}) {
   const counts = countTasksByStatus(db);
   const ready = loadReadyTasks(db);
+  const { heldBack } = readyTasks(db);
   const inFlight = loadInFlightTasks(db);
   const attention = loadAttentionTasks(db);
   const drift = core ? detectDrift(db, core, { overrides }) : [];
   const total = Object.values(counts).reduce((a, b) => a + b, 0);
-  return { counts, ready, inFlight, attention, drift, total };
+  return { counts, ready, heldBack, inFlight, attention, drift, total };
 }
 
 const BLOCKED_REASON_LABELS = {
@@ -127,6 +134,7 @@ const BLOCKED_REASON_LABELS = {
 export function formatStatus({
   counts,
   ready,
+  heldBack = [],
   inFlight,
   attention,
   drift,
@@ -146,12 +154,18 @@ export function formatStatus({
     lines.push(...missingLines);
     lines.push('');
   }
+  // Each ready task is annotated inline with why `hedgehog claim` would
+  // skip it right now, rather than listed flatly — a task can otherwise
+  // sit in READY indefinitely with no visible reason (see graphStatus).
+  const heldBackById = new Map(heldBack.map(({ task, conflict }) => [task.id, conflict]));
   lines.push('READY');
   if (ready.length === 0) {
     lines.push('  (none)');
   } else {
     for (const task of ready) {
-      lines.push(`  ${task.id}   ${task.layer}   ${task.objective}`);
+      const conflict = heldBackById.get(task.id);
+      const note = conflict ? `   (held back — ${heldBackReason(task, conflict)})` : '';
+      lines.push(`  ${task.id}   ${task.layer}   ${task.objective}${note}`);
     }
   }
 

--- a/src/skills/hedgehog-authored-loop/SKILL.md
+++ b/src/skills/hedgehog-authored-loop/SKILL.md
@@ -117,14 +117,21 @@ runtime detail.
    moves to `blocked` with a `blocked_reason` of `scope_violation` or
    `verification_failed`, and nothing downstream unlocks. Fix the work,
    then run `hedgehog retry <task-id>` to return the task to `planned`,
-   claim it again, and verify again — `hedgehog verify` only accepts a
-   task you currently hold in `building`, so a blocked task has to go
-   back through `retry` and `claim` first. Don't hand-commit around it.
+   claim it again (by task id — see below), and verify again —
+   `hedgehog verify` only accepts a task you currently hold in
+   `building`, so a blocked task has to go back through `retry` and
+   `claim` first. Don't hand-commit around it.
 
-   A `blocked` task is not pickable by `hedgehog claim`, so `hedgehog
-   status` lists it under NEEDS ATTENTION with the task id to retry.
-   If `hedgehog claim` returns nothing and the graph isn't actually done,
-   fix that task — don't treat it as "nothing left to do."
+   A `blocked` task anywhere in the graph — in this layer or any other —
+   makes `hedgehog claim --count N` refuse to hand out anything at all,
+   with a non-zero exit naming the blocked task(s). `hedgehog status`
+   lists them too, under NEEDS ATTENTION. Fix and `retry` the named
+   task(s) before claiming more. A **targeted** `hedgehog claim <task-id>
+   --owner <owner>` is exempt — that's how the just-retried task gets
+   reclaimed in the step above. A lease the same `claim` call reaps for
+   having just expired is exempt too: that call still claims whatever
+   else is ready, and the reaped task lands in NEEDS ATTENTION for the
+   next `claim` call to stop on.
 5. **Repeat** — `hedgehog claim --count N --owner <owner>` again for the
    next batch.
 

--- a/src/skills/hedgehog-landing-loop/SKILL.md
+++ b/src/skills/hedgehog-landing-loop/SKILL.md
@@ -187,10 +187,19 @@ paragraph algorithm, and their self-tests.
    check, the task moves to `blocked` with a `blocked_reason` of
    `scope_violation` or `verification_failed`, and nothing downstream
    unlocks. Fix the work, then run `hedgehog retry <task-id>` to return
-   the task to `planned`, claim it again, and verify again — `hedgehog
-   verify` only accepts a task you currently hold in `building`, so a
-   blocked task has to go back through `retry` and `claim` first. Don't
-   hand-commit around it.
+   the task to `planned`, claim it again by task id, and verify again —
+   `hedgehog verify` only accepts a task you currently hold in
+   `building`, so a blocked task has to go back through `retry` and
+   `claim` first. Don't hand-commit around it.
+
+   A `blocked` task anywhere in the graph makes `hedgehog claim --count
+   <n>` refuse to hand out anything at all, with a non-zero exit naming
+   the blocked task(s). Fix and `retry` it before claiming more. A
+   **targeted** `hedgehog claim <task-id> --owner <owner>` is exempt —
+   that's how the just-retried task gets reclaimed above. A lease the
+   same `claim` call reaps for having just expired is exempt too: that
+   call still claims whatever else is ready, and the reaped task lands in
+   NEEDS ATTENTION for the next `claim` call to stop on.
 5. **Repeat** — `hedgehog claim --owner <owner> --count <n>` again for
    the following layer.
 

--- a/src/skills/hedgehog-loop/SKILL.md
+++ b/src/skills/hedgehog-loop/SKILL.md
@@ -169,14 +169,21 @@ writes `docs/design/<module>.md`, not its own compiled layer — the
    `blocked` with a `blocked_reason` of `scope_violation` or
    `verification_failed`, and nothing downstream unlocks. Fix the work,
    then run `hedgehog retry <task-id>` to return the task to `planned`,
-   claim it again, and verify again — `hedgehog verify` only accepts a
-   task you currently hold in `building`, so a blocked task has to go
-   back through `retry` and `claim` first. Don't hand-commit around it.
+   claim it again (by task id — see below), and verify again —
+   `hedgehog verify` only accepts a task you currently hold in
+   `building`, so a blocked task has to go back through `retry` and
+   `claim` first. Don't hand-commit around it.
 
-   A `blocked` task is not pickable by `hedgehog claim`, so `hedgehog
-   status` lists it under NEEDS ATTENTION with the task id to retry.
-   If `hedgehog claim` returns nothing and the graph isn't actually done,
-   fix that task — don't treat it as "nothing left to do."
+   A `blocked` task anywhere in the graph — in this module or any other —
+   makes `hedgehog claim --count N` refuse to hand out anything at all,
+   with a non-zero exit naming the blocked task(s). `hedgehog status`
+   lists them too, under NEEDS ATTENTION. Fix and `retry` the named
+   task(s) before claiming more. A **targeted** `hedgehog claim <task-id>
+   --owner <owner>` is exempt — that's how the just-retried task gets
+   reclaimed in the step above. A lease the same `claim` call reaps for
+   having just expired is exempt too: that call still claims whatever
+   else is ready, and the reaped task lands in NEEDS ATTENTION for the
+   next `claim` call to stop on.
 5. **Repeat** — `hedgehog claim --count N --owner <owner>` again for the
    next batch.
 


### PR DESCRIPTION
## Summary
- Refuse the fan-out claim while any task is blocked (stop-the-line behavior)
- Report blocked tasks on every `next` call, not just when the queue is empty
- Annotate ready tasks in `status` that are held back by a conflict
- Bump version to 4.1.0

## Test plan
- [x] Run repro scripts (`repro/claim-fanout-blocked-stop-the-line.mjs`, `repro/claim-self-reaped-lease.mjs`, `repro/verify-lease-precedence.mjs`)
- [x] Verify `hedgehog claim`, `hedgehog next`, `hedgehog status` behave as documented in updated SKILL.md files