### PR TITLE
feat: compressed planning intake as a first-class mode; re-raise the singular module-id check at plan

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -19,7 +19,7 @@ import { dirname, join, relative, resolve } from 'node:path';
 import { spawn } from 'node:child_process';
 import { dbInit, DB_PATH, dbAbsPath, openDb } from '../src/db/init.mjs';
 import { loadCore, lintCore, isModuleAxis } from '../src/db/core.mjs';
-import { planTasks } from '../src/db/plan.mjs';
+import { planTasks, CORE_INTENT_ID } from '../src/db/plan.mjs';
 import { addIntent, INTENTS_DIR } from '../src/db/intent.mjs';
 import {
   nextTask,
@@ -866,6 +866,7 @@ async function planCommand(args = []) {
   const driftDb = openDb({ readOnly: true });
   let drifted;
   try {
+    warnSingularModuleIdsAtPlan(core, driftDb);
     drifted = detectDrift(driftDb, core, { overrides });
   } finally {
     driftDb.close();
@@ -1017,6 +1018,18 @@ async function intentCommand(args) {
 // rejecting correct ids. Raised here because this is the last moment the
 // fix is one file rename — three layers later it is a Correction Protocol
 // case across every compiled task.
+//
+// The convention is a heuristic, not a checkable property of the graph:
+// `tasks` and `task` are both structurally valid, and nothing downstream
+// knows which one the generator wants. So this only ever reports.
+function looksSingular(id) {
+  return !/(s|ae|ia|people|children)$/i.test(id);
+}
+
+// `intent add` is one route to the compiler among several — `--file`, a
+// hand-written intents/*.json, and `db rebuild` all reach it without
+// passing through here — so `plan` re-raises the same check where every
+// route converges. See planCommand.
 async function warnSingularModuleId(intent) {
   const corePath = await resolveCorePath();
   if (!corePath) return;
@@ -1030,7 +1043,7 @@ async function warnSingularModuleId(intent) {
     return;
   }
   if (!isModuleAxis(core)) return;
-  if (/(s|ae|ia|people|children)$/i.test(intent.id)) return;
+  if (!looksSingular(intent.id)) return;
 
   console.log(
     `\n${yellow(bold('Module id looks singular.'))} On this core the intent id is ${bold('{module}')} in\n` +
@@ -1040,6 +1053,63 @@ async function warnSingularModuleId(intent) {
       `  ${dim(`git mv ${INTENTS_DIR}/${intent.id}.json ${INTENTS_DIR}/${intent.id}s.json`)}\n` +
       `  ${dim(`# edit "id" and every ${intent.id.toUpperCase()}-* requirement id, then:`)}\n` +
       `  ${dim('hedgehog db rebuild')}\n`,
+  );
+}
+
+// The same advisory at `plan`, where `--file`, a hand-written intent
+// file, and `db rebuild` all converge — none of them passes through
+// `intent add`, so on those routes this is the first and last cheap
+// warning before a whole graph is compiled against the id. It reports
+// while every one of an intent's tasks is still unstarted; once work has
+// landed the fix is a Correction Protocol case rather than a rename, and
+// repeating the `git mv` advice would point at the wrong recovery.
+//
+// One block for however many ids trip it, rather than repeating the
+// per-intent explanation: the reasoning is identical every time, and
+// stacking it once per intent buries the list of names under it. The
+// recovery is still per-id, so those lines are listed one per name.
+function warnSingularModuleIdsAtPlan(core, db) {
+  if (!isModuleAxis(core)) return;
+
+  // Every intent whose tasks have all yet to start, not just the ones
+  // this run compiled. `db rebuild` replays the committed intent files
+  // *and* compiles their tasks, so a `plan` after it compiles nothing —
+  // and that is precisely the route where nothing else has ever looked at
+  // the id. The cheap-fix window is "no work has landed yet", which
+  // outlasts any single `plan` invocation.
+  const singular = db
+    .prepare(
+      `SELECT i.id FROM intents i
+        WHERE i.id <> ?
+          AND NOT EXISTS (
+            SELECT 1 FROM tasks t
+             WHERE t.intent_id = i.id
+               AND t.status NOT IN ('proposed','planned','ready')
+          )
+        ORDER BY i.id`,
+    )
+    .all(CORE_INTENT_ID)
+    .map((row) => row.id)
+    .filter(looksSingular);
+  if (singular.length === 0) return;
+
+  const many = singular.length > 1;
+  console.log(
+    `${yellow(bold(many ? `${singular.length} module ids look singular.` : 'Module id looks singular.'))} ` +
+      `On this core an intent id is ${bold('{module}')} in\n` +
+      `every layer's scope, and the generators take it plural — so ${many ? 'each of these compiles' : 'this compiles'}\n` +
+      `scope for a directory the scaffold command will never write:\n` +
+      singular.map((id) => `  ${bold(id)} ${dim(`— scope ${id}/, scaffold writes ${id}s/`)}`).join('\n') +
+      `\n\nThis is a naming convention, not a rule — ${bold('billing')} and ${bold('search')} are ` +
+      `legitimately\nsingular. If the plural is what you meant, it is still cheap to fix:\n` +
+      singular
+        .map(
+          (id) =>
+            `  ${dim(`git mv ${INTENTS_DIR}/${id}.json ${INTENTS_DIR}/${id}s.json`)}\n` +
+            `  ${dim(`# edit "id" and every ${id.toUpperCase()}-* requirement id`)}`,
+        )
+        .join('\n') +
+      `\n  ${dim('hedgehog db rebuild')}\n`,
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/repro/compressed-intake-archive-contract.mjs
+++ b/repro/compressed-intake-archive-contract.mjs
@@ -1,0 +1,111 @@
+// Reproduction: compressed intake's archive must satisfy every downstream
+// step that reads `.hedgehog/BMAD/`.
+//
+// The failure mode this pins is subtle because it is a documentation
+// contract, not a code path: compressed intake is described in one file
+// (`hedgehog-planning-intake`) and consumed in several others, so the two
+// can drift apart silently. Nothing executes these files — a consumer
+// left naming a source the mode never writes fails only on a real run, at
+// the point an agent has to improvise, which is the exact outcome the
+// mode exists to prevent.
+//
+// Three properties, one per way the drift shows up:
+//
+//   A. Every file compressed intake writes is a file some consumer reads,
+//      and every consumer's documented source is a file it writes. A
+//      consumer naming `02-brief.md` as its only source would strand a
+//      compressed run.
+//
+//   B. The mode is recorded in the archive, not inferred from absence.
+//      `00-manifest.md` carries it, so `.hedgehog/BMAD/` exists after
+//      intake whichever mode ran.
+//
+//   C. The Add-ons gate survives the compression, and landing-page is
+//      excluded — the two constraints the mode is most likely to lose if
+//      someone later "simplifies" it.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { checkContains, check, report, REPO_ROOT } from './_lib.mjs';
+
+// These files are hard-wrapped prose, so a phrase this repro asserts on
+// can be split across a line break at any time by an unrelated edit.
+// Collapsing whitespace makes the assertions test the wording rather than
+// the wrapping — the wrapping is not the contract.
+const read = (p) => readFileSync(join(REPO_ROOT, p), 'utf8').replace(/\s+/g, ' ');
+
+const INTAKE = read('src/skills/hedgehog-planning-intake/SKILL.md');
+const PLANNER = read('src/agents/planner.md');
+const UX_PLANNER = read('src/agents/ux-planner.md');
+const CORE_DESIGN = read('src/skills/hedgehog-core-design/SKILL.md');
+
+console.log('repro: compressed intake writes what its consumers read\n');
+
+// --- A. the archive covers every consumer's documented source ---------
+
+// The section that defines the mode. Scoping the assertions to it keeps a
+// stray mention elsewhere in the file from satisfying them.
+const START = INTAKE.indexOf('### Compressed intake');
+const END = INTAKE.indexOf('## Phase 1 — Mining');
+const COMPRESSED = START === -1 || END === -1 ? '' : INTAKE.slice(START, END);
+
+check('A0. the compressed-intake section exists and precedes Phase 1', true, COMPRESSED.length > 0);
+
+// Phase 1's mining reads 04-prd.md §3 and §4. Compressed intake has to
+// write exactly that, or mining has no source.
+checkContains('A1. compressed intake writes 04-prd.md', COMPRESSED, '04-prd.md');
+checkContains('A2. it writes the two sections mining reads', COMPRESSED, '§3 Glossary and §4 Features');
+
+// ux-planner's documented source is 05-ux-spec/. The mode writes the
+// EXPERIENCE half and states that DESIGN is absent by design.
+checkContains('A3. compressed intake writes 05-ux-spec/EXPERIENCE.md', COMPRESSED, 'EXPERIENCE.md');
+checkContains('A4. it states DESIGN.md is not written', COMPRESSED, '`DESIGN.md`');
+
+// The consumer side: ux-planner must not require both halves, and must
+// treat an absent file as a cue to ask rather than to infer.
+checkContains(
+  'A5. ux-planner reads whichever half the archive holds',
+  UX_PLANNER,
+  'whichever of the two the archive holds',
+);
+checkContains('A6. an absent UX spec makes ux-planner ask, not invent', UX_PLANNER, 'cue to ask, not to invent');
+
+// Re-entry names 02-brief.md, which a compressed archive never has, so it
+// has to say what it reads instead.
+checkContains('A7. Re-entry states what it reads on a compressed archive', INTAKE, 'on a compressed archive that\'s `04-prd.md`');
+
+// core-design reads the archive to choose a stack on an authored core.
+checkContains('A8. core-design checks the manifest for what the archive holds', CORE_DESIGN, '00-manifest.md');
+checkContains(
+  'A9. core-design surfaces the thinner input at Confirm & Lock',
+  CORE_DESIGN,
+  'compressed intake',
+);
+
+// --- B. the mode is recorded, never inferred from a missing directory --
+
+checkContains('B1. the manifest records which mode ran', INTAKE, 'which intake mode ran');
+checkContains('B2. the manifest states mode: compressed', COMPRESSED, 'mode: compressed');
+checkContains(
+  'B3. an absent archive means intake never ran',
+  COMPRESSED,
+  'means intake never ran',
+);
+
+// --- C. the gates that must survive the compression -------------------
+
+checkContains('C1. the Add-ons decision is still answered, never guessed', COMPRESSED, 'must each be *answered*');
+checkContains('C2. planner ties the batched round to the Add-ons gate', PLANNER, 'holds identically on compressed intake');
+checkContains('C3. landing-page is excluded from the mode', COMPRESSED, 'Not available on landing-page');
+checkContains(
+  'C4. the mode is chosen by the user, never recommended',
+  COMPRESSED,
+  'never the default',
+);
+checkContains(
+  'C5. planner still surfaces the conflict before the mode is reachable',
+  PLANNER,
+  'Surface the conflict first',
+);
+
+report('compressed intake — archive satisfies every documented consumer');

--- a/repro/plan-warns-singular-module-ids.mjs
+++ b/repro/plan-warns-singular-module-ids.mjs
@@ -1,0 +1,204 @@
+// Reproduction: `plan` re-raises the singular module-id advisory for the
+// routes that never pass through `intent add`.
+//
+// The subtle part is which routes exist. `intent add` warns, and that
+// covers the interactive path — but an intent id reaches the compiler by
+// several others, none of which re-check:
+//
+//   * `hedgehog intent add --file <path.json>`
+//   * a hand-written `.hedgehog/intents/*.json` committed directly
+//   * `hedgehog db rebuild`, which replays every committed intent file
+//
+// On any of those a singular id is silent all the way to a scope
+// violation at `hedgehog verify` — the expensive, late discovery the
+// advisory exists to prevent. `plan` is where every route converges and
+// the last point the fix is still one file rename.
+//
+// It stays a warning, never a refusal: the plural convention is a
+// heuristic, so a gate would reject legitimately-singular modules like
+// `billing` and `search`. These assertions pin that too — a later change
+// to a hard gate breaks them deliberately.
+
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  makeProject,
+  cli,
+  cleanup,
+  check,
+  checkContains,
+  report,
+  REPO_ROOT,
+} from './_lib.mjs';
+
+const shippedCore = (name) =>
+  readFileSync(join(REPO_ROOT, 'src/golden-cores', name, 'core.yaml'), 'utf8');
+
+// Writes the intent file directly, bypassing `intent add` entirely — the
+// hand-written-file route, and what `db rebuild` replays.
+function writeIntentFile(dir, id) {
+  const intents = join(dir, '.hedgehog/intents');
+  mkdirSync(intents, { recursive: true });
+  writeFileSync(
+    join(intents, `${id}.json`),
+    `${JSON.stringify(
+      {
+        id,
+        goal: `build ${id}`,
+        outcome: `${id} works`,
+        requirements: [
+          { id: `${id.toUpperCase()}-ACCEPTANCE-1`, kind: 'acceptance', statement: 'it works' },
+        ],
+        depends_on: [],
+        priority: 50,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+console.log('repro: plan re-raises the singular module-id check\n');
+
+// --- A. --file bypasses intent add's warning, plan catches it ---------
+
+{
+  const dir = makeProject(shippedCore('full-stack-app'));
+  try {
+    // Four ids: three singular, one plural. `orders` must not be flagged,
+    // or the advisory is noise on correctly-named modules.
+    for (const id of ['task', 'invoice', 'billing', 'orders']) {
+      const file = join(dir, `${id}-input.json`);
+      writeFileSync(
+        file,
+        `${JSON.stringify({
+          id,
+          goal: `build ${id}`,
+          outcome: `${id} works`,
+          acceptance: ['it works'],
+        })}\n`,
+      );
+      const r = cli(dir, ['intent', 'add', '--file', file]);
+      if (r.status !== 0) throw new Error(`intent add --file ${id} failed: ${r.stderr}`);
+    }
+
+    const planned = cli(dir, ['plan']);
+    check('A1. plan succeeds — this is an advisory, not a gate', 0, planned.status);
+    checkContains('A2. plan names how many ids tripped it', planned.stdout, '3 module ids look singular');
+    checkContains('A3. it names task', planned.stdout, 'task');
+    checkContains('A4. it names invoice', planned.stdout, 'invoice');
+    checkContains('A5. it names billing', planned.stdout, 'billing');
+    check(
+      'A6. a plural id is not flagged',
+      false,
+      planned.stdout.includes('orders — scope'),
+    );
+
+    // One shared explanation for however many ids trip it — repeating the
+    // whole per-intent block N times buries the list of names under it.
+    check(
+      'A7. the explanation appears once, not once per id',
+      1,
+      planned.stdout.split("every layer's scope").length - 1,
+    );
+    // The recovery is per-id, so those lines do repeat.
+    check(
+      'A8. a git mv line per flagged id',
+      3,
+      planned.stdout.split('git mv').length - 1,
+    );
+    checkContains('A9. it points at db rebuild to re-derive', planned.stdout, 'hedgehog db rebuild');
+    checkContains(
+      'A10. it says plainly this is a convention, not a rule',
+      planned.stdout,
+      'a naming convention, not a rule',
+    );
+
+    // Still warns on a re-plan that compiles nothing. The advisory's
+    // window is "no work has landed yet", not "this run compiled it" —
+    // keying on the latter would go silent exactly on the `db rebuild`
+    // route (section B), which compiles the tasks itself.
+    const again = cli(dir, ['plan']);
+    check('A11. a re-plan still warns while no work has started', 0, again.status);
+    checkContains(
+      'A12. the advisory survives a run that compiled nothing',
+      again.stdout,
+      '3 module ids look singular',
+    );
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// --- A2. the window closes once work has actually landed --------------
+
+{
+  const dir = makeProject(shippedCore('full-stack-app'), { git: true });
+  try {
+    const file = join(dir, 'task-input.json');
+    writeFileSync(
+      file,
+      `${JSON.stringify({ id: 'task', goal: 'g', outcome: 'o', acceptance: ['a'] })}\n`,
+    );
+    if (cli(dir, ['intent', 'add', '--file', file]).status !== 0) throw new Error('add failed');
+    if (cli(dir, ['plan']).status !== 0) throw new Error('plan failed');
+
+    // Claiming the first task starts the work. A rename is a Correction
+    // Protocol case from here, not a `git mv`, so repeating the advice
+    // would be telling the operator to do something no longer safe.
+    const claimed = cli(dir, ['claim', '--count', '1', '--owner', 'repro']);
+    check('A13. claim succeeds', 0, claimed.status);
+
+    const after = cli(dir, ['plan']);
+    check('A14. the advisory stops once a task has been started', false, /singular/i.test(after.stdout));
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// --- B. a hand-written intent file, replayed by db rebuild ------------
+
+{
+  const dir = makeProject(shippedCore('full-stack-app'), { git: true });
+  try {
+    writeIntentFile(dir, 'task');
+    const rebuilt = cli(dir, ['db', 'rebuild']);
+    if (rebuilt.status !== 0) throw new Error(`db rebuild failed: ${rebuilt.stderr}`);
+    // Nothing in the rebuild path passes through `intent add`, so this is
+    // the first time the id is looked at.
+    check('B1. rebuild itself does not warn', false, /singular/i.test(rebuilt.stdout));
+
+    const planned = cli(dir, ['plan']);
+    check('B2. plan succeeds', 0, planned.status);
+    checkContains('B3. plan catches the replayed singular id', planned.stdout, 'Module id looks singular');
+    checkContains('B4. singular phrasing for exactly one id', planned.stdout, 'so this compiles');
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// --- C. the advisory is scoped to module-axis cores -------------------
+
+{
+  // landing-page has no `{module}` in any layer's scope, so an id is
+  // never substituted as a directory name and the convention has nothing
+  // to say. Warning here would be pure noise.
+  const dir = makeProject(shippedCore('landing-page'));
+  try {
+    const file = join(dir, 'landing-input.json');
+    writeFileSync(
+      file,
+      `${JSON.stringify({ id: 'landing', goal: 'g', outcome: 'o', acceptance: ['a'] })}\n`,
+    );
+    const r = cli(dir, ['intent', 'add', '--file', file]);
+    if (r.status !== 0) throw new Error(`intent add --file landing failed: ${r.stderr}`);
+
+    const planned = cli(dir, ['plan']);
+    check('C1. plan succeeds on landing-page', 0, planned.status);
+    check('C2. no singular advisory on a core with no module axis', false, /singular/i.test(planned.stdout));
+  } finally {
+    cleanup(dir);
+  }
+}
+
+report('plan re-raises the singular module-id advisory on every route');

--- a/src/agents/planner.md
+++ b/src/agents/planner.md
@@ -61,6 +61,17 @@ present bypassing it as an equally-weighted option alongside following
 it — that smuggles the bypass in as the path of least resistance instead
 of surfacing the actual conflict.
 
+"Don't ask clarifying questions" is the common case, and on full-stack-app
+or an authored core it has a defined destination once the user has chosen
+it: **compressed intake** (`hedgehog-planning-intake`'s Phase 0). Surface
+the conflict first, exactly as above — compressed intake is what the
+user's answer can select, never what you recommend to avoid the
+conversation. Say what it costs when you name it: one batched round of
+questions instead of the shelf, a thinner archive, and an architecture
+(on an authored core) designed from a brief rather than elicited drivers.
+Landing-page has no such destination — see that skill for why — so there
+the conflict is surfaced and resolved with the user, not routed.
+
 ## Phase 0 — which core applies
 
 Before invoking any planning-intake skill, on a first run only (Workflow
@@ -200,6 +211,11 @@ anything here a background job, or is it all instant reads and writes?",
 default an add-on on or off without either a concrete trigger in the PRD
 or a direct answer.
 
+This gate holds identically on compressed intake — it is the reason that
+mode has a batched round of questions at all. Whatever the brief doesn't
+concretely trigger goes into that round; nothing here is inferred from
+silence because the user asked not to be asked.
+
 Write the decision to `.hedgehog/addons.yaml`, one entry per add-on with
 its on/off state and the one-line reason it landed there:
 
@@ -230,7 +246,9 @@ accounts get added where there were none).
 - Decide which core applies before running any planning-intake skill —
   Phase 0 above.
 - **full-stack-app**: owns `.hedgehog/BMAD/` (archival, written once,
-  never edited after) and `.hedgehog/addons.yaml` as artifacts; the
+  never edited after — including its `00-manifest.md`, which records
+  which intake mode produced it) and `.hedgehog/addons.yaml` as
+  artifacts; the
   intent records Phase 1 writes via `hedgehog intent add` live in the
   build graph, not a file this agent owns.
 - **landing-page**: owns `.hedgehog/BMAD/` and
@@ -288,11 +306,14 @@ accounts get added where there were none).
    that turns out to be wrong is a Correction Protocol case, not a quiet
    rewrite here.
 5. **Run planning intake**, in the shape this path calls for:
-   - **First run, full-stack-app**: run the vendored BMAD shelf, then
-     mine `04-prd.md` only into intent records per the PRD→graph-row
-     table (spec: "Mapping BMAD output to intents") and the Add-ons
-     decision (see above) — asking the user directly only for whatever
-     the PRD leaves unresolved.
+   - **First run, full-stack-app**: run the vendored BMAD shelf — or, if
+     the user has explicitly chosen it after the conflict was surfaced,
+     compressed intake's batched round — then mine `04-prd.md` only into
+     intent records per the PRD→graph-row table (spec: "Mapping BMAD
+     output to intents") and the Add-ons decision (see above) — asking
+     the user directly only for whatever the PRD leaves unresolved. The
+     mining step is the same either way; only how the archive was
+     produced differs.
    - **First run, landing-page**: run the same vendored BMAD shelf in
      full, then mine `.hedgehog/BMAD/` into a draft subject statement
      (subject, audience, single page job) — asking the user directly only

--- a/src/agents/ux-planner.md
+++ b/src/agents/ux-planner.md
@@ -35,15 +35,26 @@ material `planner` files per module at planning intake, for you to act on here.
 If it's thin, or a specific detail you need (information architecture, a
 named flow, visual identity) isn't in it, read the full source directly:
 `.hedgehog/BMAD/05-ux-spec/DESIGN.md` and `EXPERIENCE.md`, the un-mined
-UX spec `planner`'s notes were drawn from. Read the notes file if present,
-then say so plainly and ask for anything further
-before producing the rationale: "Phase A is closed for `<module>` — this
-is the UX planning step before the screen gets built. [If notes exist:
-"I've got what was noted at planning intake for this module — here's a quick
-recap: (one-line summary)."] If you have a mockup, screenshot, an export
-from a tool like Google Stitch or Figma, or an existing screen you want
-this to resemble, hand it over now; otherwise I'll propose the layout
-from the contract, hook, and any notes on file." Treat whatever's
+UX spec `planner`'s notes were drawn from. Read whichever of the two the
+archive holds — a project planned through compressed intake
+(`hedgehog-planning-intake`'s Phase 0) has `EXPERIENCE.md` only, and one
+whose brief stated no flows may have neither. **An absent file is your
+cue to ask, not to invent.** Visual identity is the first thing a
+compressed brief omits, so where the archive is silent, say so and
+propose from the contract and hook rather than inferring a direction the
+user never gave — that inference is the improvisation this step exists to
+replace.
+
+Read the notes file if present, then say so plainly and ask for anything
+further before producing the rationale: "Phase A is closed for
+`<module>` — this is the UX planning step before the screen gets built.
+[If notes exist: "I've got what was noted at planning intake for this
+module — here's a quick recap: (one-line summary)."] [If the archive
+holds no UX spec: "This project was planned through compressed intake, so
+there's no visual direction on file."] If you have a mockup, screenshot,
+an export from a tool like Google Stitch or Figma, or an existing screen
+you want this to resemble, hand it over now; otherwise I'll propose the
+layout from the contract, hook, and any notes on file." Treat whatever's
 supplied or on file the same way — a source of screen inventory and
 hierarchy, not something to transcribe pixel-for-pixel. No visual tool or
 prior note is required; the rationale stands on its own when nothing is
@@ -70,7 +81,10 @@ mockup, not a design system, not code:
    was (a screenshot, a Stitch/Figma export, a named reference app,
    planning-intake notes from `docs/design/<module>-notes.md`, or the
    raw UX spec at `.hedgehog/BMAD/05-ux-spec/`) and what was drawn from
-   it versus decided independently.
+   it versus decided independently. Where there was none — a compressed
+   archive with no UX spec and nothing supplied — say that plainly here,
+   so `front-end-eng` and `reviewer` read the rationale as reasoned from
+   the contract and hook rather than from a direction on file.
 
 Keep it short — a few bullets per screen, not a document. This is a
 rationale `front-end-eng` reads once before starting, and `reviewer` can
@@ -110,9 +124,11 @@ conclusion.
 1. Confirm the module's hook step is committed (`feat(<module>): hooks`)
    — if not, stop, this is being asked for too early.
 2. Check for `docs/design/<module>-notes.md` and read it if present. If
-   it's thin or missing a detail you need, read
-   `.hedgehog/BMAD/05-ux-spec/DESIGN.md` and `EXPERIENCE.md` directly for
-   the full material it was drawn from.
+   it's thin or missing a detail you need, read whichever of
+   `.hedgehog/BMAD/05-ux-spec/DESIGN.md` and `EXPERIENCE.md` the archive
+   holds, for the full material it was drawn from. Where neither the
+   notes nor the spec covers what you need, that gap goes into step 3's
+   ask — it is not something to fill in yourself.
 3. Announce the Phase B transition and ask for visual input, per "When
    you run," above.
 4. Read the contract (`packages/contracts`) for the module: what

--- a/src/skills/hedgehog-core-design/SKILL.md
+++ b/src/skills/hedgehog-core-design/SKILL.md
@@ -117,7 +117,10 @@ Every layer's `scope` and `verify` in Step 3 draws from this record.
 ## Step 3 — derive the layers
 
 Read `.hedgehog/BMAD/` for what the system actually does, then decide the
-layers it builds in. A layer earns its place by owning a distinct
+layers it builds in. Read `00-manifest.md` first for which files the
+archive holds: a compressed intake leaves `04-prd.md` as the only source
+for this step, and where it doesn't settle something a layer boundary
+depends on, ask rather than infer. A layer earns its place by owning a distinct
 artifact that can be verified on its own. Order by dependency first (a
 layer that another layer imports comes first), by contract second (a
 layer that pins an external interface — a schema, a wire format, a public
@@ -620,6 +623,11 @@ to change only until the file lands. Hard stop.
 - That this is an authored core: the sequence was designed for this
   project, not battle-tested across many, and it carries the same
   enforcement as a Golden Core but a weaker guarantee.
+- If `.hedgehog/BMAD/00-manifest.md` records a compressed intake: that
+  this architecture was designed from a brief and one batched round
+  rather than from elicited drivers, so the stack and layer choices rest
+  on thinner input than a full shelf run would give them. Name it here
+  rather than in passing — it's part of what the user is accepting.
 
 Then state plainly what happens on confirmation, before it happens:
 

--- a/src/skills/hedgehog-loop/SKILL.md
+++ b/src/skills/hedgehog-loop/SKILL.md
@@ -130,7 +130,9 @@ Phase A — one claimed packet per dispatch, in its own context. Step
 the `hook` layer's task is `complete` and before `front-end-eng` starts
 the `screen` layer — via `ux-planner`, starting from whatever `planner`
 filed in `docs/design/<module>-notes.md` at planning intake, or the raw
-UX spec directly if that file is absent. Its first run for a module also
+UX spec directly if that file is absent, or — where the archive holds
+neither — from the contract and hook plus whatever the user supplies when
+it asks. Its first run for a module also
 signals to the user that Phase B has started, and is the point a mockup,
 screenshot, or export (Google Stitch, Figma) can be handed over. It
 writes `docs/design/<module>.md`, not its own compiled layer — the

--- a/src/skills/hedgehog-planning-intake/SKILL.md
+++ b/src/skills/hedgehog-planning-intake/SKILL.md
@@ -217,9 +217,14 @@ Procedure:
    `{module}` into every layer's scope glob and verify command, and the
    generators each layer's packet names take the module plural, so a
    singular id compiles a graph scoped to a directory the generator will
-   never write. This is the only moment that choice is cheap: it is one
+   never write. This is the moment that choice is cheapest: it is one
    string here, and a Correction Protocol case across every compiled task
-   three layers later.
+   three layers later. `hedgehog intent add` and `hedgehog plan` both
+   report an id that looks singular — `plan` for as long as none of that
+   intent's tasks has been started, since every route into the graph
+   (`--file`, a hand-written intent file, `db rebuild`) converges there.
+   Both are advisory: `billing` and `search` are legitimately singular, so
+   read the report and decide, rather than renaming on sight.
 2. **Walk that Feature's FRs.** Each FR's "Consequences (testable)" list
    items become that intent's `requirements` with `kind='acceptance'`,
    one per item, verbatim or lightly tightened — no rephrasing that

--- a/src/skills/hedgehog-planning-intake/SKILL.md
+++ b/src/skills/hedgehog-planning-intake/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hedgehog-planning-intake
-description: Use on any core for first-run planning intake — Phase 0 runs the vendored BMAD-METHOD planning shelf, shared by every core, and Phase 1 (mining `04-prd.md` into intent records plus the Add-ons decision) is full-stack-app's own procedure. Also use for the Re-entry pass, which mines new scope into additional intents without re-running the shelf, on any core with a module axis to add an intent to (full-stack-app, authored) — landing-page has none, so its own new-scope path runs through `hedgehog-landing-loop`'s Correction Protocol instead. Invoked by the `planner` agent, which decides the path; don't run standalone. landing-page runs this skill's Phase 0 on first run, then mines the same archive through `hedgehog-landing-loop`'s own planning-intake section, that core's counterpart to this skill's Phase 1. An authored core runs this skill's Phase 0, then `hedgehog-core-design`, then this skill's Phase 1 mining against the designed layer sequence. A brownfield adoption (`hedgehog-adopt`) never runs this skill's shelf at all — the drivers BMAD elicits are already settled facts of a repo that already exists.
+description: Use on any core for first-run planning intake — Phase 0 runs the vendored BMAD-METHOD planning shelf, shared by every core, and Phase 1 (mining `04-prd.md` into intent records plus the Add-ons decision) is full-stack-app's own procedure. Phase 0 also defines compressed intake, the path a user's explicit "just build it" choice takes on full-stack-app and authored cores: one batched round of questions in place of the shelf, writing the same archive at the same path so Phase 1, `ux-planner`, and the Re-entry pass all keep their documented source. Also use for the Re-entry pass, which mines new scope into additional intents without re-running the shelf, on any core with a module axis to add an intent to (full-stack-app, authored) — landing-page has none, so its own new-scope path runs through `hedgehog-landing-loop`'s Correction Protocol instead. Invoked by the `planner` agent, which decides the path; don't run standalone. landing-page runs this skill's Phase 0 on first run, then mines the same archive through `hedgehog-landing-loop`'s own planning-intake section, that core's counterpart to this skill's Phase 1. An authored core runs this skill's Phase 0, then `hedgehog-core-design`, then this skill's Phase 1 mining against the designed layer sequence. A brownfield adoption (`hedgehog-adopt`) never runs this skill's shelf at all — the drivers BMAD elicits are already settled facts of a repo that already exists.
 ---
 
 # Hedgehog Planning Intake
@@ -95,7 +95,80 @@ Write each skill's output to `.hedgehog/BMAD/`, per the fixed layout:
 
 Every file/folder carries a one-line attribution header. `00-manifest.md`
 states the source repo, pinned version (`vendor-skills/BMAD/ATTRIBUTION.md` has
-the pinned commit), date, and which skills ran.
+the pinned commit), date, which intake mode ran (`full`, below, or
+`compressed`), and which skills ran.
+
+### Compressed intake (full-stack-app, authored core)
+
+A user who opens with "just build it" — no clarifying questions — is
+asking for something Phase 0's live elicitation can't give them.
+`planner` surfaces that conflict rather than resolving it silently (see
+that agent), and **compressed intake is the defined path when the user
+chooses it**. It is never the default and never offered as the
+easier option: it runs only on an explicit choice, after the conflict has
+been named.
+
+Compressed intake replaces the shelf with **one batched round of
+questions covering only what can't be inferred from the user's brief**,
+then writes the archive below directly. Everything else about intake is
+unchanged — Phase 1 mining, Confirm & Lock, and the Add-ons gate all run
+exactly as they do on a full run, against the archive this mode writes.
+
+Not available on landing-page: that core's whole chain is a traceability
+audit rooted in a subject statement mined from BMAD's material, so
+compressing the elicitation removes the thing the chain audits against.
+A "just build it" landing-page request is a conflict to surface, not a
+mode to switch into.
+
+**The Add-ons decision is what the batched round is for.** Auth, Queue,
+and Mobile must each be *answered* — inferred from a concrete trigger in
+the user's brief, or asked directly in that one round. Compressed intake
+compresses BMAD's elicitation, never `planner`'s gate; an add-on left as
+a guess is the same error here as on a full run.
+
+Write the manifest and the PRD always, and the experience spec where the
+brief gives it something to say — at the same path and in the same
+layout:
+
+```
+.hedgehog/BMAD/
+  00-manifest.md        # mode: compressed, date, what the batched round covered
+  04-prd.md             # §3 Glossary and §4 Features only, mined from the brief
+  05-ux-spec/
+    EXPERIENCE.md       # flows and behaviour, where the brief states them
+```
+
+- **`04-prd.md`** carries the load: Phase 1 below reads §3 Glossary and
+  §4 Features, so compressed intake writes exactly those two sections,
+  derived from the brief plus the batched answers, in the shape that
+  mining table expects. Not a full BMAD PRD — the minimum shape Phase 1
+  can walk.
+- **`05-ux-spec/EXPERIENCE.md`** only where the brief actually states
+  flows or behaviour ("a list you can filter", "mark done inline"). No
+  `DESIGN.md`: visual identity is what a compressed brief is least
+  likely to state, and inventing one is exactly the improvisation this
+  mode exists to prevent. `ux-planner` reads whichever of the two the
+  archive holds, and treats an absent file as its cue to ask (see that
+  agent).
+- **`01-brainstorming.md`, `02-brief.md`, `03-prfaq.md`, and
+  `06-research.md` are not written.** Those exist on a full run to
+  produce a good PRD; compressed intake reaches the PRD by a different
+  route. `00-manifest.md` naming them as not-run is the record — an
+  empty placeholder file is not.
+
+`00-manifest.md` states `mode: compressed`, the date, which files were
+written and which weren't, what the batched round asked, and which
+add-ons were answered directly versus triggered by the brief. That
+manifest is the single record of how this project was planned: **the
+archive exists on every core after intake, whichever mode ran**, so an
+absent `.hedgehog/BMAD/` means intake never ran, not that a compressed
+path was taken.
+
+On an authored core, `hedgehog-core-design` reads this archive to pick a
+stack and derive layers. A compressed PRD is thinner input for that than
+a full shelf run, so say so plainly at that skill's own Confirm & Lock —
+the architecture is being designed from a brief rather than from elicited
+drivers, and that's the user's call to accept there.
 
 `.hedgehog/BMAD/` is archival and immutable once written, on every core.
 Nothing in `hedgehog-loop`'s day-to-day operation, `hedgehog-bootstrap`,
@@ -117,6 +190,9 @@ Read `.hedgehog/BMAD/04-prd.md` only — §3 Glossary and §4 Features.
 Nothing else in `.hedgehog/BMAD/` is read again: brainstorming, brief,
 PR-FAQ, and deep-recon existed to produce a good PRD, and the UX spec is
 read later, once per module, by `ux-planner`, not by this mining pass.
+This is the same read on either intake mode — a compressed archive writes
+those two sections directly, so mining has its documented source
+whichever mode ran.
 Mining is mechanical, not interpretive — one graph row per PRD element,
 per this table:
 
@@ -187,7 +263,9 @@ stops being true, so it's a hard stop, not a recap in passing.
   `requirements` (rule/acceptance), and its `depends_on` list.
 - The Add-ons decision (Auth / Queue / Mobile, each explicitly on or
   off, with the one-line reason).
-- Which BMAD skills ran and where their output lives
+- Which intake mode ran, and on a full run which BMAD skills ran — or,
+  on a compressed run, what the batched round asked and what was inferred
+  from the brief without asking. Either way, where the output lives
   (`.hedgehog/BMAD/`).
 
 Then state plainly what happens on confirmation, before it happens:
@@ -225,9 +303,13 @@ their commits.
 
 1. **Read `.hedgehog/BMAD/` for context**, chiefly `02-brief.md` and
    `04-prd.md` — what this project is, and what its existing vocabulary
-   calls things. Read-only. The new scope has to sit inside the same
-   product and reuse its terms; you're extending a project, not starting
-   a neighbouring one.
+   calls things. Read `00-manifest.md` first for which of those the
+   archive actually holds: on a compressed archive that's `04-prd.md` and
+   the manifest's own record of the batched round, which carry the same
+   two things this step needs (the product, and its vocabulary).
+   Read-only. The new scope has to sit inside the same product and reuse
+   its terms; you're extending a project, not starting a neighbouring
+   one.
 2. **Read the existing graph**: `hedgehog status` for what's built, and
    the existing intent ids for the vocabulary already in play. New scope
    names must not collide with an existing intent id.

--- a/src/templates/CLAUDE.core.full-stack-app.md
+++ b/src/templates/CLAUDE.core.full-stack-app.md
@@ -3,7 +3,10 @@
 Backend-first, schema → contract → repository → service → controller, then
 hook → UX rationale → screen, per domain module. See `.hedgehog/BMAD/` for
 the archival planning intake output — BMAD-METHOD's brainstorming, brief,
-PRD, and UX spec, written once by `planner` and never edited after.
+PRD, and UX spec, written once by `planner` and never edited after. Its
+`00-manifest.md` records which intake mode produced it; a compressed
+archive holds the PRD and whatever flows the brief stated, and nothing
+else.
 `.hedgehog/addons.yaml` carries this core's Add-ons decision
 (Auth/Queue/Mobile, each on or off) — check it before assuming any
 add-on's infra exists.
@@ -49,7 +52,9 @@ steps from memory:
 - **`ux-planner`** — once per module in Phase B, after the hook exists and
   before the screen: writes `docs/design/<module>.md`, reading
   `.hedgehog/BMAD/05-ux-spec/` directly (or
-  `docs/design/<module>-notes.md` if a prior run already filed one).
+  `docs/design/<module>-notes.md` if a prior run already filed one). Where
+  the archive holds no UX spec, it asks for visual input rather than
+  inferring a direction.
 - **`front-end-eng`** — builds each module's Phase B layers (hook, screen)
   from the ux-planner rationale, one `hedgehog next` packet at a time,
   gated by `hedgehog verify`.


### PR DESCRIPTION
Works #129 and #133. One commit each, plus the `package.json` bump.

## #129 — compressed planning intake (`a7e2247`)

"Just build it" is a common opening, and `planner` already surfaces the conflict it creates with Phase 0's live elicitation. What was undefined is what followed the user's answer: `.hedgehog/BMAD/` never got written, so `hedgehog-planning-intake`'s Phase 1, `ux-planner`, and the Re-entry pass all lost their documented source and improvised instead.

**How the mode is recorded.** In `.hedgehog/BMAD/00-manifest.md`, as `mode: compressed` — not a CLI flag, and not a new sibling file. A flag would be wrong because the mode isn't chosen at install time; it's chosen mid-conversation, long after `init` ran. The manifest already exists in the documented layout and already carries "which skills ran", so it's the one file that owns "how was this project planned".

The payoff is that **the archive exists after intake whichever mode ran**, which restores the signal the issue says was lost: an absent `.hedgehog/BMAD/` again means intake never ran, rather than being ambiguous with a compressed path. That's the `addons.yaml` distinction between "never decided" and "decided off", reached without splitting one fact across two files.

**The minimal archive.** Manifest and `04-prd.md` always; `05-ux-spec/EXPERIENCE.md` where the brief states flows.

- `04-prd.md` carries the load: Phase 1 is specified as "read §3 Glossary and §4 Features", so compressed mode writes exactly those two sections. Phase 1 then needs no compressed-specific branch — it reads its documented source, which now exists.
- No `DESIGN.md`. Visual identity is what a compressed brief is least likely to state, and inventing one is the exact improvisation the issue objects to.
- `01`, `02`, `03`, `06` are not written. Per the skill's own words those "existed to produce a good PRD" — a document compressed mode reaches by another route. The manifest naming them as not-run is the record; empty placeholders would be ceremony.

**What `ux-planner` reads.** Less new machinery than expected, because it already had a fallback chain (`docs/design/<module>-notes.md`, falling through to `05-ux-spec/`). The gap was that on a compressed run both are absent. Two changes: it reads whichever half of the spec the archive holds, and — the more valuable half — **an absent file is now its stated cue to ask**. It already had a documented moment for requesting visual input; on a compressed run that ask becomes the substitute for the missing spec rather than optional politeness. A stated fallback, not an improvised one.

**Gates kept.** The Add-ons decision must still be *answered*, never guessed — satisfying that gate is what the batched round is **for**. Compressed intake compresses BMAD's elicitation, not `planner`'s gate. Landing-page is excluded: its chain is a traceability audit rooted in mined BMAD material, so compressing the elicitation removes what the chain audits against. Authored cores are included, with a stated caution at `hedgehog-core-design`'s Confirm & Lock that the architecture rests on thinner input.

The mode is never a default and never recommended — `planner` surfaces the conflict exactly as it does today, and this is only where the user's answer can now land.

## #133 — re-raise the singular check at `plan` (`3f7a75c`)

**A bug surfaced while writing the repro, and it changed the implementation.** The obvious version warns on the ids a given `plan` run compiled. That is silent on the single most important route: `db rebuild` replays the committed intent files *and compiles their tasks*, so a `plan` after it compiles nothing and the advisory never fires. Verified in a real workspace — the route the issue calls out would have stayed silent.

So the check reports while **all of an intent's tasks are still unstarted**, not just for this run's output. The cheap-fix window is "no work has landed yet", which outlasts any single `plan` invocation. Once a task is claimed it stops, because from there the fix is a Correction Protocol case and the `git mv` advice would point at the wrong recovery.

**Kept a warning**, as the issue specifies: the plural rule is a heuristic, and a gate would reject `billing`/`search`. The output says that in as many words and leaves the call to the operator.

**What it prints when several trip at once** — the issue's open question. One shared explanation block, since the reasoning is identical every time and stacking it per-intent buries the list of names; the recovery is genuinely per-id, so those lines are listed one per name:

```
3 module ids look singular. On this core an intent id is {module} in
every layer's scope, and the generators take it plural — so each of these compiles
scope for a directory the scaffold command will never write:
  billing — scope billing/, scaffold writes billings/
  invoice — scope invoice/, scaffold writes invoices/
  task — scope task/, scaffold writes tasks/

This is a naming convention, not a rule — billing and search are legitimately
singular. If the plural is what you meant, it is still cheap to fix:
  git mv .hedgehog/intents/billing.json .hedgehog/intents/billings.json
  # edit "id" and every BILLING-* requirement id
  ...
  hedgehog db rebuild
```

Singular/plural phrasing both branch correctly, and a plural id is never flagged.

## Verification

`npm run check` and `npm run repro` pass — 58 reproductions, up from 56.

Two repros added, both auto-discovered:

- `repro/plan-warns-singular-module-ids.mjs` — 20 assertions across the three bypass routes (`--file`, hand-written intent file, `db rebuild`), the plural-id non-flag, the one-block/per-id-line output shape, the window closing at `claim`, and silence on a non-module-axis core.
- `repro/compressed-intake-archive-contract.mjs` — 18 assertions pinning a documentation contract, which is the subtle failure mode here: compressed intake is defined in one file and consumed in four others, so they can drift apart with nothing to catch it. Confirmed it genuinely fails when a consumer is reverted, rather than passing vacuously.

Behavior verified against real workspaces generated from `src/golden-cores/` (both cores), not only the harness.

`package.json` bumped to 4.3.4; the tag `npm version` created was deleted locally so `publish.yml` can create it against the merge commit. No `skills/`, `hooks/`, or `.claude-plugin/` files changed, so the plugin version is unchanged.

Closes #129
Closes #133