### PR TITLE
docs: disambiguate root core.yaml from .hedgehog/core.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/src/skills/hedgehog-authored-loop/SKILL.md
+++ b/src/skills/hedgehog-authored-loop/SKILL.md
@@ -284,7 +284,7 @@ the ones that were designed.
 Same fresh-context handoff as `hedgehog-loop`'s Stop Condition (offer it
 once every task is `complete`, `hedgehog boundary` exits 0, and
 scope isn't genuinely ambiguous; the permanent record is the committed
-intents, friction log, and `core.yaml`, not `.hedgehog/hedgehog.db`,
+intents, friction log, and `.hedgehog/core.yaml`, not `.hedgehog/hedgehog.db`,
 which is gitignored and derived; a `tweaker` session in a *new* chat
 window handles adjustments, using the same paste-in prompt that skill's
 Stop Condition gives). On a module axis, "every task complete" means

--- a/src/skills/hedgehog-bootstrap-full-stack-app-core/SKILL.md
+++ b/src/skills/hedgehog-bootstrap-full-stack-app-core/SKILL.md
@@ -36,7 +36,11 @@ copied to the repo root:
   (`DATABASE_URL`/`NODE_ENV`/`WEB_ORIGIN`, copied to `.env` in step 4),
   `lefthook.yml`, `commitlint.config.cjs`,
   `tools/phase-gate.cjs`, `.github/workflows/phase-gate.yml`,
-  `tsconfig.base.json`, `pnpm-lock.yaml`.
+  `tsconfig.base.json`, `pnpm-lock.yaml`, and `core.yaml` — the shipped
+  layer sequence `hedgehog plan`/`verify`/`next` read for this project.
+  This root `core.yaml` is a different file from `.hedgehog/core.yaml`,
+  which only exists on an authored core (see `hedgehog-core-design`) —
+  the two never coexist on the same project.
 - `packages/config/` — `eslint-base.js`, `prettier.js` (no
   `prettier-plugin-tailwindcss` — that's `apps/web`'s own config, already
   wired), `env.schema.ts` (core fields only: `DATABASE_URL`, `NODE_ENV`,

--- a/src/skills/hedgehog-loop/SKILL.md
+++ b/src/skills/hedgehog-loop/SKILL.md
@@ -514,8 +514,10 @@ question and wait.
 On the former (a real build completion, not an ambiguity stop), offer a
 fresh-context handoff before doing anything else: tell the user the
 build is complete, and that clearing context now costs nothing. The
-permanent record is the committed intents, friction log, `core.yaml`,
-and the commit history itself — not `.hedgehog/hedgehog.db`, which is
+permanent record is the committed intents, friction log, root
+`core.yaml` (the shipped core definition — not `.hedgehog/core.yaml`,
+which only exists on an authored core), and the commit history itself —
+not `.hedgehog/hedgehog.db`, which is
 gitignored and derived, rebuildable at any time via `hedgehog db
 rebuild`. That's what makes the next session cheap.
 

--- a/src/templates/CLAUDE.md
+++ b/src/templates/CLAUDE.md
@@ -119,8 +119,9 @@ state.
 below — it checks nothing-in-flight, a clean tree, and a closed intent
 together), the build session is complete. The permanent record is the committed
 intents (`.hedgehog/intents/*.json`), the friction log
-(`.hedgehog/friction/*.md`), `core.yaml`, and the git commit history
-itself — not the database. `.hedgehog/hedgehog.db` is gitignored: a
+(`.hedgehog/friction/*.md`), the core definition (root `core.yaml` for a
+shipped core, `.hedgehog/core.yaml` for an authored one), and the git
+commit history itself — not the database. `.hedgehog/hedgehog.db` is gitignored: a
 derived index, rebuildable at any time via `hedgehog db rebuild`, which
 replays those committed sources against git history. That rebuild also
 runs automatically on a fresh clone when the DB is missing but


### PR DESCRIPTION
## Summary
- Several docs referenced `core.yaml` without a full path, in spots sitting next to `.hedgehog/`-prefixed sibling paths — reads ambiguously as if it were also under `.hedgehog/`, when it's actually the shipped-core copy at the project root.
- Confirmed the root `core.yaml` is functionally load-bearing (`resolveCorePath()` in `bin/cli.mjs` falls back to it when `.hedgehog/core.yaml` isn't present), not just a stray reference copy — so the fix spells out the correct path everywhere it was ambiguous rather than relocating the file.
- Fixed: `src/templates/CLAUDE.md`'s Stop Condition line (the exact line quoted in the issue), `hedgehog-loop`'s and `hedgehog-authored-loop`'s own Stop Condition sections, and added `core.yaml` to the "What lands" file list in `hedgehog-bootstrap-full-stack-app-core/SKILL.md` with an explicit note that it's a different file from `.hedgehog/core.yaml` and the two never coexist.
- Bumped version to 4.2.3 (docs-only fix).

Fixes #105

## Test plan
- [x] Grepped every `core.yaml` mention across `src/` and confirmed no other bare reference sits next to a `.hedgehog/`-prefixed sibling path (the actual collision pattern from the issue)
- [x] Reviewed diff for correctness of the added disambiguation text