### PR TITLE
fix: hold the discipline at the start — consent, core shape, and a path-based handoff

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "skyf0xx"
   },

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -548,31 +548,22 @@ async function init({ force, core, explicitCore, host = DEFAULT_HOST, hostOnly =
     );
     console.log(dim('     instead of polling tightly or narrating the wait.'));
     console.log(`  2. ${bold('git add -A && git commit -m "chore: install Hedgehog"')}`);
-    console.log(
-      `  3. Start a ${bold('new')} ${HOSTS[host].label} session and describe what you want to build.`,
-    );
+    console.log(`  3. Describe what you want to build.`);
   } else {
     console.log(`  1. ${bold('git add -A && git commit -m "chore: install Hedgehog"')}`);
-    console.log(
-      `  2. Start a ${bold('new')} ${HOSTS[host].label} session and describe what you want to build.`,
-    );
+    console.log(`  2. Describe what you want to build.`);
   }
+  // Hand off by path, not by name. Reading the file works on every host in
+  // the session that ran this install — no restart, no dependence on whether
+  // the harness re-scans its agent directory, and no chance of a bare
+  // `planner` resolving to an unrelated global agent of the same name.
+  const agents = HOSTS[host].agentsDir;
+  const skills = HOSTS[host].skillsDir;
   console.log(
     dim(
-      `     The ${bold('planner')} agent runs planning intake, then hands off to bootstrap.`,
-    ),
-  );
-  // A host enumerates its agents once, at session start. This install just
-  // wrote them mid-session, so in THIS session they are not dispatchable —
-  // and the failure is worse than a plain error: names like `planner` and
-  // `reviewer` often resolve to the user's own unrelated global agents,
-  // silently running a different discipline instead of erroring.
-  console.log(
-    dim(
-      `     A new session matters: ${HOSTS[host].label} lists its agents at startup, so the\n` +
-        '     ones just installed are not dispatchable in the session that ran this.\n' +
-        '     If a handoff must happen here anyway, read the agent file and follow it\n' +
-        '     inline rather than dispatching to a name that may resolve elsewhere.',
+      `     Read ${bold(`${agents}/planner.md`)} and follow it — it runs planning\n` +
+        `     intake (${skills}/hedgehog-planning-intake/SKILL.md), then hands\n` +
+        `     off to ${agents}/bootstrap.md.`,
     ),
   );
   console.log();

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -55,13 +55,32 @@ context clear if the conversation suggests it already came up.
 
 ## How to offer
 
-Ask directly: "Want me to set up Hedgehog here?" Say briefly what it means — a
-build discipline of agents and skills, matched to the kind of project
-(full-stack app, landing page, or an existing codebase to adopt).
+Two branches. Which one applies depends on whether the user has already named
+Hedgehog.
 
-Wait for an explicit yes. Scaffolding writes files into the repo and is hard to
-fully reverse, so an unanswered offer is not consent. On a yes, invoke the
-`hedgehog` skill and follow it for the install procedure.
+**The user named Hedgehog.** Consent is already in the request — "build me a
+todo app with Hedgehog" is a yes, not an opening to ask for one. Do not ask
+whether to install. Invoke the `hedgehog` skill and follow it. Use what the
+user already said to pick the core (full-stack app, landing page, or an
+existing codebase to adopt); if the core is genuinely unclear from the
+conversation, ask about that alone, and prefer the no-flag install that lets
+planning intake decide over stalling on a question.
+
+**The user did not name Hedgehog.** Ask directly: "Want me to set up Hedgehog
+here?" Say briefly what it means — a build discipline of agents and skills,
+matched to the kind of project. Wait for an explicit yes: scaffolding writes
+files into the repo and is hard to fully reverse, so an unanswered offer is not
+consent. On a yes, invoke the `hedgehog` skill and follow it.
+
+Both branches: ask about Hedgehog alone. Stack, persistence, auth, and feature
+scope are planning intake's job — do not ask them here and do not bundle them
+with the offer. The core ships its own stack, and a stack answer given now is
+one intake will ask for properly later.
+
+Hedgehog means Hedgehog. Once the user has asked for it, build it that way —
+do not counter-offer a quicker path outside the discipline, and do not treat a
+small-sounding scope as a reason to skip it. Scope grows, and a project built
+outside the discipline pays for it as debt.
 GATE
 
 # JSON-escape via bash parameter substitution: one C-level pass per rule,

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -81,6 +81,14 @@ Hedgehog means Hedgehog. Once the user has asked for it, build it that way —
 do not counter-offer a quicker path outside the discipline, and do not treat a
 small-sounding scope as a reason to skip it. Scope grows, and a project built
 outside the discipline pays for it as debt.
+
+Never propose a thinner version of what the user asked for. If they describe an
+app that stores things, that is `full-stack-app` with a real database — do not
+float localStorage, an in-memory array, or a single HTML file as the easier
+option, and do not present one as a starting point to migrate off later. That
+migration is the debt. The cores exist because their shape is the one that
+holds up; route to the core the description calls for and let planning intake
+size the rest.
 GATE
 
 # JSON-escape via bash parameter substitution: one C-level pass per rule,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "4.3.5",
+  "version": "4.3.6",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/skills/hedgehog/SKILL.md
+++ b/skills/hedgehog/SKILL.md
@@ -14,12 +14,13 @@ A project that already has `.hedgehog/` gets no injection, and its own
 installed agents and skills own the session. Do not offer to install,
 reinstall, or repair anything there.
 
-This skill carries the install procedure, for use once the user has said
-yes.
+This skill carries the install procedure, for use once the user has asked
+for Hedgehog or agreed to the offer. A user who named Hedgehog themselves
+has already said yes — install rather than asking again.
 
 ## What to do
 
-On confirmation, run the matching command:
+Run the matching command:
 
 - Full-stack app: `npx @skyf0xx/hedgehog init --ts-full-stack-app`
 - Landing page: `npx @skyf0xx/hedgehog init --landing-page`

--- a/src/agents/planner.md
+++ b/src/agents/planner.md
@@ -87,7 +87,12 @@ and the scaffolded workspace.
   real app beyond a single page. If in doubt between this and
   landing-page because the project has *both* a marketing page and a
   real app behind it, this is `full-stack-app` — the page becomes routes
-  inside `apps/web`, not a separate project.
+  inside `apps/web`, not a separate project. Data that gets stored is
+  this core, at any size: a todo list, a notes app, a tracker of any
+  kind. Never talk the user down to browser-local storage, an in-memory
+  array, or a single-file page because the app sounds small, and never
+  offer that as a quicker start — the core ships a real database, and
+  reaching for less is the drift this discipline exists to prevent.
 - **`landing-page`** — the description is a marketing/announcement/
   waitlist/portfolio page (or a small handful of such pages) with no
   persistent domain data of its own. A page that only collects an email

--- a/src/templates/CLAUDE.md
+++ b/src/templates/CLAUDE.md
@@ -38,20 +38,19 @@ Lock and the `bootstrap` handoff. This same rule holds at every later
 handoff to a newly-installed agent or skill in this session: read its
 file, don't assume its content.
 
-Dispatch is the part that can't be worked around by reading. A host lists
-its agents once, at session start, and this install wrote them after
-that — so in this session `bootstrap` and the rest may not be
-dispatchable at all. Two symptoms, and neither means a broken install:
-an error naming the available agents without Hedgehog's in it, or —
-worse, because it has no symptom — a name like `planner` or `reviewer`
-silently resolving to the user's own unrelated global agent and running a
-different discipline. If either happens, read the agent's file from
-`.claude/agents/` and follow it inline here; each one is self-contained.
-Everything delegates normally from the next session on, which is why the
-installer's next step is to start a fresh one. Don't re-explain the discipline or summarize this
-file; the greeting is one line, not a tour. Skip this entirely once the
-placeholder is filled in — every later session starts with `hedgehog
-status`, not a greeting.
+The build continues in this session — nothing here needs a restart. Hosts
+differ in whether they pick up agents written mid-session, so prefer
+reading an agent's file from `.claude/agents/` and following it inline;
+each one is self-contained, and that path works everywhere. Reading also
+avoids the quiet failure of dispatch by name, where `planner` or
+`reviewer` resolves to the user's own unrelated global agent and runs a
+different discipline with no symptom. If a dispatch does error with a
+list of available agents that omits Hedgehog's, that is the same case —
+read the file and carry on.
+
+Don't re-explain the discipline or summarize this file; the greeting is
+one line, not a tour. Skip this entirely once the placeholder is filled
+in — every later session starts with `hedgehog status`, not a greeting.
 
 ## How to work here
 
@@ -85,6 +84,16 @@ enforcement (scope boundaries, no self-certification, the commit-gated
 loop) is what a generic skill pack has no notion of, and running one
 alongside Hedgehog's own skills produces work that bypasses the very
 discipline this file describes.
+
+**Build through the loop, including when the work looks too small to need
+it.** A task that seems like a quick edit is not a reason to skip the
+graph, the step sequence, or the gate — scope grows, and the shortcut is
+what turns a small change into debt the next step has to work around.
+Don't propose going around the discipline to save a step, and don't treat
+a user's impatience as license to: say what the loop's next step is and
+take it. Where a rule genuinely conflicts with what the user is asking
+for, name the conflict and let them decide — never resolve it by quietly
+taking the faster path.
 
 {{CORE_SECTION}}
 


### PR DESCRIPTION
Two issues, plus the friction they bracket. All of it is the same failure:
the agent asking again, or quietly offering less, at the moment a user just
wants to start building.

## #135 — the offer gate had no branch for "user already said yes"

`## How to offer` had exactly one path: ask, then wait for an explicit yes.
That is right when Hedgehog is unmentioned, but a user who opens with *"help
me build a simple todo app with hedgehog"* has already given consent — the
offer was pre-answered, not unanswered. Nothing scoped the question to
Hedgehog either, so stack and persistence got bundled into the same ask,
which is what created the ambiguity that cost the extra turns.

- Split into two branches: **named Hedgehog** → treat as consent, go
  straight to the skill, ask only about the core if it is genuinely unclear;
  **did not name it** → offer as before and wait for a yes.
- Both branches now say to ask about Hedgehog alone — stack, persistence,
  auth, and feature scope are planning intake's job.
- `skills/hedgehog/SKILL.md` said "On confirmation", which re-implied the
  wait the gate now says is already satisfied. Aligned.

## #136 — installer told the user to restart a session that works fine

Step 3 led with **Start a new session**, on the belief that a host
enumerates its agents once at startup. Claude Code hot-loads
`.claude/agents/` and `.claude/skills/`, so the restart cost a full context
for no benefit — and it was the first thing a brand-new user read after a
successful install.

Now leads with the inline read, which the issue notes always works:

```
  3. Describe what you want to build.
     Read .claude/agents/planner.md and follow it — it runs planning
     intake (.claude/skills/hedgehog-planning-intake/SKILL.md), then hands
     off to .claude/agents/bootstrap.md.
```

Paths come from the host entry, so Cursor renders `.cursor/agents/...`.
Handing off by path rather than by name also removes the shadowing hazard
#136 flagged: a bare `planner` can resolve to an unrelated global agent, a
path cannot.

`src/templates/CLAUDE.md` carried the same stale claim — telling the agent
this session's agents may not be dispatchable and that the installer's next
step is a fresh session. That is the copy the agent actually reads at
install time, so it mattered more than the CLI output. It now leads with the
inline read too, keeping the dispatch-shadowing warning that is still real.

## Holding the core's shape

The gate fix removes the *bundled* stack question, but the more damaging
version is the agent volunteering a thinner answer: "localStorage only, or a
real backend?" at turn one lets a convenience answer silently veto
`full-stack-app`, because Phase 0 reads persistence off the user's own
description. A todo app then routes out of the core that fits it, and the
migration back is the debt.

Closed at the two points it happens:

- **The offer gate**, before a core is chosen — never propose a thinner
  version of what the user asked for; an app that stores things is
  `full-stack-app` with a real database, and "start with localStorage and
  migrate later" is not a starting point, it's the debt.
- **`planner`'s Phase 0 bullet**, where the core is actually selected —
  stored data is this core at any size, and the agent may not talk the user
  down to browser-local storage because the app sounds small.

Also added the build-time counterpart to the project `CLAUDE.md`: build
through the loop even when the work looks too small to need it, and don't
treat user impatience as license to go around it. Where a rule genuinely
conflicts with the ask, name the conflict rather than quietly taking the
faster path — the same stance `planner` already takes on "don't ask
clarifying questions."

## Verification

- `npm run check` passes (18 agents, 26 skills, 2 cores, tarball, CLI).
- Hook emits valid JSON in a clean dir; still silent in a project with
  `.hedgehog/`.
- `init --ts-full-stack-app` and `init --cursor` both render step 3 with
  correct per-host paths; every file named in the handoff exists after
  install.

## Versions

Both payloads changed, so both bump: npm `4.3.6` (`bin/`, `src/`), plugin
`1.2.0` (`hooks/`, `skills/`) across the Claude and Cursor manifests. No tag
pushed — `publish.yml` tags on merge.

Closes #135
Closes #136