### PR TITLE
fix: repro suite's headless-detection test fails deterministically on macOS/Windows (#88)

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1778,7 +1778,13 @@ function openInBrowser(url) {
 // either fails silently or blocks on a text browser. Printing the URL is
 // the useful behaviour in that case — a person on the other end of a
 // port-forward can still open it.
+//
+// HEDGEHOG_FORCE_HEADLESS bypasses the platform check entirely — the
+// repro suite's only way to exercise the no-display branch on macOS/
+// Windows, where DISPLAY/WAYLAND_DISPLAY are never consulted for real
+// users. Not a documented user-facing flag.
 function hasDisplay() {
+  if (process.env.HEDGEHOG_FORCE_HEADLESS) return false;
   if (process.platform === 'darwin' || process.platform === 'win32') return true;
   return Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
 }

--- a/repro/plan-no-open.mjs
+++ b/repro/plan-no-open.mjs
@@ -88,7 +88,7 @@ try {
 
   // ── 5. --open is the opt-in escape hatch ────────────────────────────
   hedgehog(project, ['intent', 'add', '--id', 'gamma', '--goal', 'g', '--outcome', 'o']);
-  const opened = hedgehog(project, ['plan', '--open'], { DISPLAY: '', WAYLAND_DISPLAY: '' });
+  const opened = hedgehog(project, ['plan', '--open'], { HEDGEHOG_FORCE_HEADLESS: '1' });
   settle();
 
   check('plan --open exits 0', opened.status === 0, {


### PR DESCRIPTION
## Summary

Fixes #88, filed after last round's issue sweep reported `plan-no-open.mjs`'s one failure as an "unrelated flake" — investigation showed it isn't a flake at all, it's a deterministic, 100%-reproducing bug specific to macOS/Windows.

**Root cause**: `bin/cli.mjs`'s `hasDisplay()` returns `true` unconditionally on `darwin`/`win32` — `DISPLAY`/`WAYLAND_DISPLAY` are only consulted on other platforms. `repro/plan-no-open.mjs` cleared those two env vars expecting that to simulate a headless session, but on macOS/Windows `hasDisplay()` never looks at them, so the command always tries to open a browser instead of printing the URL, and the test's `checkContains(..., 'http://localhost:')` fails every time. CI runs on `ubuntu-latest`, where the env vars *are* consulted, so this has been silently platform-inconsistent — green in CI, red on every macOS/Windows contributor machine — since the test was written.

**Fix**: added `HEDGEHOG_FORCE_HEADLESS`, an internal env override `hasDisplay()` checks first, and pointed the test at it instead of the env vars that were never being read on this platform. This gives the no-display branch real test coverage on every platform, rather than coverage that only exists on Linux by accident.

## Test plan

- [x] `node repro/plan-no-open.mjs` — all 11 checks pass, run 4 times consecutively on macOS
- [x] `pnpm check` — green
- [x] `pnpm repro` — all 54 reproductions pass (previously 53/54, with this test's one failure)