### PR TITLE
feat: distribute Hedgehog as a plugin instead of npx-only install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "hedgehog",
+  "description": "Marketplace for the Hedgehog plugin",
+  "owner": {
+    "name": "skyf0xx"
+  },
+  "plugins": [
+    {
+      "name": "hedgehog",
+      "description": "Offers to set up the Hedgehog build discipline in any project you open",
+      "version": "1.0.0",
+      "source": "./",
+      "skills": [
+        "./skills/"
+      ],
+      "author": {
+        "name": "skyf0xx"
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "hedgehog",
+  "description": "Offers to set up the Hedgehog build discipline in any project you open",
+  "version": "1.0.0",
+  "author": {
+    "name": "skyf0xx"
+  },
+  "homepage": "https://github.com/skyf0xx/hedgehog",
+  "repository": "https://github.com/skyf0xx/hedgehog",
+  "license": "MIT",
+  "keywords": [
+    "hedgehog",
+    "bootstrap",
+    "build-discipline"
+  ],
+  "skills": [
+    "./skills/"
+  ]
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "hedgehog",
+  "description": "Offers to set up the Hedgehog build discipline in any project you open",
+  "version": "1.0.0",
+  "author": {
+    "name": "skyf0xx"
+  },
+  "homepage": "https://github.com/skyf0xx/hedgehog",
+  "repository": "https://github.com/skyf0xx/hedgehog",
+  "license": "MIT",
+  "skills": [
+    "./skills/"
+  ]
+}

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+@./skills/hedgehog/SKILL.md

--- a/README.md
+++ b/README.md
@@ -152,20 +152,30 @@ Hedgehog onto it.
 
 ## Install
 
-From an empty project folder, ask Claude or your Agent to run:
+Install the Hedgehog plugin for your coding agent. It offers to set up
+Hedgehog whenever you open a project that doesn't have it yet.
+
+### Claude Code
 
 ``` bash
-# Full-stack app
-npx @skyf0xx/hedgehog init --ts-full-stack-app
-
-# Landing page
-npx @skyf0xx/hedgehog init --landing-page
-
-# Anything else (CLI, library, browser extension, data pipeline, etc.)
-npx @skyf0xx/hedgehog init
+claude plugin marketplace add skyf0xx/hedgehog
+claude plugin install hedgehog
 ```
 
-Then open your coding agent and describe what you want to build.
+### Gemini CLI
+
+``` bash
+gemini extensions install https://github.com/skyf0xx/hedgehog
+```
+
+### Cursor
+
+``` bash
+git clone https://github.com/skyf0xx/hedgehog ~/.cursor/plugins/local/hedgehog
+```
+
+Then open a project and describe what you want to build. Hedgehog offers
+to set itself up, and takes it from there once you say yes.
 
 The golden cores print a `pnpm install` step as part of their next steps.
 On a fresh project with no warm pnpm store, that first install can take
@@ -173,22 +183,6 @@ several minutes — it's pulling a full monorepo toolchain (Nx, webpack,
 sass-embedded, Playwright, etc.) and, on first commit, running the commit
 gate against the whole workspace. A quiet stretch of output during that
 step is expected, not a hang.
-
-### Coding agents
-
-Hedgehog installs for **Claude Code** by default. Add a host flag to
-install for another one, or several at once:
-
-``` bash
-npx @skyf0xx/hedgehog init --cursor              # Cursor
-npx @skyf0xx/hedgehog init --gemini              # Gemini CLI
-npx @skyf0xx/hedgehog init --host=claude,cursor  # both
-npx @skyf0xx/hedgehog init --all-hosts           # every supported agent
-```
-
-Each one gets the discipline in its own native shape — agents and skills
-in the directory it reads, and the instructions file it loads at session
-start (`CLAUDE.md`, `HEDGEHOG.md`, or `GEMINI.md`).
 
 To update:
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,6 @@
+{
+  "name": "hedgehog",
+  "version": "1.0.0",
+  "description": "Offers to set up the Hedgehog build discipline in any project you open",
+  "contextFileName": "GEMINI.md"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "4.2.3",
+  "version": "4.3.0",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/skills/hedgehog/SKILL.md
+++ b/skills/hedgehog/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: hedgehog
+description: Use when a project has no Hedgehog discipline installed yet and the user is starting or building something, or when the user mentions Hedgehog by name — offers to install it and runs the matching init command
+---
+
+## When this fires
+
+Check for a `.hedgehog/` directory at the project root first.
+
+If `.hedgehog/` exists, stay silent. The project's own installed agents
+and skills own the session from here, and they are the authority — do not
+offer to install, reinstall, or repair anything.
+
+Otherwise, offer when either:
+
+- the user's message is about starting, scaffolding, or building a
+  project, or
+- the user mentions Hedgehog by name.
+
+An unrelated question in a repo without `.hedgehog/` is not an opening.
+Answer it and say nothing about Hedgehog.
+
+## What to do
+
+Ask directly: "Want me to set up Hedgehog here?" Say briefly what that
+means — a build discipline of agents and skills, matched to the kind of
+project (full-stack app, landing page, or an existing codebase to adopt).
+
+Wait for an explicit yes. Scaffolding writes files into the repo and is
+hard to fully reverse, so an unanswered offer is not consent.
+
+On confirmation, run the matching command:
+
+- Full-stack app: `npx @skyf0xx/hedgehog init --ts-full-stack-app`
+- Landing page: `npx @skyf0xx/hedgehog init --landing-page`
+- Anything else — CLI, library, browser extension, data pipeline, an
+  existing codebase, or not yet clear from the conversation:
+  `npx @skyf0xx/hedgehog init` with no core flag. Planning intake decides
+  from there, so prefer this over guessing between the two golden cores.
+
+Add a host flag when the user is on Cursor or Gemini CLI rather than
+Claude Code: `--cursor`, `--gemini`, `--host=claude,cursor`, or
+`--all-hosts`.
+
+If the user declines or steers elsewhere, drop it and carry on. Do not
+raise the offer again in the same session.

--- a/src/agents/bootstrap.md
+++ b/src/agents/bootstrap.md
@@ -104,8 +104,10 @@ rather than guessing which way to resolve it.
    done; don't hand off. (Skip this entirely for a skipped add-on step —
    there's nothing to commit.)
 2. If every `on` add-on in `.hedgehog/addons.yaml` now has a matching
-   commit: Bootstrap is closed. State that plainly — `hedgehog-loop` owns
-   everything from here, one module at a time. Don't hand off again.
+   commit: Bootstrap is closed. Run `hedgehog graph` to start (or reuse)
+   the live graph server and open it, so the build graph is on screen
+   before the first module starts. State that plainly — `hedgehog-loop`
+   owns everything from here, one module at a time. Don't hand off again.
    Check every `on` add-on for a commit before deciding you're done —
    don't assume by step order alone (a project with Queue and Mobile
    both off closes right after Auth, for instance).
@@ -129,9 +131,12 @@ Open `hedgehog-bootstrap-landing-page-core` and follow it in full: confirm
 not already run, land `src/golden-cores/landing-page/` if the installer
 hasn't already, `pnpm install`, verify `astro check` and `pnpm build`
 clean, one commit (`feat(landing): workspace`), check the Bootstrap box.
-That's the whole of Bootstrap on this core — state plainly that it's
-closed and `hedgehog-landing-loop` owns everything from here. Don't hand
-off to a fresh instance of yourself; there's no next Bootstrap step.
+That's the whole of Bootstrap on this core. Run `hedgehog graph` to start
+(or reuse) the live graph server and open it, so the build graph is on
+screen before the Strategist phase starts, then state plainly that
+Bootstrap is closed and `hedgehog-landing-loop` owns everything from
+here. Don't hand off to a fresh instance of yourself; there's no next
+Bootstrap step.
 
 ## authored core: running Bootstrap
 
@@ -147,8 +152,10 @@ already run, fill root `CLAUDE.md`'s `{{CORE_SECTION}}` placeholder with
 from `.hedgehog/core-design.md` and `.hedgehog/core.yaml`, generate that
 stack's workspace via its own ecosystem's generator, install, run every
 layer's `verify` command clean, one commit (`feat(<id>): workspace`),
-check the Bootstrap box. That's the whole of Bootstrap on this core —
-state plainly that it's closed and `hedgehog-authored-loop` owns
+check the Bootstrap box. That's the whole of Bootstrap on this core. Run
+`hedgehog graph` to start (or reuse) the live graph server and open it,
+so the build graph is on screen before the first layer starts, then
+state plainly that Bootstrap is closed and `hedgehog-authored-loop` owns
 everything from here. Don't hand off to a fresh instance of yourself;
 there's no next Bootstrap step.
 

--- a/src/skills/hedgehog-core-design/blueprints/desktop-app.md
+++ b/src/skills/hedgehog-core-design/blueprints/desktop-app.md
@@ -17,7 +17,7 @@ renderer — the UI, reaching the privileged process only through ipc
 - Merge `domain` into `main` for an app whose logic is mostly OS
   orchestration (a launcher, a sync daemon with a thin window) — there's
   no separable domain to isolate.
-- Add a `persistence` layer between `domain` and `main`, depending on
+- Add a `persistence` layer between `main` and `domain`, depending on
   `domain`, when the app owns a real local store (SQLite, a document
   format) rather than plain preference files.
 - On a native stack (Swift/AppKit, C#/WinUI) the `ipc` layer disappears —


### PR DESCRIPTION
## Summary
- Adds root-level `.claude-plugin/`, `.cursor-plugin/`, and `gemini-extension.json` manifests so Claude Code, Cursor, and Gemini CLI can each discover and install Hedgehog as a native plugin/extension
- Replaces the earlier `distribution/<host>/` layout and its hand-rolled session-start hook — the `hedgehog` skill now loads via each host's native `skills/` auto-discovery, and self-gates on an existing `.hedgehog/` directory instead of relying on a hook to suppress it
- Updates the README's Install section with per-host install commands (plugin marketplace for Claude Code, extension install for Gemini CLI, local plugin clone for Cursor)

## Test plan
- [x] Verified all manifest JSON is valid
- [x] Verified the Gemini `@`-import path resolves to `skills/hedgehog/SKILL.md`
- [x] Verified `skills/` auto-discovery doesn't leak the repo's internal `src/skills/` (26 dev skills) into the plugin surface
- [ ] `claude plugin marketplace add skyf0xx/hedgehog` + `claude plugin install hedgehog@hedgehog` against this branch, then confirm the skill fires on a fresh repo and stays silent when `.hedgehog/` exists
- [ ] Gemini CLI: `gemini extensions install https://github.com/skyf0xx/hedgehog`
- [ ] Cursor: clone into `~/.cursor/plugins/local/hedgehog` and confirm skill loads