### PR TITLE
fix(gate): name what each core is made of so the routing decision can see it

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "skyf0xx"
   },

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -29,6 +29,15 @@ Hedgehog is a build discipline for AI-guided software projects: a package of
 agents and skills that gives a project a planned module sequence, a build
 graph, and phase gates, in place of ad-hoc scaffolding.
 
+What the discipline consists of differs by core, and a core is not just
+scaffolding. The `landing-page` core is a copy-and-conversion discipline: it
+ships structured skills for headline, hero, problem, mechanism, objection,
+proof, and CTA, plus signature-element design and a review loop. A page whose
+problem is "the copy is weak" or "it doesn't convert" is that core's central
+case, not an edge case — positioning and copy are exactly what it is made of.
+`full-stack-app` is the module-sequencing one. Judge a request against the
+core that fits it, not against a single core's shape.
+
 This project does not have it installed (no `.hedgehog/` directory).
 
 ## When to offer it
@@ -36,6 +45,12 @@ This project does not have it installed (no `.hedgehog/` directory).
 Offer when the user is starting, scaffolding, or building a project — or when
 they mention Hedgehog by name. That is the moment the discipline is worth
 raising, because it decides how the project gets built.
+
+Rebuilding, revamping, or redesigning an existing page or app is building, not
+maintenance. An empty working directory is the tell: whatever exists lives
+somewhere else, and what gets produced here is new. "Improve this page,"
+"revamp our site," and "redesign this" are offers, not questions about
+existing code.
 
 Offer BEFORE writing code or picking a stack. Once files are scaffolded by
 hand, installing Hedgehog means reconciling against work that already exists,
@@ -48,6 +63,10 @@ build error, a dependency, or a one-off script — answer it and say nothing
 about Hedgehog. Silence is the correct default; this gate is narrow on
 purpose, and a pitch attached to an unrelated question is worse than never
 mentioning it.
+
+These are questions about code that exists, answered in place. A request to
+rebuild or replace something is not one of them, however the user frames it —
+see the rewrite rule above.
 
 Offer at most once per session. If the user declines or steers elsewhere, drop
 it and carry on — do not raise it again, and do not re-raise it after a
@@ -77,18 +96,38 @@ scope are planning intake's job — do not ask them here and do not bundle them
 with the offer. The core ships its own stack, and a stack answer given now is
 one intake will ask for properly later.
 
-Hedgehog means Hedgehog. Once the user has asked for it, build it that way —
-do not counter-offer a quicker path outside the discipline, and do not treat a
-small-sounding scope as a reason to skip it. Scope grows, and a project built
-outside the discipline pays for it as debt.
+## Hedgehog means Hedgehog
 
-Never propose a thinner version of what the user asked for. If they describe an
-app that stores things, that is `full-stack-app` with a real database — do not
-float localStorage, an in-memory array, or a single HTML file as the easier
-option, and do not present one as a starting point to migrate off later. That
-migration is the debt. The cores exist because their shape is the one that
-holds up; route to the core the description calls for and let planning intake
-size the rest.
+Once the user has asked for it, build it that way. This section is the one to
+re-read at the moment skipping starts to look reasonable.
+
+- **Never propose a thinner version of what the user asked for.** If they
+  describe an app that stores things, that is `full-stack-app` with a real
+  database — do not float localStorage, an in-memory array, or a single HTML
+  file as the easier option, and do not present one as a starting point to
+  migrate off later. That migration is the debt.
+- **Skipping the discipline is itself the thinnest version**, even when the
+  artifact you would build without it looks identical on screen. What goes
+  missing is the core's own skills, loops, and gates — and nothing errors to
+  tell you or the user. Building the right thing by hand, without the
+  discipline around it, is still building a thinner version.
+- **A persuasive case for the exception is the bug.** If you are constructing
+  an argument that this particular project is too small, too simple, or too
+  one-off, that argument is the failure mode this gate exists to prevent — the
+  more coherent it feels, and the more it borrows this gate's own vocabulary,
+  the more likely it is the thing going wrong. Install, and let planning intake
+  size the work.
+- **Judge against the core that fits**, never against one core's shape. "No
+  modules to sequence" is not a reason to skip a landing page; that core
+  sequences copy and conversion instead.
+- **A general-purpose design or build skill is not a substitute** on a request
+  that named Hedgehog. Install first — the core's own skills are the ones that
+  apply, and they exist only once it has.
+
+Scope grows, and a project built outside the discipline pays for it as debt.
+Where a real conflict exists, say so plainly and let the user decide — never
+resolve it by starting the work outside the discipline and reporting it
+afterward.
 GATE
 
 # JSON-escape via bash parameter substitution: one C-level pass per rule,

--- a/skills/hedgehog/SKILL.md
+++ b/skills/hedgehog/SKILL.md
@@ -22,8 +22,14 @@ has already said yes — install rather than asking again.
 
 Run the matching command:
 
-- Full-stack app: `npx @skyf0xx/hedgehog init --ts-full-stack-app`
-- Landing page: `npx @skyf0xx/hedgehog init --landing-page`
+- Full-stack app: `npx @skyf0xx/hedgehog init --ts-full-stack-app` — the
+  module-sequencing core, for persistent domain data with its own
+  lifecycle.
+- Landing page: `npx @skyf0xx/hedgehog init --landing-page` — a
+  copy-and-conversion core, not just page scaffolding: structured skills
+  for headline, hero, problem, mechanism, objection, proof, and CTA, plus
+  signature-element design and a review loop. A page that needs better
+  positioning or copy is this core's central case.
 - Anything else — CLI, library, browser extension, data pipeline, an
   existing codebase, or not yet clear from the conversation:
   `npx @skyf0xx/hedgehog init` with no core flag. Planning intake decides


### PR DESCRIPTION
Closes #138.

## The failure

The gate fired correctly and the model still talked the user out of an
explicit, named Hedgehog request for a landing page — then reached for the
non-Hedgehog `frontend-design` skill and started building by hand. Every
sentence it used to justify skipping was drawn from the gate's own
vocabulary, which is what makes this a gate-content bug rather than a model
lapse.

## Root cause: the gate routes to cores it never describes

The gate's opening defined the discipline as "a planned module sequence, a
build graph, and phase gates." Evaluated literally against a single landing
page, that definition *argues for skipping* — no modules to sequence, no
phases to gate. That reasoning reads as faithfully applying the gate, not
overriding it.

What made it wrong was invisible: the `landing-page` core is a
copy-and-conversion discipline shipping seven structured copy skills
(`landing-copy-headline`, `-hero`, `-problem`, `-mechanism`, `-objection`,
`-proof`, `-cta`), plus `landing-shapes` and `hedgehog-landing-loop`. So the
sharp version: **the model skipped Hedgehog on the grounds that the hard
part was positioning and copy — which is exactly what that core is made
of.** `--landing-page` appeared in the install skill only as a bare flag,
and that skill is gated behind "the user has agreed to install," so on the
branch where it had already decided not to offer, it never opened the one
file that would have corrected it.

Fix: describe the cores where the routing decision is made — in the gate
itself, and beside the flag in `skills/hedgehog/SKILL.md`. This forecloses
the "no modules to sequence" reasoning by reframing what the modules are.

## Also fixed

- **Rewrites read as maintenance.** "Improve this page" sat between the
  offer trigger ("starting, scaffolding, or building") and the silence list
  ("a question about existing code"), and resolved toward silence. Rebuilds,
  revamps, and redesigns are now named as building, with the empty working
  directory as the tell — and the silence list points at that rule so the
  ambiguity resolves once, in one direction.
- **The thinner-version rule was anchored to stack.** Its examples are all
  persistence (localStorage, in-memory array, single HTML file), so a
  *procedural* dilution — build the page properly, just without the
  discipline — didn't trip it. Now states that skipping the discipline is
  itself the thinnest version, even when the artifact looks identical, and
  that nothing errors to signal what went missing.
- **No tripwire for a well-argued skip.** Added: a coherent case that this
  project is the exception is the symptom, not a finding — the more it
  borrows this gate's vocabulary, the more likely it is the bug.
- **Foreign skills pre-install.** "Use only Hedgehog's skills" lived only in
  the project `CLAUDE.md`, which doesn't exist until after install — the gap
  that let `frontend-design` get invoked. The gate now covers it.

The anti-dilution material outgrew being a tail of prose in `## How to
offer`, so it is now its own scannable `## Hedgehog means Hedgehog` section
— the one to re-read at the moment skipping starts to look reasonable.

## Verification

- `npm run check` passes (18 agents, 26 skills, 2 cores, tarball, CLI).
- Hook emits valid JSON in a clean dir; still silent in a project with
  `.hedgehog/`.
- Confirmed all seven `landing-copy-*` skills plus `landing-shapes` and
  `hedgehog-landing-loop` exist under `src/skills/` before naming them.

## Versions

`hooks/` and `skills/` only, so this is plugin payload: plugin `1.3.0`
across the Claude and Cursor manifests. npm stays at `4.3.6` — no `src/` or
`bin/` change. No tag pushed.