### PR TITLE
fix: 5 mechanical fixes (#61, #62, #72, #74, #79)

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1539,7 +1539,27 @@ async function statusCommand() {
     }
   }
 
-  const overrides = core ? await loadOverrides() : new Map();
+  // Loaded whether or not a core resolved: drift is the only consumer
+  // that needs `core` composed against these, and graphStatus already
+  // gates that on `core` itself. The orphan check reads task ids out of
+  // the database, so it is answerable — and worth answering — on a
+  // project whose core.yaml is missing or unparseable. A missing
+  // overrides directory reads as an empty Map (loadOverrides), so this
+  // costs nothing on a project that has never written one.
+  //
+  // A malformed override file throws, and for the same reason an
+  // unparseable core.yaml doesn't take `status` down, neither may this:
+  // status is the command every session starts with, and the report of
+  // the broken file is more useful than an aborted overview.
+  let overrides = new Map();
+  try {
+    overrides = await loadOverrides();
+  } catch (err) {
+    console.error(
+      `${yellow('Override file unreadable:')} ${err.message}\n${dim('Scope overrides are ignored until it parses.')}\n`,
+    );
+  }
+
   const db = openDb();
   let result;
   try {

--- a/repro/status-reports-drift.mjs
+++ b/repro/status-reports-drift.mjs
@@ -4,9 +4,13 @@
 // core.yaml that no longer matches the compiled tasks has to show up
 // there, naming the tasks and fields that diverged.
 //
-// Against v4.0.3 `status` prints counts + ready list only, and a
-// divergent core.yaml is completely silent.
+// The same argument covers the other whole-graph condition `status`
+// owns: an override naming a task id that doesn't exist widens nothing,
+// throws nothing, and produces no drift, so `status` is the only place
+// an operator who isn't already suspicious will find it.
 
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import {
   plannedProject,
   cleanupAll,
@@ -16,6 +20,18 @@ import {
   assertNotIncludes,
   CORE_YAML_AFTER,
 } from './drift-lib.mjs';
+
+// Writes one `.hedgehog/overrides/*.json` record directly rather than
+// going through `hedgehog override add`, so a scenario can name a task
+// id that doesn't exist — which is exactly the state under test and the
+// one the CLI's own validation has no opinion about.
+function writeOverride(p, taskId, scopeAdd) {
+  mkdirSync(join(p.dir, '.hedgehog/overrides'), { recursive: true });
+  writeFileSync(
+    join(p.dir, `.hedgehog/overrides/${taskId.toLowerCase()}.json`),
+    JSON.stringify({ task: taskId, scope_add: [scopeAdd], reason: 'repro' }, null, 2),
+  );
+}
 
 let ok = true;
 
@@ -57,6 +73,39 @@ ok =
     const r = mustSucceed(p.run('status'), 'hedgehog status');
     assertIncludes(r.out, 'DRIFT', 'drift on a complete task keeps showing');
     assertIncludes(r.out, 'BILLING-FOUNDATION', 'the complete task is named');
+  }) && ok;
+
+ok =
+  scenario('status is quiet when every override names a real task', () => {
+    const p = plannedProject('billing');
+    writeOverride(p, 'BILLING-FOUNDATION', 'infra/billing.manifest.json');
+    const r = mustSucceed(p.run('status'), 'hedgehog status');
+    assertNotIncludes(r.out, 'ORPHANED OVERRIDES', 'a matching override raises nothing');
+  }) && ok;
+
+ok =
+  scenario('status reports an override whose task id matches nothing', () => {
+    const p = plannedProject('billing');
+    writeOverride(p, 'BILLING-FONUDATION', 'infra/billing.manifest.json');
+
+    const r = mustSucceed(p.run('status'), 'hedgehog status');
+    assertIncludes(r.out, 'ORPHANED OVERRIDES', 'status names the orphaned-override section');
+    assertIncludes(r.out, 'BILLING-FONUDATION', 'status names the typo\'d task id');
+    assertIncludes(r.out, 'widens nothing', 'status states the consequence');
+  }) && ok;
+
+// The orphan check reads task ids out of the database, not core.yaml, so
+// an unreadable core must not suppress it — that gap is what made a dead
+// override reachable only by already knowing to run `override list`.
+ok =
+  scenario('an orphaned override is reported even with no readable core', () => {
+    const p = plannedProject('billing');
+    writeOverride(p, 'BILLING-FONUDATION', 'infra/billing.manifest.json');
+    p.writeCore('id: repro-core\nlayers: [\n');
+
+    const r = mustSucceed(p.run('status'), 'hedgehog status');
+    assertIncludes(r.out, 'ORPHANED OVERRIDES', 'the section survives an unparseable core.yaml');
+    assertIncludes(r.out, 'BILLING-FONUDATION', 'the orphaned id is still named');
   }) && ok;
 
 cleanupAll();

--- a/repro/status-reports-drift.mjs
+++ b/repro/status-reports-drift.mjs
@@ -8,6 +8,13 @@
 // owns: an override naming a task id that doesn't exist widens nothing,
 // throws nothing, and produces no drift, so `status` is the only place
 // an operator who isn't already suspicious will find it.
+//
+// And it covers the two append-only side channels. Declared debt and
+// logged friction are reachable only through `debt list <task>` (which
+// needs a task id the operator has no way to guess) and `friction list`
+// (which needs the operator to already suspect there is something to
+// read), so a graph carrying either looks perfectly healthy from
+// `status` unless `status` says so.
 
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -106,6 +113,84 @@ ok =
     const r = mustSucceed(p.run('status'), 'hedgehog status');
     assertIncludes(r.out, 'ORPHANED OVERRIDES', 'the section survives an unparseable core.yaml');
     assertIncludes(r.out, 'BILLING-FONUDATION', 'the orphaned id is still named');
+  }) && ok;
+
+ok =
+  scenario('status is quiet when nothing has been declared or logged', () => {
+    const p = plannedProject('billing');
+    const r = mustSucceed(p.run('status'), 'hedgehog status');
+    assertNotIncludes(r.out, 'DECLARED DEBT', 'no debt section on a graph with no debt');
+    assertNotIncludes(r.out, 'FRICTION LOGGED', 'no friction section on a graph with none');
+  }) && ok;
+
+ok =
+  scenario('status reports declared debt and names the declaring task', () => {
+    const p = plannedProject('billing');
+    mustSucceed(
+      p.run('debt', 'add', 'BILLING-FOUNDATION', 'manifest is hand-rolled'),
+      'hedgehog debt add',
+    );
+
+    const r = mustSucceed(p.run('status'), 'hedgehog status');
+    assertIncludes(r.out, 'DECLARED DEBT', 'status names the debt section');
+    assertIncludes(r.out, 'BILLING-FOUNDATION', 'status names the declaring task');
+    assertIncludes(r.out, 'hedgehog debt list', 'status points at the listing command');
+    // The count is the altitude here: `debt list` owns the notes, and a
+    // status overview that reprints them is that command with extra steps.
+    assertNotIncludes(r.out, 'manifest is hand-rolled', 'the note text stays in debt list');
+  }) && ok;
+
+// Two rows against one task collapse to one line — the per-task count is
+// what makes `debt list <task>` reachable, and one line per note would
+// turn the overview back into the listing it defers to.
+ok =
+  scenario('multiple debt notes on one task collapse to a count', () => {
+    const p = plannedProject('billing');
+    mustSucceed(p.run('debt', 'add', 'BILLING-FOUNDATION', 'first'), 'hedgehog debt add');
+    mustSucceed(p.run('debt', 'add', 'BILLING-FOUNDATION', 'second'), 'hedgehog debt add');
+
+    const r = mustSucceed(p.run('status'), 'hedgehog status');
+    assertIncludes(r.out, 'DECLARED DEBT  2', 'the section header carries the row total');
+    assertIncludes(r.out, '2 notes', 'the declaring task carries its own count');
+  }) && ok;
+
+ok =
+  scenario('status reports logged friction', () => {
+    const p = plannedProject('billing');
+    mustSucceed(p.run('friction', 'add', 'plan --recompile was hard to find'), 'hedgehog friction add');
+
+    const r = mustSucceed(p.run('status'), 'hedgehog status');
+    assertIncludes(r.out, 'FRICTION LOGGED  1', 'status counts the friction row');
+    assertIncludes(r.out, 'hedgehog friction list', 'status points at the listing command');
+  }) && ok;
+
+// A friction row's task_id is nullable — tweaker's reviewed-marker row
+// has none. The count is whole-project, so a row with no task must land
+// in it rather than being dropped for lacking an id to attribute it to.
+ok =
+  scenario('friction with no task id is still counted', () => {
+    const p = plannedProject('billing');
+    mustSucceed(p.run('friction', 'add', 'attributed', '--task', 'BILLING-FOUNDATION'), 'hedgehog friction add');
+    mustSucceed(p.run('friction', 'add', 'reviewed: 2026-01-01, issues: none filed'), 'hedgehog friction add');
+
+    const r = mustSucceed(p.run('status'), 'hedgehog status');
+    assertIncludes(r.out, 'FRICTION LOGGED  2', 'both rows count, with and without a task');
+  }) && ok;
+
+// Neither table has a resolved column, so the report must not claim a
+// state the schema can't back — nothing here is "open" or "unresolved",
+// only declared and logged.
+ok =
+  scenario('neither section claims an open/unresolved state', () => {
+    const p = plannedProject('billing');
+    mustSucceed(p.run('debt', 'add', 'BILLING-FOUNDATION', 'a note'), 'hedgehog debt add');
+    mustSucceed(p.run('friction', 'add', 'a friction note'), 'hedgehog friction add');
+
+    const r = mustSucceed(p.run('status'), 'hedgehog status');
+    assertIncludes(r.out, 'DECLARED DEBT', 'debt is reported as declared');
+    assertIncludes(r.out, 'FRICTION LOGGED', 'friction is reported as logged');
+    assertNotIncludes(r.out, 'OPEN DEBT', 'debt is declared, not open');
+    assertNotIncludes(r.out, 'UNRESOLVED', 'friction is logged, not unresolved');
   }) && ok;
 
 cleanupAll();

--- a/src/agents/backend-eng.md
+++ b/src/agents/backend-eng.md
@@ -42,7 +42,13 @@ needed.
   module = one table. Cross-module references are FK-by-ID columns
   only — never a foreign schema import.
 - **`contract`**: derive the Zod schema from Drizzle (`drizzle-zod`) and
-  wire the ts-rest contract in `packages/contracts`.
+  wire the ts-rest contract in `packages/contracts`. A `date`-mode
+  `timestamp` column reflected through `createSelectSchema` is overridden
+  to a union of `z.date()` and an ISO datetime string, never left as the
+  derived `z.date()` alone and never narrowed to a string-only schema —
+  the same field is checked server-side against a real `Date` and
+  client-side against JSON's string, and no `.transform()` can satisfy
+  both.
 - **`repository`**: a port (interface) plus a Drizzle adapter in
   `libs/<module>/repository`. A `findById`-shaped miss returns
   `undefined` — plain absence, not a thrown error; the service decides

--- a/src/db/status.mjs
+++ b/src/db/status.mjs
@@ -12,6 +12,7 @@
 // would pick.
 
 import { detectDrift, formatDrift } from './drift.mjs';
+import { orphanedOverrides } from './overrides.mjs';
 import { formatMissingRequirements } from './requires.mjs';
 import { readyTasks, heldBackReason } from './ready.mjs';
 
@@ -82,16 +83,17 @@ function loadAttentionTasks(db) {
   return db.prepare(ATTENTION_TASKS_SQL).all();
 }
 
-// Returns { counts, ready, heldBack, inFlight, attention, drift, total } —
-// counts keyed by every status in the tasks CHECK constraint (present even
-// at zero), ready the full list of currently-pickable tasks, heldBack the
-// subset of those that `hedgehog claim` would skip over right now because
-// they conflict with in-flight work or another ready task ahead of them
-// (ready.mjs's own simulation, reused rather than reimplemented — without
-// this a task can sit in READY indefinitely with no visible reason, the
-// same invisible-stall shape blocked tasks had before `attention` existed),
-// inFlight the tasks currently leased (building or verifying), attention
-// the stalled tasks needing a fix, total the sum across all statuses.
+// Returns { counts, ready, heldBack, inFlight, attention, drift,
+// orphanedOverrides, total } — counts keyed by every status in the tasks
+// CHECK constraint (present even at zero), ready the full list of
+// currently-pickable tasks, heldBack the subset of those that `hedgehog
+// claim` would skip over right now because they conflict with in-flight
+// work or another ready task ahead of them (ready.mjs's own simulation,
+// reused rather than reimplemented — without this a task can sit in READY
+// indefinitely with no visible reason, the same invisible-stall shape
+// blocked tasks had before `attention` existed), inFlight the tasks
+// currently leased (building or verifying), attention the stalled tasks
+// needing a fix, total the sum across all statuses.
 //
 // `core` is optional and, when given, adds `drift`: the tasks whose
 // layer-derived fields no longer match core.yaml (drift.mjs). It's a
@@ -103,6 +105,15 @@ function loadAttentionTasks(db) {
 // resolve and pass in — detectDrift needs it composed against `core` or
 // every task widened by `.hedgehog/overrides/*.json` reports permanent,
 // spurious drift here.
+//
+// `orphanedOverrides` (overrides.mjs) is the override ids matching no
+// task row. It rides on `status` rather than on `override list` alone
+// because a dead override is invisible by construction — composeScope
+// missing a key is a no-op, so the file widens nothing and raises
+// nothing, and `override list` is a command an operator only runs once
+// they already suspect something. It reads only `tasks`, not core.yaml,
+// so it is computed unconditionally: an override id is stale or it
+// isn't, whether or not a core definition is loadable.
 export function graphStatus(db, { core = null, overrides = new Map() } = {}) {
   const counts = countTasksByStatus(db);
   const ready = loadReadyTasks(db);
@@ -110,8 +121,18 @@ export function graphStatus(db, { core = null, overrides = new Map() } = {}) {
   const inFlight = loadInFlightTasks(db);
   const attention = loadAttentionTasks(db);
   const drift = core ? detectDrift(db, core, { overrides }) : [];
+  const orphaned = orphanedOverrides(db, overrides);
   const total = Object.values(counts).reduce((a, b) => a + b, 0);
-  return { counts, ready, heldBack, inFlight, attention, drift, total };
+  return {
+    counts,
+    ready,
+    heldBack,
+    inFlight,
+    attention,
+    drift,
+    orphanedOverrides: orphaned,
+    total,
+  };
 }
 
 const BLOCKED_REASON_LABELS = {
@@ -123,7 +144,8 @@ const BLOCKED_REASON_LABELS = {
 // Renders a graphStatus() result into a plain-text overview: counts by
 // status (only non-zero ones, in lifecycle order), any declared binary
 // this environment can't resolve, the ready list, tasks currently in
-// flight, anything needing attention, and core.yaml drift.
+// flight, anything needing attention, core.yaml drift, and overrides
+// pointing at no task.
 //
 // `missingRequirements` comes from the core definition rather than the
 // database (src/db/requires.mjs#coreMissingRequirements), so the caller
@@ -138,6 +160,7 @@ export function formatStatus({
   inFlight,
   attention,
   drift,
+  orphanedOverrides = [],
   total,
   missingRequirements,
 }) {
@@ -191,12 +214,28 @@ export function formatStatus({
     lines.push('  Fix the work, then: hedgehog retry <task-id> && hedgehog claim <task-id> --owner <owner>');
   }
 
-  // Last, because it's a condition of the graph as a whole rather than
-  // of any one task, and because an operator reading top-down should
-  // reach it after knowing what's ready and what's stuck.
+  // Last two, because both are conditions of the graph as a whole rather
+  // than of any one task, and because an operator reading top-down should
+  // reach them after knowing what's ready and what's stuck.
   if (drift && drift.length > 0) {
     lines.push('');
     lines.push(formatDrift(drift));
+  }
+
+  // Below drift because it's the rarer of the two and never blocks the
+  // build: an orphaned override is work the operator asked for that isn't
+  // happening, not work the graph is getting wrong. `hedgehog override
+  // list` carries the full explanation of how an id goes stale; here the
+  // consequence is the whole point, since this is the only place an
+  // operator who doesn't already suspect it will ever see it.
+  if (orphanedOverrides.length > 0) {
+    lines.push('');
+    lines.push('ORPHANED OVERRIDES');
+    for (const taskId of orphanedOverrides) {
+      lines.push(`  ${taskId}   no task with this id in the build graph`);
+    }
+    lines.push('');
+    lines.push('  Each widens nothing until the id matches a real task. See: hedgehog override list');
   }
 
   return lines.join('\n');

--- a/src/db/status.mjs
+++ b/src/db/status.mjs
@@ -11,7 +11,9 @@
 // every task meeting that condition, not just the one `hedgehog next`
 // would pick.
 
+import { listDebt } from './debt.mjs';
 import { detectDrift, formatDrift } from './drift.mjs';
+import { listFriction } from './friction.mjs';
 import { orphanedOverrides } from './overrides.mjs';
 import { formatMissingRequirements } from './requires.mjs';
 import { readyTasks, heldBackReason } from './ready.mjs';
@@ -83,17 +85,49 @@ function loadAttentionTasks(db) {
   return db.prepare(ATTENTION_TASKS_SQL).all();
 }
 
+// Collapses every debt row to one entry per declaring task: { taskId, n }
+// in task-id order. The notes themselves stay out — a status overview
+// that reprints them is `debt list` with extra steps, and the note only
+// becomes actionable in the packet of a task that inherits it, where
+// next.mjs already renders it in full. The task id is the part that has
+// to be here, because it is the argument `debt list <task>` needs and
+// the thing an operator has no other way to guess.
+function loadDebtByTask(db) {
+  const byTask = new Map();
+  for (const { taskId } of listDebt(db)) {
+    byTask.set(taskId, (byTask.get(taskId) ?? 0) + 1);
+  }
+  return [...byTask.entries()]
+    .map(([taskId, n]) => ({ taskId, n }))
+    .sort((a, b) => a.taskId.localeCompare(b.taskId));
+}
+
+// The friction row count, or 0. `listFriction` reads the table
+// unguarded, so a build graph predating it throws here where `listDebt`
+// would return [] — caught rather than propagated for the same reason
+// the CLI tolerates an unparseable core.yaml: status is the command
+// every session starts with, and one absent table must not cost the
+// operator the whole overview. Every other section is still true.
+function countFriction(db) {
+  try {
+    return listFriction(db).length;
+  } catch {
+    return 0;
+  }
+}
+
 // Returns { counts, ready, heldBack, inFlight, attention, drift,
-// orphanedOverrides, total } — counts keyed by every status in the tasks
-// CHECK constraint (present even at zero), ready the full list of
-// currently-pickable tasks, heldBack the subset of those that `hedgehog
-// claim` would skip over right now because they conflict with in-flight
-// work or another ready task ahead of them (ready.mjs's own simulation,
-// reused rather than reimplemented — without this a task can sit in READY
-// indefinitely with no visible reason, the same invisible-stall shape
-// blocked tasks had before `attention` existed), inFlight the tasks
-// currently leased (building or verifying), attention the stalled tasks
-// needing a fix, total the sum across all statuses.
+// orphanedOverrides, debt, frictionCount, total } — counts keyed by
+// every status in the tasks CHECK constraint (present even at zero),
+// ready the full list of currently-pickable tasks, heldBack the subset
+// of those that `hedgehog claim` would skip over right now because they
+// conflict with in-flight work or another ready task ahead of them
+// (ready.mjs's own simulation, reused rather than reimplemented —
+// without this a task can sit in READY indefinitely with no visible
+// reason, the same invisible-stall shape blocked tasks had before
+// `attention` existed), inFlight the tasks currently leased (building or
+// verifying), attention the stalled tasks needing a fix, total the sum
+// across all statuses.
 //
 // `core` is optional and, when given, adds `drift`: the tasks whose
 // layer-derived fields no longer match core.yaml (drift.mjs). It's a
@@ -114,6 +148,17 @@ function loadAttentionTasks(db) {
 // they already suspect something. It reads only `tasks`, not core.yaml,
 // so it is computed unconditionally: an override id is stale or it
 // isn't, whether or not a core definition is loadable.
+//
+// `debt` (per declaring task) and `frictionCount` are counts, not
+// listings: both tables are append-only with no resolved column, so
+// there is no "open" subset to filter to and this can only ever report
+// what has been declared. That is the honest reading and also the
+// useful one — a debt note is consumed by whichever downstream task
+// inherits it, and friction is reviewed in a batch by tweaker, so
+// neither is a queue `status` could burn down. What was missing was
+// only the existence signal: `debt list` needs a task id the operator
+// has no way to guess, and `friction list` needs the operator to
+// already suspect there is something to read.
 export function graphStatus(db, { core = null, overrides = new Map() } = {}) {
   const counts = countTasksByStatus(db);
   const ready = loadReadyTasks(db);
@@ -122,6 +167,8 @@ export function graphStatus(db, { core = null, overrides = new Map() } = {}) {
   const attention = loadAttentionTasks(db);
   const drift = core ? detectDrift(db, core, { overrides }) : [];
   const orphaned = orphanedOverrides(db, overrides);
+  const debt = loadDebtByTask(db);
+  const frictionCount = countFriction(db);
   const total = Object.values(counts).reduce((a, b) => a + b, 0);
   return {
     counts,
@@ -131,6 +178,8 @@ export function graphStatus(db, { core = null, overrides = new Map() } = {}) {
     attention,
     drift,
     orphanedOverrides: orphaned,
+    debt,
+    frictionCount,
     total,
   };
 }
@@ -144,8 +193,9 @@ const BLOCKED_REASON_LABELS = {
 // Renders a graphStatus() result into a plain-text overview: counts by
 // status (only non-zero ones, in lifecycle order), any declared binary
 // this environment can't resolve, the ready list, tasks currently in
-// flight, anything needing attention, core.yaml drift, and overrides
-// pointing at no task.
+// flight, anything needing attention, core.yaml drift, overrides
+// pointing at no task, and what has been recorded in the two
+// append-only side channels (declared debt, logged friction).
 //
 // `missingRequirements` comes from the core definition rather than the
 // database (src/db/requires.mjs#coreMissingRequirements), so the caller
@@ -161,6 +211,8 @@ export function formatStatus({
   attention,
   drift,
   orphanedOverrides = [],
+  debt = [],
+  frictionCount = 0,
   total,
   missingRequirements,
 }) {
@@ -236,6 +288,40 @@ export function formatStatus({
     }
     lines.push('');
     lines.push('  Each widens nothing until the id matches a real task. See: hedgehog override list');
+  }
+
+  // Bottom, below every condition above, and two sections rather than
+  // one. Everything above is something wrong — work stalled, a graph
+  // that disagrees with its core, an override doing nothing. These two
+  // are neither wrong nor actionable here: both tables are append-only,
+  // so nothing printed can be cleared by acting on it, and an operator
+  // scanning top-down should hit what needs a decision first.
+  //
+  // Kept apart because they are read by different people at different
+  // times through different commands. Debt is in-build traffic between
+  // two tasks — it arrives on its own in the inheriting task's packet,
+  // and naming the declaring tasks here is only so `debt list <task>`
+  // is reachable without guessing the id. Friction is about Hedgehog
+  // itself, batch-reviewed by tweaker at the end of a build, and has no
+  // per-task reading at all (a row's task_id is nullable). Merging them
+  // into one "notes" count would imply a single follow-up action where
+  // there are two unrelated ones.
+  if (debt.length > 0) {
+    const rows = debt.reduce((sum, { n }) => sum + n, 0);
+    lines.push('');
+    lines.push(`DECLARED DEBT  ${rows}`);
+    for (const { taskId, n } of debt) {
+      lines.push(`  ${taskId}   ${n} note${n === 1 ? '' : 's'}`);
+    }
+    lines.push('');
+    lines.push('  Reaches each dependent task\'s packet on its own. See: hedgehog debt list <task-id>');
+  }
+
+  if (frictionCount > 0) {
+    lines.push('');
+    lines.push(`FRICTION LOGGED  ${frictionCount}`);
+    lines.push('');
+    lines.push('  Reviewed as a batch at the end of a build. See: hedgehog friction list');
   }
 
   return lines.join('\n');

--- a/src/golden-cores/full-stack-app/.env.example
+++ b/src/golden-cores/full-stack-app/.env.example
@@ -2,3 +2,4 @@
 # service — no edits needed unless you've changed those credentials.
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/app
 NODE_ENV=development
+WEB_ORIGIN=http://localhost:3000

--- a/src/golden-cores/full-stack-app/apps/api/src/main.ts
+++ b/src/golden-cores/full-stack-app/apps/api/src/main.ts
@@ -3,11 +3,16 @@ import { Logger } from 'nestjs-pino';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app/app.module';
 
-loadEnv();
+const env = loadEnv();
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { bufferLogs: true });
   app.useLogger(app.get(Logger));
+  // apps/web runs on its own origin in local dev (see the port comment
+  // below), so the browser's fetches to this api are cross-origin by
+  // default — enable CORS for that origin rather than rediscovering this
+  // per project.
+  app.enableCors({ origin: env.WEB_ORIGIN });
   const globalPrefix = 'api';
   app.setGlobalPrefix(globalPrefix);
   // Defaults to 3333, not 3000 — `apps/web`'s `next dev` also defaults to

--- a/src/golden-cores/full-stack-app/core.yaml
+++ b/src/golden-cores/full-stack-app/core.yaml
@@ -52,6 +52,8 @@ layers:
     scope: ["apps/web/src/app/{module}/**", "apps/mobile/src/{module}/**"]
     verify: "pnpm nx test web -- src/app/{module}/ && pnpm nx test mobile -- src/{module}/"
     commit: "feat({module}): screen-web"
+  # Workspace-wide by design: the only gate that can see cross-module
+  # breakage, since every layer above is parallel and module-scoped.
   - id: join
     depends_on: screen
     scope: ["**"]

--- a/src/golden-cores/full-stack-app/packages/config/src/env.schema.spec.ts
+++ b/src/golden-cores/full-stack-app/packages/config/src/env.schema.spec.ts
@@ -22,4 +22,17 @@ describe('envSchema', () => {
     const result = envSchema.safeParse({ ...valid, NODE_ENV: 'staging' });
     expect(result.success).toBe(false);
   });
+
+  it('defaults WEB_ORIGIN when absent', () => {
+    const result = envSchema.safeParse(valid);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.WEB_ORIGIN).toBe('http://localhost:3000');
+    }
+  });
+
+  it('rejects a non-URL WEB_ORIGIN', () => {
+    const result = envSchema.safeParse({ ...valid, WEB_ORIGIN: 'not-a-url' });
+    expect(result.success).toBe(false);
+  });
 });

--- a/src/golden-cores/full-stack-app/packages/config/src/env.schema.ts
+++ b/src/golden-cores/full-stack-app/packages/config/src/env.schema.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const envSchema = z.object({
   DATABASE_URL: z.string().url(),
   NODE_ENV: z.enum(['development', 'test', 'production']),
+  WEB_ORIGIN: z.string().url().default('http://localhost:3000'),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/skills/hedgehog-bootstrap-full-stack-app-core/SKILL.md
+++ b/src/skills/hedgehog-bootstrap-full-stack-app-core/SKILL.md
@@ -32,19 +32,22 @@ copied to the repo root:
   --projects=api,web --parallel` — so a fresh clone has one command that
   brings up Postgres and both apps together), `eslint.config.mjs`,
   `docker-compose.yml` (Postgres only — Redis joins later, only if the
-  Queue add-on turns on), `.env.example` (`DATABASE_URL`/`NODE_ENV`,
-  copied to `.env` in step 4), `lefthook.yml`, `commitlint.config.cjs`,
+  Queue add-on turns on), `.env.example`
+  (`DATABASE_URL`/`NODE_ENV`/`WEB_ORIGIN`, copied to `.env` in step 4),
+  `lefthook.yml`, `commitlint.config.cjs`,
   `tools/phase-gate.cjs`, `.github/workflows/phase-gate.yml`,
   `tsconfig.base.json`, `pnpm-lock.yaml`.
 - `packages/config/` — `eslint-base.js`, `prettier.js` (no
   `prettier-plugin-tailwindcss` — that's `apps/web`'s own config, already
-  wired), `env.schema.ts` (core fields only: `DATABASE_URL`, `NODE_ENV`).
-  Tagged `type:util`.
+  wired), `env.schema.ts` (core fields only: `DATABASE_URL`, `NODE_ENV`,
+  and `WEB_ORIGIN` — the origin `apps/api` enables CORS for, defaulted to
+  `apps/web`'s dev origin). Tagged `type:util`.
 - `packages/db/` — Drizzle client/connection wired to `loadEnv()`, no
   domain schema. Tagged `scope:db`, `type:adapter`.
-- `apps/api/` — Nest shell, `nestjs-pino` wired, health check only, no
-  domain controllers. `apps/api-e2e` already converted to Vitest with an
-  explicit `e2e` target. Tagged `scope:api`.
+- `apps/api/` — Nest shell, `nestjs-pino` wired, CORS enabled for
+  `WEB_ORIGIN`, health check only, no domain controllers. `apps/api-e2e`
+  already converted to Vitest with an explicit `e2e` target. Tagged
+  `scope:api`.
 - `apps/web/` — Next shell, Tailwind v4 (PostCSS plugin, no
   `tailwind.config.js`), hand-built ShadCN base (`components.json`,
   `cn()` util, CSS variable theme, light/dark toggle via an inline


### PR DESCRIPTION
## Summary

Five mechanical fixes from a triage sweep of open issues, each its own commit:

- **#61** — `hedgehog status` now surfaces overrides that name no existing task (orphaned overrides), previously silent.
- **#62** — `hedgehog status` now reports declared debt (per-task counts) and logged friction. Labeled as counts, not "open"/"unresolved" — neither table has a resolved/closed column, so the output doesn't claim state the schema can't back.
- **#72** — `apps/api`'s golden-core scaffold now calls `enableCors()` against a `WEB_ORIGIN` env var (optional, defaults to `http://localhost:3000` so it doesn't break existing `.env` files). Bootstrap skill's env-field prose updated in the two other places it enumerated fields, to avoid reintroducing the drift this was fixing.
- **#74** — `backend-eng.md`'s contract-layer step pins the timestamp convention (`z.date()` / ISO-string union, no `.transform()`) so `createSelectSchema` output survives the Drizzle → JSON → client round trip. Doc-only; doesn't touch codegen.
- **#79** — investigated as a suspected bug (final verify gate using `nx run-many` instead of affected-only like every sibling layer) and found it's intentional: the `join` layer is the only gate that sees cross-module breakage, since the per-module layers are deliberately scoped narrow. Documented the rationale in `core.yaml` instead of changing behavior.

Two fixes surfaced adjacent issues caught in review rather than left for a subagent's word:
- #72's scaffold change initially left the bootstrap skill's env-field enumeration out of sync with the new field — fixed in the same commit.
- #61's fix (loading overrides unconditionally) exposed a latent crash: malformed override JSON would throw out of `status`, the first command any session runs. Wrapped with the same try/catch pattern used for the adjacent unparseable-`core.yaml` case.

## Screened out this round

Issues considered but not touched, because the fix requires a judgment call, new scaffolding, or is too broad to verify safely here: #15 (security, untouched on purpose), #47, #64, #65, #66, #67, #68, #69, #70, #71, #73, #75, #76, #77, #78, #80. Comments going up on the ones where the sweep learned something specific that'll help scope a fix next time.

## Test plan

- [x] `pnpm check` passes (18 agents, 24 skills, 2 cores, tarball, CLI)
- [x] `pnpm repro` — 53/54; the one failure (`plan-no-open.mjs`) confirmed pre-existing against a clean stashed tree, unrelated headless-display path
- [x] `repro/05-shipped-cores-unchanged.mjs` passes — confirms the `core.yaml` doc-only edit left the compiled task graph byte-identical