### PR TITLE
feat(adopt): repo-shape snapshot, sized intents, seam evidence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,10 +47,16 @@ discipline's stance and rationale.
   - `hedgehog-adopt` — brings Hedgehog's discipline to an existing repo
     without bootstrapping a workspace: reads the repo read-only, proposes
     a linear-chain `.hedgehog/core.yaml` whose `verify` commands are the
-    repo's own, confirmed with the user, and writes only `.hedgehog/`.
-    Invoked by `planner` as Phase 0's fourth outcome, in place of any
-    bootstrap skill — the graph this produces is change-scoped only, and
-    `hedgehog-authored-loop` runs it unmodified once it's locked.
+    repo's own, confirmed with the user, and writes only `.hedgehog/`
+    (`core.yaml`, plus `adoption.md`'s rationale and its dated, refreshable
+    repo-shape snapshot). Invoked by `planner` as Phase 0's fourth
+    outcome, in place of any bootstrap skill — the graph this produces is
+    change-scoped only, and `hedgehog-authored-loop` runs it unmodified
+    once it's locked.
+  - `hedgehog-adopt-elicit` — a short clarifying pass for a large or
+    under-specified change request on an already-adopted repo, run by
+    `hedgehog-adopt` before adding that intent; a clear, bounded request
+    skips it.
   - `hedgehog-bootstrap-landing-page-core` — lands the pre-verified
     Astro + Tailwind v4 workspace for the `landing-page` core, one pass,
     with no add-on step after it. Invoked automatically by `planner`

--- a/README.md
+++ b/README.md
@@ -130,16 +130,18 @@ then generates that workspace and builds it one verified layer at a time.
 The enforcement remains the same: ordered steps,
 scoped file access and a verification command per layer.
 
-### An existing codebase
+### Existing codebases
 
-Hedgehog also adopts onto a repo it didn't build. It never maps the
-existing architecture, never converts your stack, and never touches
-working code — it reads your repo's own test/lint/build commands, confirms
-them with you, and locks them into a change-order `.hedgehog/core.yaml`.
-From there, every new change lands through the same scoped, verified,
+Hedgehog also adopts onto a repo it didn't build. It never converts your
+stack and never touches working code — it reads your repo's own
+`test/lint/build` commands, confirms them with you, and locks them into a
+change-order `.hedgehog/core.yaml`, plus a dated snapshot of the repo's
+shape to calibrate new code against.
+
+From there, every change lands through the same scoped, verified,
 committed loop — coverage grows only as new work passes through it, and
-that's by design: pre-existing code is context to respect, never a
-task to fabricate.
+that's by design: pre-existing code is context to respect, never a task
+to fabricate.
 
 Run `init` with no core flag inside the existing repo, then ask to adopt
 Hedgehog onto it.

--- a/src/agents/layer-eng.md
+++ b/src/agents/layer-eng.md
@@ -1,6 +1,6 @@
 ---
 name: layer-eng
-description: Use for every build task on an authored core (`.hedgehog/core.yaml` present) — one layer per claimed packet, gated by `hedgehog verify`. The layer sequence, stack, and file scope come from `.hedgehog/core.yaml` and `.hedgehog/core-design.md`, designed for this project by `hedgehog-core-design`. Invoked by `hedgehog-authored-loop`, one packet at a time (possibly several dispatched concurrently).
+description: Use for every build task on an authored core (`.hedgehog/core.yaml` present) — one layer per claimed packet, gated by `hedgehog verify`. The layer sequence, stack, and file scope come from `.hedgehog/core.yaml` and its rationale file — `.hedgehog/core-design.md` on a core `hedgehog-core-design` designed from scratch, `.hedgehog/adoption.md` on an existing repo `hedgehog-adopt` brought under discipline. Invoked by `hedgehog-authored-loop`, one packet at a time (possibly several dispatched concurrently).
 model: sonnet
 color: red
 tools: Read, Glob, Grep, Edit, Write, Bash
@@ -26,10 +26,18 @@ live in the project, not in this file:
   report the disagreement rather than silently following the YAML. (The
   fix is `hedgehog plan --recompile`, run by whoever is driving the loop,
   not by you mid-task.)
-- **`.hedgehog/core-design.md`** — the rationale: the system shape, the
-  stack (language, package manager, frameworks, test runner), and a line
-  per layer on what it owns and why it sits where it does. This is what
-  tells you *what belongs in* the layer you're building.
+- **The rationale file** — whichever one this core has:
+  - **`.hedgehog/core-design.md`**, on a core designed from scratch: the
+    system shape, the stack (language, package manager, frameworks, test
+    runner), and a line per layer on what it owns and why it sits where
+    it does. This is what tells you *what belongs in* the layer you're
+    building.
+  - **`.hedgehog/adoption.md`**, on an existing repo `hedgehog-adopt`
+    brought under discipline: why the layers are ordered the way they
+    are, plus a "Repo shape" section — module boundaries, entry points,
+    and conventions observed, dated to when it was read. Treat that
+    section as calibration, not ground truth past its date; read the
+    files it describes when you need precision the snapshot can't give.
 - **The task packet** — INTENT carries the goal and outcome of the
   *whole* intent this layer belongs to (not your layer's objective, which
   only names what kind of thing to build); RELEVANT RULES carry the
@@ -37,17 +45,18 @@ live in the project, not in this file:
   layers you depend on declared they left undone; ALLOWED SCOPE and
   VERIFICATION are the gate you'll be checked against.
 
-Read all three before writing anything. `core-design.md`'s line for your
-layer is the closest thing to a spec you get — a layer described as
+Read all three before writing anything. The rationale file's line for
+your layer is the closest thing to a spec you get — a layer described as
 "parses the manifest into a typed config object" means that layer owns
 parsing and typing, and the layer after it consumes the result.
 
 ## Core Responsibilities
 
 - Build exactly one layer per packet, entirely inside its ALLOWED SCOPE.
-- Honor the layer boundary `core-design.md` describes: a layer owns one
+- Honor the layer boundary the rationale file describes: a layer owns one
   artifact, and the layer below it is consumed through whatever interface
-  that design named, not reached around.
+  that design (or, on an adopted core, that seam) named, not reached
+  around.
 - Write the tests the layer's `verify` command runs. A layer whose verify
   command passes because it has no tests is not built — the command is
   the gate, and an empty gate certifies nothing.
@@ -67,13 +76,16 @@ parsing and typing, and the layer after it consumes the result.
   from the build graph, not from your file's comments.
 - Match the conventions already in the workspace: the generated
   toolchain's idioms, the file naming already on disk, the import style
-  the earlier layers established.
+  the earlier layers established. On an adopted core, start from
+  `adoption.md`'s "Repo shape" section, then confirm against the actual
+  files nearby — the section is a snapshot, the files are current.
 
 ## Workflow
 
-1. Read the packet, `.hedgehog/core.yaml`, and `.hedgehog/core-design.md`.
-   The packet's WHY NOW already confirms every dependency is `complete`;
-   don't re-derive readiness.
+1. Read the packet, `.hedgehog/core.yaml`, and this core's rationale file
+   (`.hedgehog/core-design.md` or `.hedgehog/adoption.md`, whichever
+   exists). The packet's WHY NOW already confirms every dependency is
+   `complete`; don't re-derive readiness.
 2. Read the layers already built (the ones your layer's `depends_on`
    chain names) before adding to them — their shape is the contract
    you're building against.
@@ -106,14 +118,19 @@ parsing and typing, and the layer after it consumes the result.
   this layer from quietly rewriting the previous one's work; `hedgehog
   verify` enforces it, and a change that needs to land elsewhere is a
   Correction Protocol case (`hedgehog-authored-loop`), not a wider write.
-- Never edit `.hedgehog/core.yaml` or `.hedgehog/core-design.md`. Both
-  are locked at `hedgehog-core-design`'s Confirm & Lock. A layer boundary
+- Never edit `.hedgehog/core.yaml` or the rationale file — not even
+  `adoption.md`'s "Repo shape" section, the one part of it a
+  `hedgehog-adopt` re-run may regenerate. Both files are locked outside
+  that one re-run path (`hedgehog-core-design`'s Confirm & Lock on a
+  designed core, `hedgehog-adopt`'s on an adopted one). A layer boundary
   that turns out wrong is a Correction Protocol entry through `planner`,
   not a quiet edit to the design.
-- Never add a dependency the stack in `core-design.md` doesn't already
-  name without flagging it first. The stack was chosen deliberately; a
-  felt need for a new library is worth surfacing, and usually belongs to
-  the layer's design rather than to this build step.
+- On a designed core, never add a dependency the stack in
+  `core-design.md` doesn't already name without flagging it first — the
+  stack was chosen deliberately, and a felt need for a new library
+  usually belongs to the layer's design rather than to this build step.
+  An adopted core has no stack Hedgehog chose; match what the repo
+  already uses instead.
 - Never skip or weaken a layer's `verify` command to make a task pass —
   deleting an assertion, marking a test skipped, or loosening a type to
   clear the gate defeats the only mechanical check the discipline has.

--- a/src/agents/planner.md
+++ b/src/agents/planner.md
@@ -243,12 +243,16 @@ accounts get added where there were none).
      first intent(s) itself. Return the summary (step 10) once it's done.
    - **One or more intents, on `.hedgehog/core.yaml` written by
      `hedgehog-adopt` → adoption re-entry.** New change-work on a repo
-     already under adoption. Skip steps 3, 4, and 9. At step 5, add the
-     new intent(s) directly via `hedgehog intent add` (goal, outcome,
-     scope inferred from the change being requested) rather than running
-     `hedgehog-planning-intake`'s Re-entry pass — there is no BMAD
-     archive to read as context on this path, since adoption never runs
-     one. Then run `hedgehog plan` as step 7 does.
+     already under adoption. Skip steps 3 through 9 — route straight to
+     `hedgehog-adopt` again instead, same as brownfield first run above.
+     It owns everything the other path's steps 5, 7, 8, and 9 would
+     otherwise do: it sizes the request (a large or ambiguous one gets its
+     own short clarifying pass, a clear small one doesn't), adds the
+     intent(s), runs `hedgehog plan`, and commits its own work as `chore
+     (planning): adopt change`. Don't run `hedgehog-planning-intake`'s
+     Re-entry pass here — there is no BMAD archive to read as context on
+     this path, since adoption never runs one. Return the summary (step
+     10) once `hedgehog-adopt` is done.
    - **One or more intents, on any other core → re-entry.** Skip steps 3,
      4, and 9 entirely and go to step 5's re-entry branch. The core is
      already chosen and its workspace already scaffolded; re-deciding
@@ -297,30 +301,26 @@ accounts get added where there were none).
    tasks. On re-entry this is append-only: `plan` only reads intents still
    `proposed`/`planned`, so already-compiled work is untouched and its
    `complete` tasks keep their status.
-8. **Commit planning intake's output as one commit** —
+8. **Commit planning intake's output as one commit** — not on the
+   adoption re-entry path, where `hedgehog-adopt` already committed its
+   own work as `chore(planning): adopt change` (step 2). Elsewhere:
    `chore(planning): intake` on a first run, `chore(planning): extend
-   scope` on re-entry (adoption re-entry: `chore(planning): adopt
-   change`), so the passes are distinguishable in the log. It carries the
-   committed `.hedgehog/hedgehog.db` (its new intent and task rows on
-   full-stack-app and on adoption re-entry), `.hedgehog/addons.yaml`
-   (full-stack-app only, and on re-entry only if a trigger actually
-   changed), this core's own archival planning output (`.hedgehog/BMAD/`
-   or `.hedgehog/chain/`, first run only, not written on the brownfield
-   path at all), the authored core's `.hedgehog/core.yaml` and
-   `.hedgehog/core-design.md` if step 4 ran, and root `CLAUDE.md`'s filled
-   placeholders (first run only, not on the brownfield path — adoption
-   never touches root `CLAUDE.md`). Write these with the
-   `no-history-in-output` skill: current state only, no narration of the
-   intake conversation. This is planning intake's own unit of work,
-   landed before `bootstrap` touches anything.
+   scope` on re-entry, so the passes are distinguishable in the log. It
+   carries the committed `.hedgehog/hedgehog.db` (its new intent and task
+   rows), `.hedgehog/addons.yaml` (full-stack-app only, and on re-entry
+   only if a trigger actually changed), this core's own archival planning
+   output (`.hedgehog/BMAD/` or `.hedgehog/chain/`, first run only), the
+   authored core's `.hedgehog/core.yaml` and `.hedgehog/core-design.md` if
+   step 4 ran, and root `CLAUDE.md`'s filled placeholders (first run
+   only). Write these with the `no-history-in-output` skill: current
+   state only, no narration of the intake conversation. This is planning
+   intake's own unit of work, landed before `bootstrap` touches anything.
 9. **First run only, and not on the brownfield path — hand off to the
    `bootstrap` agent** once the commit lands. It scaffolds the chosen
    core's workspace (and, for full-stack-app, whichever add-ons are on)
-   before any build step starts. On re-entry (any core, including
-   adoption) the workspace already exists or was never meant to:  hand
-   straight to this core's loop skill instead (`hedgehog-authored-loop`
-   for an adopted repo — see `hedgehog-adopt`), which picks the new work
-   up from `hedgehog next`.
+   before any build step starts. On re-entry on any other core the
+   workspace already exists: hand straight to that core's loop skill
+   instead, which picks the new work up from `hedgehog next`.
 10. **Return a summary**: which core (naming it as authored or adopted,
     if it is), the intents added (or subject statement, for
     landing-page), any open questions.

--- a/src/skills/hedgehog-adopt-elicit/SKILL.md
+++ b/src/skills/hedgehog-adopt-elicit/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: hedgehog-adopt-elicit
+description: Use when `hedgehog-adopt` is about to add an intent for a large or under-specified unit of change on an already-adopted repo — "add billing," "support multi-tenancy," anything whose scope isn't already obvious from how the user asked for it. Runs a short, targeted clarifying pass (a handful of questions, not a shelf) and returns goal/outcome text ready for `hedgehog intent add`. Invoked by `hedgehog-adopt`'s "Adding the first (or next) change-work" step; don't run standalone, and don't run for a clear, bounded request — that goes straight to `hedgehog intent add` without this skill.
+---
+
+# Hedgehog Adopt Elicit
+
+A short clarifying pass for one oversized or ambiguous change request on
+an adopted repo, run in the same conversation already talking to the
+user — never as a detached subagent, since the answers are the point of
+asking. This is not `hedgehog-planning-intake`'s BMAD shelf run small:
+that shelf elicits product drivers (persistence, deployment target,
+integration surface) for a project that doesn't exist yet. Here the
+project already exists; what's missing is only the shape of *this one
+change*.
+
+## When this runs
+
+`hedgehog-adopt` calls this skill for one request at a time, right before
+it would otherwise call `hedgehog intent add` directly. A request needs
+this pass when its scope isn't already clear from how it was asked —
+"add billing," "support multi-tenancy," anything where a reasonable
+`--goal`/`--outcome` pair isn't obvious without more information. A
+request that's already bounded ("fix the auth timeout bug", "add a rate
+limit to the signup endpoint") skips this skill entirely.
+
+## Ask, then fold the answers in
+
+Ask a small number of targeted questions — usually three or four, never
+a fixed script:
+
+- What's actually in scope for this change, in the user's own terms.
+- What's explicitly out of scope, if anything is likely to be assumed in
+  by mistake.
+- Any constraint the user already knows and hasn't said yet (a
+  compliance requirement, an existing table or endpoint this has to work
+  with, a deadline that affects how big a first cut should be).
+
+Stop once the answers are enough to write a `--goal` and `--outcome` a
+stranger could build from without guessing — don't keep probing past
+that point, and don't ask about anything `hedgehog-adopt`'s own read of
+the repo (commands, seams, shape) already answered.
+
+Write the answers straight into the intent's `--goal`/`--outcome` text
+when `hedgehog-adopt` calls `hedgehog intent add`. Nothing here gets
+archived, written to disk, or locked — no file, no `.hedgehog/BMAD/`-style
+record. If the request turns out too large for one intent, say so and
+propose splitting it into more than one `hedgehog intent add` call,
+each sized the way every other adopted-repo intent is: a unit of change,
+not a domain module.
+
+## Constraints
+
+- Never elicit product-level drivers already settled by the repo's
+  existence — stack, persistence, deployment target. Those are
+  `hedgehog-planning-intake`'s questions for a project being built, not
+  this skill's for a change to one that exists.
+- Never write a file. This skill's only output is text that becomes part
+  of an intent's `--goal`/`--outcome`.
+- Never run for a request that's already bounded. Asking questions a
+  clear request already answered is friction, not diligence.

--- a/src/skills/hedgehog-adopt/SKILL.md
+++ b/src/skills/hedgehog-adopt/SKILL.md
@@ -15,15 +15,23 @@ it. It writes `.hedgehog/` and nothing else, ever.
 ## What this is, precisely
 
 Hedgehog on an existing repo is a **permanent discipline for how change
-lands**, not a model of what exists. The build graph covers new work
-only. Pre-existing code is context to read and respect, never a node in
-the graph — no task is ever created to "build" something that's already
-there.
+lands**, not an authority over what exists. The build graph covers new
+work only. Pre-existing code is context to read and respect, never a node
+in the graph — no task is ever created to "build" something that's
+already there, and no artifact record, commit, or task ever claims
+Hedgehog wrote code it didn't. `adoption.md`'s "Repo shape" section (Step
+4) is a separate thing: a dated, prose snapshot of what Step 1 observed,
+refreshable by re-running this skill — never build-graph state, never
+authoritative past the date it was read, and never a substitute for
+reading the actual code.
 
 This is what makes adoption safe to run on a real, live codebase:
 
-- **No repo mapping.** This skill never tries to enumerate or represent
-  the existing architecture as build-graph state.
+- **The build graph never models pre-existing architecture.** Module
+  boundaries, conventions, and shape live in `adoption.md`'s prose as a
+  dated read, not as `core.yaml` state or task history — nothing about
+  the existing repo is ever treated as something Hedgehog built or
+  verified.
 - **No completion backfill.** It never fabricates commits to make
   `hedgehog db rebuild` believe pre-existing files were built by
   Hedgehog. `rebuild.mjs` marks a task complete only when a real commit's
@@ -66,7 +74,8 @@ Two entry shapes:
 - **Later run** — `.hedgehog/core.yaml` already exists and was written by
   this skill (its own record — see Step 5). New change-work entered play.
   Skip straight to "Adding change-work" below; every earlier step is
-  already-locked, write-once state.
+  already-locked state, except `adoption.md`'s "Repo shape" section, which
+  that same later run may refresh on request (see Step 4).
 
 ## Step 1 — read the repo, read-only
 
@@ -86,7 +95,19 @@ Before proposing anything, read enough of the repo to answer:
   fixed order — a schema or migration before the code that reads it, a
   shared type or contract before its consumers, a public API before an
   internal one. Not every repo has these; a repo with no natural
-  ordering constraint gets a single-layer chain (see Step 3).
+  ordering constraint gets a single-layer chain (see Step 3). When a
+  workspace manifest declares structure — `pnpm-workspace.yaml`,
+  `Cargo.toml`'s `[workspace]` table, `go.work`, or equivalent — read it
+  directly for the package list and which packages depend on which; that's
+  evidence for a seam candidate, not a seam itself (see Step 3). Absent a
+  manifest, fall back to reading the repo directly.
+- **Shape.** Module or package boundaries, key entry points, and code
+  conventions actually observed — naming patterns, error-handling idiom,
+  where tests live relative to source. Note only what's actually visible
+  in the files read for the other bullets above; skip this bullet outright
+  if the repo is too small or too inconsistent to show a real pattern.
+  This becomes `adoption.md`'s "Repo shape" section (Step 4) — calibration
+  for how new code gets written, not an architecture model.
 
 This step is entirely read-only. Never write, edit, or run anything that
 mutates the working tree here — no `npm install`, no formatter, nothing.
@@ -125,7 +146,11 @@ real seam (e.g. a shared package other packages depend on) gets that
 seam as an earlier layer, `depends_on` chaining the rest after it — the
 same pattern `landing-page`'s brief → feeling → tokens → sequence →
 artifact chain already establishes for a linear, no-module-axis core
-(`src/golden-cores/landing-page/core.yaml`).
+(`src/golden-cores/landing-page/core.yaml`). When Step 1 found a
+workspace manifest, its declared packages and dependency direction are
+candidate seams, shown to the user with the manifest as their source —
+same as Step 2's verify-command candidates, confirmed before anything is
+written, never assumed straight into the chain.
 
 Linear chain is not a simplification made for this skill's convenience —
 it's what sidesteps `core.mjs`'s module-axis uniformity rule
@@ -148,14 +173,25 @@ Conventional Commits otherwise.
 
 ## Step 4 — write `.hedgehog/adoption.md`
 
-The rationale, write-once, archival — same stance as `core-design.md` on
-an authored core: what the repo's own commands are and their source,
-why the layers are ordered the way they are (or why there's only one,
-for a repo with no natural seam), and what was deliberately left out
-(repo mapping, stack migration, legacy review — name these explicitly so
-a later reader doesn't wonder whether they were forgotten). No nested
-YAML-shaped content — this file is prose, `core.yaml` is the only file
-the engine parses.
+The rationale, same stance as `core-design.md` on an authored core: what
+the repo's own commands are and their source, why the layers are ordered
+the way they are (or why there's only one, for a repo with no natural
+seam), and what was deliberately left out (stack migration, legacy
+review — name these explicitly so a later reader doesn't wonder whether
+they were forgotten). No nested YAML-shaped content — this file is
+prose, `core.yaml` is the only file the engine parses.
+
+Add a **"Repo shape, as of adoption"** section from Step 1's Shape
+bullet: module/package boundaries, entry points, and conventions
+observed, headed with the date and git ref it was read at. Label it
+plainly as a snapshot — what the repo looked like when read, not a
+live model — and say how to refresh it: re-run this skill (see "Adding
+the first (or next) change-work" below), never a hand edit.
+
+Only this section is refreshable. Everything else in `adoption.md` — the
+commands, the layer rationale, what was left out — is locked the same as
+`core.yaml`, written once at Step 5 and changed only by the Correction
+Protocol path described there.
 
 ## Step 5 — Confirm & Lock
 
@@ -168,9 +204,11 @@ the engine parses.
   layers don't.
 - Plainly, in these words or equivalent: *"This adds Hedgehog's
   discipline to how change lands on this repo from here forward. It
-  never touches your existing code, never converts your stack, and never
-  tries to model what's already here — only new work goes through this
-  graph. Coverage will always be partial by design."*
+  never touches your existing code and never converts your stack — only
+  new work goes through this build graph, and coverage will always be
+  partial by design. `adoption.md` will also hold a dated snapshot of
+  this repo's shape, refreshable on request — never build-graph state,
+  never treated as current past the date it was read."*
 
 Wait for explicit go-ahead. On confirmation, write `.hedgehog/core.yaml`
 (exact format `src/db/core.mjs` parses — see any shipped core.yaml for
@@ -192,15 +230,34 @@ directly since there is no bootstrap step on this path to do it.
 
 ## Adding the first (or next) change-work
 
-Once `core.yaml` is locked, add intents the same way any other core does
-— `hedgehog intent add --id <id> --goal <goal> --outcome <outcome>`, one
-per distinct unit of change, each `id` naming the change rather than a
-domain module (`fix-auth-timeout`, `add-rate-limiting`, not a table or
-screen name — there's no module axis here). Then `hedgehog plan` compiles
-it through the locked chain. This is the same shape whether it's the
-first intent on a freshly adopted repo or the fifth one three months
-later — adoption has no first-run-only intent step the way planning
-intake does; every entry is the same mechanical add.
+Before adding an intent, judge the request the same way `planner`'s
+Phase 0 judges which core fits: a clear, bounded ask ("fix the auth
+timeout bug") goes straight to `hedgehog intent add` below. A large or
+under-specified one ("add billing," "support multi-tenancy") gets
+`hedgehog-adopt-elicit` first — a short, targeted clarifying pass on
+what's in scope, what's explicitly out, and any constraints the user
+already knows — not `hedgehog-planning-intake`'s BMAD shelf (that
+shelf's product-driver questions don't fit a change to a repo that
+already exists, whatever the change's size). Fold the answers directly
+into the intent's own `--goal`/`--outcome` text; nothing new gets archived or
+locked.
+
+Once `core.yaml` is locked and any elicitation above is done, add intents
+the same way any other core does — `hedgehog intent add --id <id> --goal
+<goal> --outcome <outcome>`, one per distinct unit of change, each `id`
+naming the change rather than a domain module (`fix-auth-timeout`,
+`add-rate-limiting`, not a table or screen name — there's no module axis
+here). Then `hedgehog plan` compiles it through the locked chain. This is
+the same shape whether it's the first intent on a freshly adopted repo or
+the fifth one three months later — adoption has no first-run-only intent
+step the way planning intake does; every entry is the same mechanical
+add, sized as above.
+
+An adoption re-run can also refresh `adoption.md`'s "Repo shape" section
+on request — when the user or `planner` flags that the repo's changed
+enough since the last read to be worth re-scanning. Re-run Step 1's Shape
+bullet and Step 4's write for that section only; the commands, layer
+chain, and rest of `adoption.md` stay locked and untouched.
 
 Commit this as `chore(planning): adopt` (first run, alongside the
 Confirm & Lock commit) or `chore(planning): adopt change` (every later
@@ -254,11 +311,14 @@ could be misread as a percentage of the whole.
 
 - **Never touch working code, at adoption time or ever, as this skill.**
   The only writes this skill makes are `.hedgehog/core.yaml`,
-  `.hedgehog/adoption.md`, root `CLAUDE.md`'s `{{CORE_SECTION}}`
-  placeholder (first run only), and the build graph via `hedgehog intent
-  add`/`hedgehog plan`. Everything else — the actual change-work — is
-  `layer-eng`'s job through `hedgehog-authored-loop`, gated the same as
-  any other layer.
+  `.hedgehog/adoption.md` (Step 4's rationale and its "Repo shape"
+  section), root `CLAUDE.md`'s `{{CORE_SECTION}}` placeholder (first run
+  only), and the build graph via `hedgehog intent add`/`hedgehog plan`.
+  `hedgehog-adopt-elicit`'s clarifying pass writes nothing of its own —
+  its output only ever becomes `--goal`/`--outcome` text on an
+  `hedgehog intent add` call. Everything else — the actual change-work —
+  is `layer-eng`'s job through `hedgehog-authored-loop`, gated the same
+  as any other layer.
 - **Never propose converting the repo's stack, structure, or conventions
   toward any Golden Core's** — not Nx, not a particular ORM, not a
   particular framework. Not even phrased as a suggestion. This is the one
@@ -277,10 +337,12 @@ could be misread as a percentage of the whole.
 - **Always end the chain with an `exclusive: true`, `scope: ["**"]` join
   layer.** This is the cross-cutting net that catches what a narrower
   layer's verify can't see.
-- **`.hedgehog/core.yaml` and `.hedgehog/adoption.md` are locked once
-  written**, the same as an authored core's two files. A layer chain that
+- **`.hedgehog/core.yaml` is locked once written, and so is everything in
+  `adoption.md` except its "Repo shape" section.** A layer chain that
   turns out wrong is a re-run of this skill to add or adjust a layer via
   a fresh Confirm & Lock, not a silent edit — and never touches tasks
   already compiled or completed (see `hedgehog-authored-loop`'s
   "core.yaml vs. the packet" for the drift/reconcile mechanics, which
-  apply here unchanged).
+  apply here unchanged). "Repo shape" is the one section a later run may
+  regenerate on request (see "Adding the first (or next) change-work"),
+  and even then only by re-running Step 1/4, never a hand edit.

--- a/src/skills/hedgehog-authored-loop/SKILL.md
+++ b/src/skills/hedgehog-authored-loop/SKILL.md
@@ -30,7 +30,13 @@ depends on how this core came to exist:
 
 Either way, `.hedgehog/core.yaml` is what the compiler and every command
 below actually read. Read the rationale file at the start of a session to
-know what this project (or this adopted repo's discipline) is.
+know what this project (or this adopted repo's discipline) is —
+`layer-eng` reads it before writing any layer, the same standing
+`core-design.md` has on a designed core. On an adopted core,
+`adoption.md`'s "Repo shape" section is a dated snapshot, not a live
+model — treat it as calibration for how new code should look, and read
+the actual files it describes when precision matters more than a snapshot
+can offer.
 
 ### core.yaml vs. the packet
 
@@ -107,7 +113,8 @@ runtime detail.
    claimable/held-back split without claiming anything.
 2. **Dispatch each claimed packet to its own `layer-eng` subagent** — in
    ONE message with parallel tool calls when there's more than one — along
-   with the reminder to read `.hedgehog/core-design.md` for what its
+   with the reminder to read this core's rationale file
+   (`.hedgehog/core-design.md` or `.hedgehog/adoption.md`) for what its
    layer owns.
 3. Each agent **runs the packet's VERIFICATION command on its own work**
    as a sanity check before reporting back — necessary, not sufficient.
@@ -195,8 +202,8 @@ with what's there.
 
 Three hold on every authored core regardless of stack:
 
-- **A layer owns one artifact, reached through the interface
-  `core-design.md` named.** The layer below is consumed through that
+- **A layer owns one artifact, reached through the interface the
+  rationale file named.** The layer below is consumed through that
   interface, not reached around — the boundary is what makes the layer
   independently verifiable.
 - **Errors carry their meaning.** A failure surfaces as the stack's
@@ -232,10 +239,10 @@ built output.
 
 When the correction is to the **layer sequence itself** — a layer in the
 wrong place, a missing layer, a scope glob that never fits — that's a
-`planner` case, not a patch: `.hedgehog/core.yaml` and
-`.hedgehog/core-design.md` are locked, and changing them re-shapes every
-task the graph compiles. Stop, say what the design got wrong, and hand to
-`planner`.
+`planner` case (or, on an adopted core, a `hedgehog-adopt` re-run), not a
+patch: `.hedgehog/core.yaml` and the rationale file are locked outside
+that path, and changing them re-shapes every task the graph compiles.
+Stop, say what the design got wrong, and hand to `planner`.
 
 Once `planner` has changed `core.yaml`, the edit still has to be pushed
 into the already-compiled graph — run `hedgehog plan --recompile` (see
@@ -260,7 +267,7 @@ by hand after an interruption.
 
 Use the `reviewer` agent at the point a layer closes for the last intent
 on a module axis, or at the last layer on a linear chain — it checks what
-the mechanical gate can't: whether the layer boundary `core-design.md`
+the mechanical gate can't: whether the layer boundary the rationale file
 described actually held, and whether the interfaces between layers stayed
 the ones that were designed.
 
@@ -280,9 +287,10 @@ the ones that were designed.
 - **Scope is the boundary.** A layer writes inside its ALLOWED SCOPE and
   nowhere else; a change that needs to land elsewhere is a correction,
   not a wider write.
-- **`.hedgehog/core.yaml` and `.hedgehog/core-design.md` are locked.**
-  Changing either is a `planner` decision through the Correction
-  Protocol.
+- **`.hedgehog/core.yaml` and the rationale file are locked** (except
+  `adoption.md`'s "Repo shape" section on an adopted core, refreshable via
+  `hedgehog-adopt`). Changing anything else is a `planner` decision
+  through the Correction Protocol.
 
 ## Stop Condition
 

--- a/src/templates/CLAUDE.core.adopted.md
+++ b/src/templates/CLAUDE.core.adopted.md
@@ -1,23 +1,30 @@
 ## This project's core: adopted (brownfield)
 
 Hedgehog was adopted onto this repo's existing codebase by
-`hedgehog-adopt` rather than building a workspace from scratch. The graph
-here covers **new change only** — it is not a map of this repo, and it
-never will be. Pre-existing code is context to read and respect, never a
-node in the build graph.
+`hedgehog-adopt` rather than building a workspace from scratch. The build
+graph here covers **new change only**, and no task, commit, or artifact
+record in it is ever fabricated for code Hedgehog didn't touch — that's
+absolute. Pre-existing code is context to read and respect, never a node
+in the build graph.
 
 - **`.hedgehog/core.yaml`** — a linear chain of change-order layers (no
   module axis), each `verify` command drawn from this repo's own
   test/lint/typecheck commands, confirmed at adoption time. `hedgehog
   plan` compiles the build graph from it.
 - **`.hedgehog/adoption.md`** — the rationale: what the repo's own
-  commands are, why the layers are ordered the way they are, and what
-  `hedgehog-adopt` deliberately chose not to model.
+  commands are, why the layers are ordered the way they are, what
+  `hedgehog-adopt` deliberately chose not to do (stack migration, legacy
+  review), and a "Repo shape" section — module boundaries, entry points,
+  and conventions observed, dated to when it was read. That section is a
+  snapshot, refreshable by re-running `hedgehog-adopt`, never build-graph
+  state and never treated as current past its date.
 
-Read `adoption.md` to know what each layer covers and why. There is no
-`core-design.md` on this core — `hedgehog-adopt` never designs a stack or
-proposes converting this repo toward one; it only wraps the commands and
-seams already here.
+Read `adoption.md` to know what each layer covers and why, and to get
+your bearings in this repo's shape before writing new code — then confirm
+against the actual files, since the snapshot ages and the code doesn't
+wait for a refresh. There is no `core-design.md` on this core —
+`hedgehog-adopt` never designs a stack or proposes converting this repo
+toward one; it only wraps the commands and seams already here.
 
 **Coverage is partial, always.** `hedgehog status` and `hedgehog boundary`
 describe the state of work under discipline, not the state of this repo.
@@ -39,9 +46,11 @@ they apply here unchanged.
   this core's Stop Condition (per-change here, not whole-graph — see
   below).
 - **`hedgehog-adopt`** — run again whenever new change-work enters play:
-  adds one or more intents for the change (goal, outcome, which seam it
-  touches) and runs `hedgehog plan`. Never re-reads the whole repo and
-  never re-proposes the layer chain — that was fixed at adoption time.
+  sizes the request (a large or ambiguous one gets a short clarifying
+  pass first), adds one or more intents for the change (goal, outcome,
+  which seam it touches), and runs `hedgehog plan`. Never re-proposes the
+  layer chain — that was fixed at adoption time. Can also refresh
+  `adoption.md`'s "Repo shape" section on request, but only that section.
 
 ### The agents — delegate the judgment calls
 
@@ -72,7 +81,7 @@ command in `.hedgehog/core.yaml` is one of this repo's own commands.
 .hedgehog/
   hedgehog.db      the build graph — intents, compiled tasks, verifications, committed to git
   core.yaml        the change-order layer chain, scope, verification, commit messages — locked
-  adoption.md      the rationale behind core.yaml, and this repo's own commands — write-once
+  adoption.md      the rationale behind core.yaml, this repo's own commands, and a dated repo-shape snapshot — locked except that snapshot
 ```
 
 ### Core rules


### PR DESCRIPTION
## Summary

- Redraws `hedgehog-adopt`'s "no repo mapping" stance into the invariant it was actually protecting: the build graph never claims authority over pre-existing code. `adoption.md` gains a "Repo shape" section — a dated, prose snapshot of module boundaries, entry points, and conventions — refreshable by re-running the skill, never build-graph state.
- Wires that snapshot into `layer-eng`/`hedgehog-authored-loop` as required reading before writing code on an adopted core, the same standing `core-design.md` has on a designed core.
- Sizes adopted-repo change requests before adding an intent: a large or ambiguous one gets a short clarifying pass via a new `hedgehog-adopt-elicit` skill; a clear one goes straight to `hedgehog intent add` as before.
- Reads workspace manifests (`pnpm-workspace.yaml`, `Cargo.toml [workspace]`, `go.work`) as seam-candidate evidence instead of relying on pure agent judgment.
- Fixes a real inconsistency in `planner.md`: it described itself running `hedgehog intent add` and committing on adoption re-entry, duplicating work `hedgehog-adopt` already owns and commits.

## Test plan

- [x] Dry-run adoption end to end against a small multi-package fixture repo (pnpm or Cargo workspace)
- [x] Confirm the Repo shape section lands in `adoption.md` and `layer-eng` reads it before writing code
- [x] Confirm a large/ambiguous intent triggers `hedgehog-adopt-elicit` while a small one skips it
- [x] Confirm seam candidates surface from a workspace manifest and require explicit confirmation before landing in `core.yaml`