### PR TITLE
fix: keep a blank line between the update notice and the offer gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "author": {
     "name": "skyf0xx"
   },

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -128,11 +128,18 @@ plugin_update_notice() {
     # The marketplace name is read from the install path rather than
     # hardcoded, so a plugin installed from a fork or a differently-named
     # marketplace still gets a command that works.
-    printf '# Hedgehog plugin update available\n\nThe installed Hedgehog plugin is version %s; version %s is published.\n\nMention this to the user once, briefly, and tell them to run both lines:\n\n    claude plugin marketplace update %s\n    claude plugin update hedgehog@%s\n\nBoth are needed: the first fetches the new version, the second installs\nit, and it takes effect on restart. Do not run them yourself and do not\nrepeat this later in the session.\n\n' \
+    printf '# Hedgehog plugin update available\n\nThe installed Hedgehog plugin is version %s; version %s is published.\n\nMention this to the user once, briefly, and tell them to run both lines:\n\n    claude plugin marketplace update %s\n    claude plugin update hedgehog@%s\n\nBoth are needed: the first fetches the new version, the second installs\nit, and it takes effect on restart. Do not run them yourself and do not\nrepeat this later in the session.\n' \
         "$installed_version" "$latest" "$marketplace" "$marketplace"
 }
 
 plugin_notice="$(plugin_update_notice 2>/dev/null || true)"
+
+# Command substitution strips every trailing newline, so the blank line
+# that separates this notice from whatever follows it cannot be carried
+# out of the function — it has to be re-added here, at the join.
+if [ -n "$plugin_notice" ]; then
+    plugin_notice="${plugin_notice}"$'\n\n'
+fi
 
 # Refresh the remote ref the check above reads, for the next session
 # rather than this one. Fully detached and discarded: a session start must


### PR DESCRIPTION
Follow-up to #142. When a stale plugin met a project without `.hedgehog/`,
the two context blocks ran together:

```
...do not repeat this later in the session.# Hedgehog is available in this project
```

Found by rendering the notice from the installed 1.4.1 payload after #142
merged.

## Cause

The notice's `printf` ends in `\n\n`, but it is captured with
`$(...)`, and command substitution strips every trailing newline. The
separator could never survive being carried out of the function.

Only the both-blocks path was affected. The notice-alone path (stale
plugin in an already-installed project) has nothing after it, so it
looked correct — which is why earlier testing missed this.

## Fix

Own the separator at the join, where nothing can strip it, rather than
relying on newlines surviving capture.

## Verification

Nine hook cases pass, now including an explicit assertion that the two
blocks never run together: stale+uninstalled (the regression),
stale+installed, current, no `CLAUDE_PLUGIN_ROOT`, no `/cache/` segment,
missing clone, `version: "unknown"`, local ahead of marketplace, and
Cursor's `additional_context` field. All emit valid JSON. `npm run check`
and all 58 reproductions pass.

## Version

Plugin 1.4.1 → 1.4.2. Scoped to `hooks/`, so `package.json` stays at
4.4.0 and no npm republish is triggered.
