### PR TITLE
fix(core): name layer generators and surface core.yaml's tag shape in packets

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -653,6 +653,20 @@ async function resolveCorePath() {
   return null;
 }
 
+// The active core's `id` (e.g. `full-stack-app`), or null when no core has
+// landed yet or it fails to parse — packet rendering degrades gracefully
+// either way (see next.mjs's layerShapeLines), so a caller only asking for
+// the id doesn't need its own try/catch.
+async function resolveCoreId() {
+  const corePath = await resolveCorePath();
+  if (!corePath) return null;
+  try {
+    return (await loadCore(corePath)).id;
+  } catch {
+    return null;
+  }
+}
+
 // `hedgehog plan --recompile` — the reconciliation path for a core.yaml
 // edited after `plan` already compiled it.
 //
@@ -973,7 +987,7 @@ async function nextCommand() {
     console.error('');
   }
 
-  console.log(formatNext(packet));
+  console.log(formatNext(packet, await resolveCoreId()));
 }
 
 function printStalledTasks(stalled) {
@@ -1192,14 +1206,15 @@ async function verifyCommand(args) {
 // doesn't print the packet here, the STATUS/ALLOWED SCOPE/VERIFICATION an
 // agent is supposed to be dispatched with is no longer reachable from any
 // command. (`hedgehog show <task-id>` reprints it later.)
-function printPackets(tasks) {
+async function printPackets(tasks) {
+  const coreId = await resolveCoreId();
   const db = openDb();
   try {
     for (const task of tasks) {
       const packet = taskPacket(db, task.id);
       if (!packet) continue;
       console.log();
-      console.log(formatPacket(packet, taskStatusLine(packet.task)));
+      console.log(formatPacket(packet, taskStatusLine(packet.task), coreId));
     }
   } finally {
     db.close();
@@ -1286,7 +1301,7 @@ async function claimCommand(args) {
     if (claimed.length > 1) console.log(`  ${bold(task.id)}`);
     console.log(`  ${dim('expires')}  ${task.lease_expires_at}`);
   }
-  printPackets(claimed);
+  await printPackets(claimed);
 }
 
 // The targeted half of `claim`: one named task, or a non-zero exit
@@ -1305,7 +1320,7 @@ async function claimOneCommand(taskId, owner) {
   if (result.claimed) {
     console.log(`${green(bold('Claimed.'))} Task ${bold(taskId)} leased to ${bold(owner)}.`);
     console.log(`  ${dim('expires')}  ${result.task.lease_expires_at}`);
-    printPackets([result.task]);
+    await printPackets([result.task]);
     return;
   }
 
@@ -1429,7 +1444,7 @@ async function showCommand(args) {
     return;
   }
 
-  console.log(formatPacket(packet, taskStatusLine(packet.task)));
+  console.log(formatPacket(packet, taskStatusLine(packet.task), await resolveCoreId()));
 }
 
 // `hedgehog release <task-id> --owner <owner>` — hands a claimed task

--- a/src/agents/backend-eng.md
+++ b/src/agents/backend-eng.md
@@ -34,7 +34,10 @@ build exactly what its ALLOWED SCOPE names, one layer at a time, gated by
 Use `nx-run-tasks` (build/lint/test/typecheck), `nx-workspace` (inspecting
 project/target config), `nx-generate` (scaffolding a new library/app), and
 `link-workspace-packages` (wiring a new package into a consumer) as
-needed.
+needed. A layer's first-arrival package shell (`contract`, `repository`,
+`service`) is a generator call, not a hand-copy of a sibling package —
+`hedgehog-loop`'s "First arrival in a package" section names the exact
+command and tags for each.
 
 ## Core Responsibilities
 

--- a/src/agents/front-end-eng.md
+++ b/src/agents/front-end-eng.md
@@ -32,7 +32,9 @@ before the next starts.
 Use `nx-run-tasks` (build/lint/test/typecheck), `nx-workspace` (inspecting
 project/target config), `nx-generate` (scaffolding a new library/app), and
 `link-workspace-packages` (wiring a new package into a consumer) as
-needed.
+needed. The `hook` layer's first-arrival package shell is a generator
+call, not a hand-copy of a sibling package — `hedgehog-loop`'s "First
+arrival in a package" section names the exact command and tags.
 
 If the screen step calls for animation or motion — entrances, sequencing,
 scroll-driven effects, drag, SVG/morph effects — use GSAP, loading the

--- a/src/db/next.mjs
+++ b/src/db/next.mjs
@@ -234,6 +234,47 @@ export function taskStatusLine(task) {
   return task.status.toUpperCase();
 }
 
+// full-stack-app's own layer → Nx tag shape, mirroring the tag reference
+// table `src/golden-cores/full-stack-app/packages/config/eslint-base.js`
+// ships as a comment. A layer's `depConstraints` failure is a mechanical
+// consequence of this table crossed with `core.yaml`'s `depends_on` chain
+// — printing it in the packet turns that failure into a pre-flight fact
+// instead of something `nx lint` teaches the agent after the fact. Keyed
+// by layer id, not module, since the shape is the same for every module.
+const FULL_STACK_APP_LAYER_TAGS = {
+  schema: { tags: ['scope:db', 'type:adapter'], dependsOnTags: [] },
+  contract: { tags: ['scope:contracts', 'type:contract'], dependsOnTags: ['type:adapter', 'type:util'] },
+  repository: { tags: ['scope:{module}', 'type:adapter'], dependsOnTags: ['type:adapter', 'type:contract', 'type:util'] },
+  service: { tags: ['scope:{module}', 'type:service'], dependsOnTags: ['type:adapter', 'type:contract', 'type:util'] },
+  controller: { tags: ['scope:api'], dependsOnTags: ['type:adapter', 'type:service', 'type:contract', 'type:util'] },
+  hook: { tags: ['scope:hooks', 'type:hook'], dependsOnTags: ['type:contract', 'type:util'] },
+  screen: { tags: ['scope:web'], dependsOnTags: ['scope:contracts', 'scope:hooks', 'scope:shared', 'type:util'] },
+};
+
+// A LAYER SHAPE section for full-stack-app tasks only (`coreId ===
+// 'full-stack-app'`) — an authored core has no equivalent tag scheme
+// (layer-eng.md already points that agent at reading .hedgehog/core.yaml
+// directly instead), and `join` has no fixed tag shape of its own to
+// state, so both fall through to null and print nothing.
+function layerShapeLines(task, coreId) {
+  if (coreId !== 'full-stack-app') return null;
+  const shape = FULL_STACK_APP_LAYER_TAGS[task.layer];
+  if (!shape) return null;
+  const tags = shape.tags.map((t) => t.replace('{module}', task.module));
+  const lines = ['LAYER SHAPE', `  this layer's tags:      ${tags.join(', ')}`];
+  if (shape.dependsOnTags.length === 0) {
+    lines.push('  may depend on tags:     (nothing in-workspace — floor layer)');
+  } else {
+    lines.push(`  may depend on tags:     ${shape.dependsOnTags.join(', ')}`);
+  }
+  lines.push(
+    "  Confirm against packages/config/eslint-base.js's depConstraints before",
+    "  writing an import — a mismatch here is a pre-flight fact, not a lint",
+    '  failure to discover later.',
+  );
+  return lines;
+}
+
 // The standing honesty requirement, appended to every packet.
 //
 // Every other section is task-specific — this one is constant, which is
@@ -264,8 +305,8 @@ const HONESTY = [
 ];
 
 // Renders a packet into the STATUS / INTENT / RELEVANT RULES /
-// INHERITED DEBT / WHY NOW / BLOCKED DOWNSTREAM / ALLOWED SCOPE /
-// VERIFICATION / HONESTY format. The spec
+// INHERITED DEBT / WHY NOW / BLOCKED DOWNSTREAM / ALLOWED SCOPE / LAYER
+// SHAPE / VERIFICATION / HONESTY format. The spec
 // splits this across two examples — the `hedgehog next` display and "The
 // task packet" (which carries the intent and its rules) — but an agent
 // receives one thing, so the packet is one thing: everything the worker
@@ -273,12 +314,15 @@ const HONESTY = [
 //
 // `statusLine` is what goes on the STATUS row. `next` passes READY
 // literally, as it always has; `show` passes taskStatusLine(task), which
-// names the task's real state.
+// names the task's real state. `coreId` is the active core's `id` (from
+// `core.yaml`) — optional, since a caller with no core resolved yet (a
+// deferred install) still has to be able to render *something*; LAYER
+// SHAPE only ever appears for a recognised full-stack-app layer.
 //
 // HONESTY is last deliberately: it's the one section that qualifies the
 // gate above it, so it reads as the answer to "and what if I can't clear
 // VERIFICATION honestly" rather than as preamble.
-export function formatPacket(packet, statusLine) {
+export function formatPacket(packet, statusLine, coreId = null) {
   const { task, intent, requirements, dependents, incompleteDeps = [], inheritedDebt = [] } = packet;
   const scopeGlobs = JSON.parse(task.scope_globs);
 
@@ -346,6 +390,11 @@ export function formatPacket(packet, statusLine) {
   lines.push('ALLOWED SCOPE');
   for (const glob of scopeGlobs) lines.push(`  ${glob}`);
   lines.push('');
+  const shapeLines = layerShapeLines(task, coreId);
+  if (shapeLines) {
+    lines.push(...shapeLines);
+    lines.push('');
+  }
   lines.push('VERIFICATION');
   lines.push(`  ${task.verify_command}`);
   lines.push('');
@@ -354,8 +403,8 @@ export function formatPacket(packet, statusLine) {
   return lines.join('\n');
 }
 
-// `hedgehog next`'s rendering, unchanged: its task always came out of the
-// readiness SELECT, so STATUS is READY by construction.
-export function formatNext(packet) {
-  return formatPacket(packet, 'READY');
+// `hedgehog next`'s rendering: its task always came out of the readiness
+// SELECT, so STATUS is READY by construction.
+export function formatNext(packet, coreId = null) {
+  return formatPacket(packet, 'READY', coreId);
 }

--- a/src/skills/hedgehog-loop/SKILL.md
+++ b/src/skills/hedgehog-loop/SKILL.md
@@ -251,6 +251,33 @@ Never widen a scope to route around a violation the Correction Protocol
 should handle — this is for a package shell the layer genuinely creates,
 nothing else.
 
+**Generate the shell — never hand-author it.** `@nx/js:lib` produces a
+correct, non-buildable, Vitest-wired `package.json`/`tsconfig*.json`/
+`vitest.config.mts`/`src/index.ts` in one deterministic step; hand-copying
+a sibling package invites exactly the kind of drift (missing `nx.tags`,
+missing project references) `hedgehog verify`'s lint step then has to
+catch. Run the generator for the layer that's first-arriving, then add its
+tags — the pair `eslint-base.js`'s `depConstraints` expects (see its own
+tag reference table) — to the generated `package.json`'s `"nx".tags`:
+
+```bash
+# contract — first module through this layer only
+npx nx g @nx/js:lib packages/contracts --bundler=none --unitTestRunner=vitest
+# then set "nx": { "tags": ["scope:contracts", "type:contract"] } in packages/contracts/package.json
+
+# hook — first module through this layer only
+npx nx g @nx/js:lib packages/hooks --bundler=none --unitTestRunner=vitest
+# then set "nx": { "tags": ["scope:hooks", "type:hook"] } in packages/hooks/package.json
+
+# repository — every module, new lib each time
+npx nx g @nx/js:lib libs/{module}/repository --bundler=none --unitTestRunner=vitest
+# then set "nx": { "tags": ["scope:{module}", "type:adapter"] } in libs/{module}/repository/package.json
+
+# service — every module, new lib each time
+npx nx g @nx/js:lib libs/{module}/service --bundler=none --unitTestRunner=vitest
+# then set "nx": { "tags": ["scope:{module}", "type:service"] } in libs/{module}/service/package.json
+```
+
 **Wire the new package in before reporting the layer done.** A package
 that exists on disk isn't yet part of the workspace:
 


### PR DESCRIPTION
## Summary

Fixes the two cheaper root causes from #76 (agent "overthinking" on full-stack-app builds):

- **Generator scaffolding was optional, not mandatory.** `hedgehog-loop`'s "First arrival in a package" section widened scope for a layer's package shell but never said how to create it, so agents hand-copied a sibling package and drifted on `nx.tags`/project references. Now names the exact `nx g @nx/js:lib` command and resulting tags for `contract`/`repository`/`service`/`hook`, matching the precedent already set in `hedgehog-bootstrap`'s add-on scaffolding.
- **`core.yaml`'s tag/dependency shape wasn't surfaced up front.** The task packet had only ALLOWED SCOPE and VERIFICATION — a `depConstraints` mismatch was discovered via `nx lint` failure instead of read as a fact before writing code. Packets for full-stack-app tasks now include a LAYER SHAPE section (this layer's tags, and which tags it may depend on, sourced from `eslint-base.js`'s tag table) between ALLOWED SCOPE and VERIFICATION. Degrades to nothing for authored cores and `join`.

Proposal #3 from the issue (repeated-failure-class detection) is a bigger lift and left for a separate issue.

## Test plan

- [x] `npm run repro` — all 54 reproductions pass
- [x] `npm run check` — clean
- [x] Manually rendered sample packets for `repository` (mid-chain), `schema` (floor layer), `join` (no shape), an authored core, and no-core-resolved — all render correctly