### PR TITLE
feat: detect and report stale Hedgehog installs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": {
     "name": "skyf0xx"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,16 +132,23 @@ discipline's stance and rationale.
   when its format differs from the canonical one. `capabilities.mjs`
   owns the agent → tool-grant fact for hosts that can't register a
   per-agent grant; `routing.mjs` generates the root `AGENTS.md` index
-  from the agents' and skills' own frontmatter. See
+  from the agents' and skills' own frontmatter. `version.mjs` owns
+  payload-staleness detection: `init` and `update` stamp the version they
+  wrote into `.hedgehog/version.json`, and that stamp is compared against
+  the newest published release. See
   [ARCHITECTURE.md](ARCHITECTURE.md) for the host table.
 
 - `hooks/` — the Claude Code plugin's `SessionStart` hook, which injects
   the offer gate (when to raise Hedgehog, when to stay silent, how to
   ask) into context at session start rather than leaving that to
   skill-description matching. `session-start` checks for `.hedgehog/`
-  and emits nothing when it exists, so an already-installed project's own
-  payload owns the session; that check is the one place the silence rule
-  is enforced. `hooks.json` (Claude Code) and `hooks-cursor.json`
+  and emits no offer gate when it exists, so an already-installed
+  project's own payload owns the session; that check is the one place the
+  silence rule is enforced. It also reports a stale plugin — the version
+  recorded in the install path against the marketplace clone's
+  `origin/<branch>` manifest, read locally with no network wait — which
+  is independent of that gate and so is the one thing it emits into an
+  already-installed project. `hooks.json` (Claude Code) and `hooks-cursor.json`
   (Cursor) register it; `run-hook.cmd` is a cmd/bash polyglot so the hook
   runs on Windows, and hook scripts stay extensionless because Claude
   Code prepends `bash` to any command containing `.sh`. Part of the

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -50,6 +50,7 @@ import { rebuildDb } from '../src/db/rebuild.mjs';
 import { loadOverrides, addOverride, orphanedOverrides, OVERRIDES_DIR } from '../src/db/overrides.mjs';
 import { HOSTS, HOST_FLAGS, DEFAULT_HOST, availableHosts } from '../src/hosts/index.mjs';
 import { recordHosts, installedHosts } from '../src/hosts/installed.mjs';
+import { recordVersion, checkForUpdate, installedVersion } from '../src/hosts/version.mjs';
 
 const AUTHORED_CORE_PATH = '.hedgehog/core.yaml';
 
@@ -64,6 +65,12 @@ const PKG_ROOT = resolve(__dirname, '..');
 const DEST_ROOT = process.cwd();
 const CORES_ROOT = join(PKG_ROOT, 'src/golden-cores');
 const DEFAULT_CORE = 'full-stack-app';
+
+// The version of the payload this CLI carries — what `init` and
+// `update` stamp into the project they write to.
+const PKG_VERSION = JSON.parse(
+  await readFile(join(PKG_ROOT, 'package.json'), 'utf8'),
+).version;
 
 // One install flag per core, named for what a user is asking to build
 // rather than the internal src/golden-cores/<name> directory — the two
@@ -384,6 +391,7 @@ ${bold('Usage')}
   npx @skyf0xx/hedgehog init --all-hosts          install for every supported coding agent
   npx @skyf0xx/hedgehog init --force              overwrite existing files
   npx @skyf0xx/hedgehog update                    refresh the installed agents + skills
+  npx @skyf0xx/hedgehog update --check            report whether a newer release is published
   npx @skyf0xx/hedgehog db init                   create .hedgehog/hedgehog.db if absent
   npx @skyf0xx/hedgehog db rebuild                re-derive the build graph from committed intents + git history
   npx @skyf0xx/hedgehog plan                      compile pending intents into tasks + dependencies
@@ -449,6 +457,15 @@ those directories. The instructions file, the build graph, the core
 workspace, and vendor-skills/BMAD and vendor-skills/GSAP stay as they
 are — those are project-specific or updated deliberately, not by this
 command.
+
+Both ${bold('init')} and ${bold('update')} stamp the version they wrote into
+.hedgehog/version.json. ${bold('update --check')} compares that stamp against
+the newest published release and exits 1 when a newer one exists, without
+writing anything. The same comparison rides on ${bold('status')} and
+${bold('next')} as a one-line notice, from a once-a-day cached lookup, so a
+stale project surfaces itself; set HEDGEHOG_NO_UPDATE_CHECK=1 to silence it.
+Run ${bold('npx @skyf0xx/hedgehog@latest update')} to pull a newer release —
+the @latest tag matters, since a bare npx may reuse a cached older CLI.
 `);
 }
 
@@ -500,6 +517,7 @@ async function init({ force, core, explicitCore, host = DEFAULT_HOST, hostOnly =
   // Recorded before anything is written: the routing doc is generated
   // from this list, so it has to already name the host being installed.
   await recordHosts(DEST_ROOT, [host]);
+  await recordVersion(DEST_ROOT, PKG_VERSION);
 
   let written = 0;
   let overwritten = 0;
@@ -588,6 +606,42 @@ async function init({ force, core, explicitCore, host = DEFAULT_HOST, hostOnly =
   }
 }
 
+// `update --check` answers the question without acting on it: what's
+// installed, what's published, and whether they differ. Exit code 0 when
+// current or unknown, 1 when an update is available, so a script or a
+// host's own tooling can branch on it without parsing the output.
+async function updateCheck() {
+  const { installed, latest, stale } = await checkForUpdate(DEST_ROOT, {
+    force: true,
+  });
+
+  if (!installed) {
+    console.log(
+      `${yellow('Installed version unknown.')} ${dim(
+        'This project predates version stamping — run `hedgehog update` to refresh and stamp it.',
+      )}\n`,
+    );
+    return;
+  }
+  if (!latest) {
+    console.log(
+      `Installed: ${bold(installed)}\n${dim(
+        "Couldn't reach the npm registry — no update check performed.",
+      )}\n`,
+    );
+    return;
+  }
+  if (stale) {
+    console.log(
+      `${yellow(bold('Update available.'))} installed ${bold(installed)} → latest ${bold(latest)}\n\n` +
+        `  Run ${bold('npx @skyf0xx/hedgehog@latest update')} to refresh this project's agents and skills.\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`${green('Up to date.')} ${dim(`installed ${installed}, latest ${latest}`)}\n`);
+}
+
 async function update({ hosts }) {
   const targets = hosts?.length ? hosts : await installedHosts(DEST_ROOT);
 
@@ -614,10 +668,19 @@ async function update({ hosts }) {
     }
   }
 
+  // Stamped after the writes land, so the recorded version always
+  // describes the payload actually on disk.
+  const previous = await installedVersion(DEST_ROOT);
+  await recordVersion(DEST_ROOT, PKG_VERSION);
+
   const label = targets.map((h) => HOSTS[h].label).join(', ');
+  const versionNote =
+    previous && previous !== PKG_VERSION
+      ? `${previous} → ${PKG_VERSION}`
+      : PKG_VERSION;
   console.log(
     `\n${green(bold('Hedgehog agents/skills updated.'))} ${dim(
-      `${written} files written for ${label}`,
+      `${versionNote} — ${written} files written for ${label}`,
     )}\n`,
   );
   console.log('Next steps:');
@@ -1104,6 +1167,34 @@ function warnSingularModuleIdsAtPlan(core, db) {
   );
 }
 
+// The passive half of update detection. Printed to stderr, after a
+// command's real output, on the commands every host's loop runs anyway —
+// so a stale project surfaces itself without anyone thinking to ask.
+//
+// This lives in the CLI rather than in any one host's hook because every
+// host drives the same binary: Claude Code, Cursor, and Gemini CLI all
+// reach it through `hedgehog next`, and one implementation here covers
+// all of them.
+//
+// Never throws and never blocks: the answer comes from a day-long cache,
+// a missing or unreachable registry reads as "no news", and the notice is
+// skipped entirely when output isn't a terminal so it can't corrupt
+// anything parsing stdout.
+async function noteAvailableUpdate() {
+  if (process.env.HEDGEHOG_NO_UPDATE_CHECK) return;
+  try {
+    const { installed, latest, stale } = await checkForUpdate(DEST_ROOT);
+    if (!stale) return;
+    console.error(
+      `\n${yellow(bold('Hedgehog update available.'))} ${dim(
+        `${installed} → ${latest}. Run \`npx @skyf0xx/hedgehog@latest update\` to refresh this project's agents and skills.`,
+      )}`,
+    );
+  } catch {
+    // Advisory only — a failed check is never worth failing a command over.
+  }
+}
+
 async function nextCommand() {
   await ensureDb();
 
@@ -1140,6 +1231,7 @@ async function nextCommand() {
       return;
     }
     console.log(`${dim('No ready task.')} Nothing is planned with all dependencies complete.\n`);
+    await noteAvailableUpdate();
     return;
   }
 
@@ -1156,6 +1248,7 @@ async function nextCommand() {
   }
 
   console.log(formatNext(packet, await resolveCoreId(), packetExists));
+  await noteAvailableUpdate();
 }
 
 function printStalledTasks(stalled) {
@@ -1825,6 +1918,8 @@ async function statusCommand() {
 
   const warningLines = await coreWarningLines();
   if (warningLines.length > 0) console.log(warningLines.join('\n'));
+
+  await noteAvailableUpdate();
 }
 
 // `hedgehog ready` — read-only preview of what a `hedgehog claim` call
@@ -2441,6 +2536,10 @@ async function main() {
   }
 
   if (cmd === 'update') {
+    if (args.includes('--check')) {
+      await updateCheck();
+      return;
+    }
     await update({ hosts });
     return;
   }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -17,8 +17,139 @@ set -euo pipefail
 # (other hosts, direct invocation in tests).
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
 
-# Already a Hedgehog project. Stay out of the way.
+# JSON-escape via bash parameter substitution: one C-level pass per rule,
+# rather than a character-by-character loop.
+escape_for_json() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\r'/\\r}"
+    s="${s//$'\t'/\\t}"
+    printf '%s' "$s"
+}
+
+# Emit one context payload in whichever shape the current host reads.
+#
+# Hosts read different fields:
+#   Cursor          -> additional_context (snake_case, top level)
+#   Claude Code     -> hookSpecificOutput.additionalContext (nested)
+#   SDK standard    -> additionalContext (top level)
+# Claude Code reads both additional_context and hookSpecificOutput without
+# deduplicating, so emit only the field the current host consumes.
+#
+# printf rather than a heredoc here: bash 5.3+ can hang on heredocs in this
+# position (see obra/superpowers#571).
+#
+# The payload goes through %s and the JSON structure is written as literal
+# newlines inside the format string. Putting \n escapes in the format string
+# instead would make printf re-interpret the \n sequences that escape_for_json
+# just produced, turning them back into raw newlines and emitting invalid JSON.
+emit_context() {
+    local escaped
+    escaped=$(escape_for_json "$1")
+
+    if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
+        printf '{
+  "additional_context": "%s"
+}
+' "$escaped"
+    elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
+        printf '{
+  "hookSpecificOutput": {
+    "hookEventName": "SessionStart",
+    "additionalContext": "%s"
+  }
+}
+' "$escaped"
+    else
+        printf '{
+  "additionalContext": "%s"
+}
+' "$escaped"
+    fi
+}
+
+# Is the installed plugin behind the marketplace it came from?
+#
+# The plugin ships often, and a stale copy is invisible: the skill and this
+# gate still load, they're just an older version's text. The host owns the
+# install directory, so this only ever reports — updating is the user's
+# command to run.
+#
+# Entirely local: the marketplace is a git clone the host already maintains,
+# so comparing the manifest version there against the installed one costs no
+# network call and cannot hang a session start.
+plugin_update_notice() {
+    [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || return 0
+    command -v git >/dev/null 2>&1 || return 0
+
+    # .../plugins/cache/<marketplace>/<plugin>/<version> — the marketplace
+    # clone sits at .../plugins/marketplaces/<marketplace>.
+    local plugins_root marketplace installed_version manifest latest
+    plugins_root="${CLAUDE_PLUGIN_ROOT%/cache/*}"
+    [ "$plugins_root" != "$CLAUDE_PLUGIN_ROOT" ] || return 0
+    installed_version="$(basename "$CLAUDE_PLUGIN_ROOT")"
+    marketplace="${CLAUDE_PLUGIN_ROOT#"${plugins_root}"/cache/}"
+    marketplace="${marketplace%%/*}"
+
+    local clone="${plugins_root}/marketplaces/${marketplace}"
+    [ -d "${clone}/.git" ] || return 0
+
+    # Read the manifest from the tracked remote branch, not the working
+    # tree. The working tree is whatever the host last pulled, so a
+    # published update is invisible there until the host happens to
+    # refresh — which is precisely the staleness this is meant to catch.
+    local branch
+    branch="$(git -C "$clone" symbolic-ref --quiet --short HEAD 2>/dev/null || echo master)"
+    manifest="$(git -C "$clone" show "origin/${branch}:.claude-plugin/marketplace.json" 2>/dev/null)"
+    [ -n "$manifest" ] || return 0
+
+    # Only the version field, and only from the hedgehog entry. sed rather
+    # than a JSON parser: no node dependency in a hook that must stay fast
+    # and must never fail a session start.
+    latest="$(printf '%s\n' "$manifest" \
+        | sed -n '/"name"[[:space:]]*:[[:space:]]*"hedgehog"/,/}/p' \
+        | sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+    [ -n "$latest" ] || return 0
+    [ "$latest" != "$installed_version" ] || return 0
+
+    # Sort -V decides direction: report only when the marketplace is ahead,
+    # never when a locally-built plugin is ahead of it.
+    [ "$(printf '%s\n%s\n' "$installed_version" "$latest" | sort -V | tail -1)" = "$latest" ] || return 0
+    [ "$installed_version" != "unknown" ] || return 0
+
+    printf '# Hedgehog plugin update available\n\nThe installed Hedgehog plugin is version %s; version %s is published.\n\nMention this to the user once, briefly, and tell them to run:\n\n    claude plugin update hedgehog\n\nDo not run it yourself and do not repeat it later in the session.\n\n' \
+        "$installed_version" "$latest"
+}
+
+plugin_notice="$(plugin_update_notice 2>/dev/null || true)"
+
+# Refresh the remote ref the check above reads, for the next session
+# rather than this one. Fully detached and discarded: a session start must
+# never wait on the network, so this session reports against whatever was
+# already fetched and the fetch it kicks off lands in time for the next.
+refresh_marketplace_ref() {
+    [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || return 0
+    command -v git >/dev/null 2>&1 || return 0
+    local plugins_root marketplace clone
+    plugins_root="${CLAUDE_PLUGIN_ROOT%/cache/*}"
+    [ "$plugins_root" != "$CLAUDE_PLUGIN_ROOT" ] || return 0
+    marketplace="${CLAUDE_PLUGIN_ROOT#"${plugins_root}"/cache/}"
+    marketplace="${marketplace%%/*}"
+    clone="${plugins_root}/marketplaces/${marketplace}"
+    [ -d "${clone}/.git" ] || return 0
+    ( git -C "$clone" fetch --quiet origin >/dev/null 2>&1 & ) >/dev/null 2>&1
+}
+refresh_marketplace_ref || true
+
+# Already a Hedgehog project. Its own installed payload owns the session, so
+# the offer gate stays silent — but a stale plugin is still worth one line,
+# since that's true regardless of whether this project is installed.
 if [ -d "${PROJECT_DIR}/.hedgehog" ]; then
+    if [ -n "$plugin_notice" ]; then
+        emit_context "$plugin_notice"
+    fi
     exit 0
 fi
 
@@ -130,52 +261,6 @@ resolve it by starting the work outside the discipline and reporting it
 afterward.
 GATE
 
-# JSON-escape via bash parameter substitution: one C-level pass per rule,
-# rather than a character-by-character loop.
-escape_for_json() {
-    local s="$1"
-    s="${s//\\/\\\\}"
-    s="${s//\"/\\\"}"
-    s="${s//$'\n'/\\n}"
-    s="${s//$'\r'/\\r}"
-    s="${s//$'\t'/\\t}"
-    printf '%s' "$s"
-}
-
-gate_escaped=$(escape_for_json "$gate_text")
-
-# Hosts read different fields:
-#   Cursor          -> additional_context (snake_case, top level)
-#   Claude Code     -> hookSpecificOutput.additionalContext (nested)
-#   SDK standard    -> additionalContext (top level)
-# Claude Code reads both additional_context and hookSpecificOutput without
-# deduplicating, so emit only the field the current host consumes.
-#
-# printf rather than a heredoc here: bash 5.3+ can hang on heredocs in this
-# position (see obra/superpowers#571).
-#
-# The payload goes through %s and the JSON structure is written as literal
-# newlines inside the format string. Putting \n escapes in the format string
-# instead would make printf re-interpret the \n sequences that escape_for_json
-# just produced, turning them back into raw newlines and emitting invalid JSON.
-if [ -n "${CURSOR_PLUGIN_ROOT:-}" ]; then
-    printf '{
-  "additional_context": "%s"
-}
-' "$gate_escaped"
-elif [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -z "${COPILOT_CLI:-}" ]; then
-    printf '{
-  "hookSpecificOutput": {
-    "hookEventName": "SessionStart",
-    "additionalContext": "%s"
-  }
-}
-' "$gate_escaped"
-else
-    printf '{
-  "additionalContext": "%s"
-}
-' "$gate_escaped"
-fi
+emit_context "${plugin_notice}${gate_text}"
 
 exit 0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "4.3.6",
+  "version": "4.4.0",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/src/hosts/version.mjs
+++ b/src/hosts/version.mjs
@@ -1,0 +1,154 @@
+// What version of the payload a project has, and whether a newer one exists.
+//
+// `init` and `update` stamp the version they wrote into
+// `.hedgehog/version.json`. Without that stamp a project's installed
+// agents and skills are indistinguishable from any other release's, so
+// staleness can only be discovered by reading the files themselves.
+//
+// The registry lookup is cached and best-effort: a project that can't
+// reach npm, or is offline entirely, gets no answer rather than an error.
+// Nothing here is on the path of any command that has real work to do.
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+const VERSION_PATH = '.hedgehog/version.json';
+const REGISTRY_URL = 'https://registry.npmjs.org/@skyf0xx/hedgehog/latest';
+
+// How long a registry answer stays good. The payload ships daily, so a
+// once-a-day question matches how often the answer can actually change,
+// and keeps a session that runs many commands to a single network call.
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+// The check is advisory — it must never delay a command that has real
+// work to do, so a registry that hangs is treated the same as one that
+// says nothing.
+const FETCH_TIMEOUT_MS = 1500;
+
+/**
+ * Record the payload version now installed in `root`. Called by both
+ * `init` and `update`, so the stamp tracks the payload on disk rather
+ * than whichever release first landed.
+ */
+export async function recordVersion(root, version) {
+  const path = join(root, VERSION_PATH);
+  const prior = await readVersionFile(root);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(
+    path,
+    `${JSON.stringify({ ...prior, version, installedAt: new Date().toISOString() }, null, 2)}\n`,
+  );
+  return version;
+}
+
+async function readVersionFile(root) {
+  try {
+    return JSON.parse(await readFile(join(root, VERSION_PATH), 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * The payload version installed in `root`, or null for a project
+ * installed before the stamp existed.
+ */
+export async function installedVersion(root) {
+  const { version } = await readVersionFile(root);
+  return typeof version === 'string' ? version : null;
+}
+
+/**
+ * Compare two semver strings. Returns true when `a` is strictly newer
+ * than `b`. Prerelease tags sort before their release, matching semver;
+ * anything unparseable compares as equal so a malformed version can
+ * never fabricate an update prompt.
+ */
+export function isNewer(a, b) {
+  const parse = (v) => {
+    const m = /^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$/.exec(String(v ?? '').trim());
+    return m
+      ? { nums: [+m[1], +m[2], +m[3]], pre: m[4] ?? null }
+      : null;
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  if (!pa || !pb) return false;
+  for (let i = 0; i < 3; i++) {
+    if (pa.nums[i] !== pb.nums[i]) return pa.nums[i] > pb.nums[i];
+  }
+  // Equal release numbers: a release outranks its own prereleases.
+  if (pa.pre === pb.pre) return false;
+  if (pa.pre === null) return true;
+  if (pb.pre === null) return false;
+  return pa.pre > pb.pre;
+}
+
+/**
+ * The newest published version, from cache when it's fresh and from the
+ * registry otherwise. Returns null on any failure — offline, timeout,
+ * rate limit, malformed response. A null answer means "don't know", and
+ * every caller treats that as "say nothing".
+ */
+export async function latestVersion(root, { force = false } = {}) {
+  const cached = await readVersionFile(root);
+  if (!force && cached.checkedAt && cached.latest) {
+    const age = Date.now() - Date.parse(cached.checkedAt);
+    if (age >= 0 && age < CACHE_TTL_MS) return cached.latest;
+  }
+
+  const latest = await fetchLatest();
+  if (!latest) return null;
+
+  // Cache alongside the install stamp rather than in a separate file, so
+  // one read answers both halves of the question.
+  const path = join(root, VERSION_PATH);
+  try {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(
+      path,
+      `${JSON.stringify({ ...cached, latest, checkedAt: new Date().toISOString() }, null, 2)}\n`,
+    );
+  } catch {
+    // A read-only or missing .hedgehog just means no caching; the
+    // answer we fetched is still good for this call.
+  }
+  return latest;
+}
+
+async function fetchLatest() {
+  try {
+    // No `accept` header. The abbreviated-metadata type
+    // (application/vnd.npm.install-v1+json) is only valid on the
+    // packument root — sending it to /latest returns 406, which this
+    // function would swallow as "no answer" and the check would
+    // silently never fire. Plain /latest returns just the one version
+    // object, which is also far smaller than the full packument.
+    const res = await fetch(REGISTRY_URL, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    const { version } = await res.json();
+    return typeof version === 'string' ? version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The full staleness picture for a project: what's installed, what's
+ * published, and whether the gap is worth telling anyone about.
+ *
+ * `stale` is true only when both versions are known and the published
+ * one is newer — an unknown on either side reads as "no", so a project
+ * installed before stamping and an offline machine both stay quiet.
+ */
+export async function checkForUpdate(root, { force = false } = {}) {
+  const installed = await installedVersion(root);
+  const latest = await latestVersion(root, { force });
+  return {
+    installed,
+    latest,
+    stale: Boolean(installed && latest && isNewer(latest, installed)),
+  };
+}


### PR DESCRIPTION
Hedgehog ships close to daily, so an installed copy goes stale fast and
nothing tells anyone. Two things go stale independently, and they update
by different mechanisms:

| | What goes stale | How it updates | Who owns it |
|---|---|---|---|
| **npm payload** | the agents/skills copied into a project | `npx @skyf0xx/hedgehog@latest update` | the project |
| **plugin** | the global offer gate + hooks | `claude plugin update hedgehog` | the host |

A user can easily have a current plugin and a year-old repo payload.

## Detecting a stale payload

`init` and `update` stamp the version they wrote into
`.hedgehog/version.json`. Nothing recorded this before, so an installed
payload was indistinguishable from any other release's.

That stamp is compared against the newest published release two ways:

- **Passive** — a one-line notice on `status` and `next`, so a stale
  project surfaces itself without anyone thinking to ask.
- **Explicit** — `hedgehog update --check`, which exits 1 when a newer
  release exists and writes nothing.

The lookup is cached for a day and best-effort: offline, timeout, or an
unstamped project all read as "no news". The notice goes to stderr and is
skipped under `HEDGEHOG_NO_UPDATE_CHECK`, so it can't corrupt anything
parsing stdout.

## Every host, not just Claude Code

The notice lives in the CLI rather than in any host's hook, because all
three hosts drive the same binary — 12 skill/agent files call `hedgehog
status`/`next`, and those ship verbatim to every host. One implementation
reaches Claude Code, Cursor, and Gemini CLI, including Gemini CLI, which
has no hook mechanism at all.

Verified on a real three-host install: one `update` refreshed 165 files
across all three in a single pass.

| Host | Payload | Plugin |
|---|---|---|
| Claude Code | CLI notice + `--check` | session-start notice |
| Cursor | CLI notice + `--check` | session-start notice |
| Gemini CLI | CLI notice + `--check` | n/a — no plugin exists |

The plugin check is Claude Code and Cursor only by design, not oversight:
Gemini CLI installs the npm payload directly and has no plugin to be
stale.

## Detecting a stale plugin

The host owns the plugin directory, so the `SessionStart` hook reports
and names the command rather than writing behind the host's back. The
notice is independent of the `.hedgehog` offer gate, making it the one
thing emitted into an already-installed project.

## Two bugs found while building this

Both would have made the feature silently never fire:

- **Registry 406.** npm's abbreviated-metadata `accept` header is only
  valid on the packument root; sending it to `/latest` returns 406, which
  the `res.ok` guard swallowed as "no answer". Dropping the header fixes
  it and returns ~47KB less data.
- **Reading the working tree.** The plugin check first read the
  marketplace clone's checked-out manifest — which is whatever the host
  last pulled, so a published update is invisible there until the host
  refreshes, precisely the staleness being checked for. This repo's own
  machine proved it: installed 1.2.0, working tree 1.2.0, `origin/master`
  1.3.0. It now reads `origin/<branch>` via `git show`, with a detached
  fetch keeping that ref current.

## Verification

`npm run check` and all 58 reproductions pass. Beyond that, tested
against the live registry (stale/current/ahead), the real stale 1.2.0
plugin, and the failure paths that must never break a session start — no
`CLAUDE_PLUGIN_ROOT`, missing clone, `version: "unknown"`, local ahead of
marketplace, and Cursor's `additional_context` field. All emit valid
JSON. Hook runtime ~65ms with no network wait; cache confirmed at 398ms
first call, ~77ms after.

## Versions

npm 4.3.6 → 4.4.0 (`src/`, `bin/`) and plugin 1.3.0 → 1.4.0 (`hooks/`),
bumped independently per their own triggers. The plugin bump is what a
marketplace update check reads to know a new version exists — the
mechanism this change depends on.

No tag pushed: `publish.yml` creates `v4.4.0` from the merge commit.

## Known limit

The plugin check detects staleness one session late on a cold clone: the
first session reports against the already-fetched ref, and the fetch it
starts lands for the next. Blocking session start on a network call
seemed the worse trade.
