### PR TITLE
fix: name the plugin update command that actually works

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": {
     "name": "skyf0xx"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,13 @@ discipline's stance and rationale.
   recorded in the install path against the marketplace clone's
   `origin/<branch>` manifest, read locally with no network wait — which
   is independent of that gate and so is the one thing it emits into an
-  already-installed project. `hooks.json` (Claude Code) and `hooks-cursor.json`
+  already-installed project. Updating a plugin takes two commands
+  (`claude plugin marketplace update <marketplace>`, then `claude plugin
+  update hedgehog@<marketplace>`): the first fetches the new version, the
+  second installs it, and `update` resolves only the qualified
+  `plugin@marketplace` id — a bare plugin name fails. The notice reads
+  the marketplace name from the install path so a fork's own name comes
+  through. `hooks.json` (Claude Code) and `hooks-cursor.json`
   (Cursor) register it; `run-hook.cmd` is a cmd/bash polyglot so the hook
   runs on Windows, and hook scripts stay extensionless because Claude
   Code prepends `bash` to any command containing `.sh`. Part of the

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -119,8 +119,17 @@ plugin_update_notice() {
     [ "$(printf '%s\n%s\n' "$installed_version" "$latest" | sort -V | tail -1)" = "$latest" ] || return 0
     [ "$installed_version" != "unknown" ] || return 0
 
-    printf '# Hedgehog plugin update available\n\nThe installed Hedgehog plugin is version %s; version %s is published.\n\nMention this to the user once, briefly, and tell them to run:\n\n    claude plugin update hedgehog\n\nDo not run it yourself and do not repeat it later in the session.\n\n' \
-        "$installed_version" "$latest"
+    # Two steps, and the qualified plugin@marketplace id in the second.
+    # `claude plugin update` resolves its argument as that id — the bare
+    # plugin name fails with "Plugin not found" — and it offers only the
+    # version the marketplace has already fetched, so refreshing the
+    # marketplace first is what makes the new version available at all.
+    #
+    # The marketplace name is read from the install path rather than
+    # hardcoded, so a plugin installed from a fork or a differently-named
+    # marketplace still gets a command that works.
+    printf '# Hedgehog plugin update available\n\nThe installed Hedgehog plugin is version %s; version %s is published.\n\nMention this to the user once, briefly, and tell them to run both lines:\n\n    claude plugin marketplace update %s\n    claude plugin update hedgehog@%s\n\nBoth are needed: the first fetches the new version, the second installs\nit, and it takes effect on restart. Do not run them yourself and do not\nrepeat this later in the session.\n\n' \
+        "$installed_version" "$latest" "$marketplace" "$marketplace"
 }
 
 plugin_notice="$(plugin_update_notice 2>/dev/null || true)"


### PR DESCRIPTION
Follow-up to #141. The stale-plugin notice shipped in 1.4.0 told users to
run a command that does not work:

```
$ claude plugin update hedgehog
✘ Failed to update plugin "hedgehog": Plugin "hedgehog" not found
```

Found by using it — updating this machine's own plugin after #141 merged.

## Why it fails

Two separate reasons, both needed:

- `claude plugin update` resolves its argument as a qualified
  `plugin@marketplace` id. A bare plugin name is not found, even though
  `claude plugin list` shows the plugin as installed.
- It offers only the version the marketplace has already fetched. A stale
  marketplace clone cannot install a version it has not pulled, so the
  marketplace has to be refreshed first.

## The fix

The notice now emits both steps:

```
claude plugin marketplace update hedgehog
claude plugin update hedgehog@hedgehog
```

The marketplace name is read from the install path rather than
hardcoded, so a plugin installed from a fork or a differently-named
marketplace still gets a command that works. The notice also says the
change takes effect on restart, which is what the updater reports.

## Verification

Both emitted lines were run verbatim and succeed. All eight hook edge
cases still pass — stale (notice), current (silent), no
`CLAUDE_PLUGIN_ROOT`, no `/cache/` segment, missing clone,
`version: "unknown"`, local ahead of marketplace, and Cursor's
`additional_context` field — all emitting valid JSON. `npm run check` and
all 58 reproductions pass.

## Version

Plugin 1.4.0 → 1.4.1 across all three manifests. Scoped to `hooks/`, so
`package.json` stays at 4.4.0 and no npm republish is triggered.
