### PR TITLE
fix: surface hard-rule conflicts instead of bypass; state hot-load status after init

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -539,18 +539,6 @@ async function init({ force, core, explicitCore, host = DEFAULT_HOST, hostOnly =
     ),
   );
   console.log();
-  console.log(
-    dim(
-      `If an agent ran this command itself, mid-session: the agents/skills\n` +
-        `just written are usable immediately in this same session, no restart\n` +
-        `needed. Before the first dispatch to one of them, confirm the name\n` +
-        `resolves in the available-agent-types listing, and read the agent's\n` +
-        `or skill's own file rather than assuming its behavior from this CLI\n` +
-        'output or prior knowledge of Hedgehog — this run may have written a\n' +
-        'newer version than what you last read.',
-    ),
-  );
-  console.log();
   if (explicitCore) {
     console.log(dim(`Core: ${bold(core)}.`));
     console.log(

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -539,6 +539,15 @@ async function init({ force, core, explicitCore, host = DEFAULT_HOST, hostOnly =
     ),
   );
   console.log();
+  console.log(
+    dim(
+      `If an agent ran this command itself, mid-session: the agents/skills\n` +
+        `just written are usable immediately in this same session, no restart\n` +
+        `needed — verify against the available-agent-types listing before\n` +
+        'the first dispatch to one of them if in doubt.',
+    ),
+  );
+  console.log();
   if (explicitCore) {
     console.log(dim(`Core: ${bold(core)}.`));
     console.log(

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -543,8 +543,11 @@ async function init({ force, core, explicitCore, host = DEFAULT_HOST, hostOnly =
     dim(
       `If an agent ran this command itself, mid-session: the agents/skills\n` +
         `just written are usable immediately in this same session, no restart\n` +
-        `needed — verify against the available-agent-types listing before\n` +
-        'the first dispatch to one of them if in doubt.',
+        `needed. Before the first dispatch to one of them, confirm the name\n` +
+        `resolves in the available-agent-types listing, and read the agent's\n` +
+        `or skill's own file rather than assuming its behavior from this CLI\n` +
+        'output or prior knowledge of Hedgehog — this run may have written a\n' +
+        'newer version than what you last read.',
     ),
   );
   console.log();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/src/agents/planner.md
+++ b/src/agents/planner.md
@@ -50,6 +50,17 @@ follows delegates normally. Re-entry stays a subagent dispatch: its
 questions are short, scoped, and answer-shaped, not a facilitated
 session.
 
+A hard rule stated in this file or `hedgehog-planning-intake` (this one
+included) is not one option to weigh against a user's earlier
+instruction — it's a constraint to work within. If a user instruction
+genuinely conflicts with one (e.g. "don't ask clarifying questions"
+against Phase 0's live elicitation requirement), say plainly that the
+two conflict and ask the user how to proceed. Never resolve the conflict
+by defaulting to a recommendation that bypasses the rule, and never
+present bypassing it as an equally-weighted option alongside following
+it — that smuggles the bypass in as the path of least resistance instead
+of surfacing the actual conflict.
+
 ## Phase 0 — which core applies
 
 Before invoking any planning-intake skill, on a first run only (Workflow

--- a/src/templates/CLAUDE.md
+++ b/src/templates/CLAUDE.md
@@ -31,12 +31,16 @@ brand-new install and nothing has been built yet. Open with something
 short and warm — 🦔 plus one line asking what the user wants to build —
 then follow `planner` in this thread, not as a subagent dispatch —
 Phase 0's BMAD elicitation is a live, multi-turn conversation the user
-needs a direct channel for. Read `planner.md` and run it here through
-Confirm & Lock and the `bootstrap` handoff; that handoff and everything
-after it delegates normally. Don't re-explain the discipline or
-summarize this file; the greeting is one line, not a tour. Skip this
-entirely once the placeholder is filled
-in — every later session starts with `hedgehog status`, not a greeting.
+needs a direct channel for. Read `planner.md` fresh off disk (this
+install just wrote it, in this session — don't rely on a prior read or
+prior-project memory of what it says) and run it here through Confirm &
+Lock and the `bootstrap` handoff; that handoff and everything after it
+delegates normally. This same rule holds at every later handoff to a
+newly-installed agent or skill in this session: read its file, don't
+assume its content. Don't re-explain the discipline or summarize this
+file; the greeting is one line, not a tour. Skip this entirely once the
+placeholder is filled in — every later session starts with `hedgehog
+status`, not a greeting.
 
 ## How to work here
 


### PR DESCRIPTION
## Summary

Addresses #116, #117, #118, #119 — all filed from the same session where an agent installed Hedgehog and ran its first planning intake.

- **#117** (fixed): `planner.md` now states that a hard rule in that file or `hedgehog-planning-intake` (e.g. Phase 0's live-elicitation-only requirement) is a constraint to work within, not one option to weigh against a conflicting user instruction. When the two genuinely conflict, the agent must surface the conflict and ask, rather than defaulting to a recommendation that bypasses the rule or presenting the bypass as an equally-weighted option.
- **#119** (fixed): the fix lives in `src/templates/CLAUDE.md`'s fresh-install greeting rather than `hedgehog init`'s CLI output. That greeting is read at the exact moment the fix needs to apply — the first handoff to a newly-installed agent, on every project, unconditionally — so it now says to read `planner.md` fresh off disk (not from a prior read or prior-project memory) before following it, and states the same rule holds at every later handoff to a newly-installed agent or skill in the session. This is a stronger and less noisy fix than appending text to CLI stdout: it doesn't tax the common single-human-run case, and it lands in a file that's actually opened at the moment of first dispatch rather than scrollback that may not get re-read.
- **#116**: per the issue's own follow-up comments, the actual root cause was a dispatch-rule violation (Phase 0 run as a detached subagent) against a rule already stated plainly in three places the agent had read (`planner.md`, `hedgehog-planning-intake/SKILL.md`, root `CLAUDE.md`). A fourth restatement wouldn't have prevented a failure the first three didn't — no code change indicated; closing as an agent-behavior note.
- **#118**: no comments filed, and the issue's own analysis concludes this was an instruction-following miss, not a text ambiguity — the skill's trigger check is already emphatic ("MANDATORY CHECK", "before writing any code or picking a stack"). No code change indicated.

`package.json` bumped to 4.3.2 per this repo's release rules (change scoped to `src/` and `bin/`). No `skills/` or `.claude-plugin/` changes, so the plugin version is untouched.

## Test plan

- [x] `node -c bin/cli.mjs` — syntax check passes
- [x] `npm run check` — `ok — 18 agents, 26 skills, 2 cores, tarball, CLI`
- [x] Smoke-tested `hedgehog init` in a scratch dir — CLI output is unchanged from baseline; `CLAUDE.md`'s fresh-install greeting renders the new read-before-dispatch instruction correctly