### PR TITLE
fix: release workflow's version diff misses multi-commit pushes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - package.json
+  workflow_dispatch: {}
 
 permissions:
   contents: write
@@ -18,12 +19,24 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
+      # On a push, "before" is package.json at the pre-push state of the
+      # branch (github.event.before), so any number of commits landing in
+      # one push is still compared correctly. workflow_dispatch carries no
+      # push event to read that from, so a manual run instead compares
+      # against the version actually live on npm right now — the real
+      # ground truth for whether this version still needs releasing.
       - id: version
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
-          before=$(git show HEAD^:package.json | node -p 'JSON.parse(require("fs").readFileSync(0, "utf8")).version' 2>/dev/null || echo "")
           after=$(node -p 'require("./package.json").version')
+          if [ -n "$BEFORE_SHA" ]; then
+            before=$(git show "$BEFORE_SHA:package.json" | node -p 'JSON.parse(require("fs").readFileSync(0, "utf8")).version' 2>/dev/null || echo "")
+          else
+            before=$(npm view "$(node -p 'require("./package.json").name')" version 2>/dev/null || echo "")
+          fi
           echo "before=$before" >> "$GITHUB_OUTPUT"
           echo "after=$after" >> "$GITHUB_OUTPUT"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,15 +130,19 @@ triggers and never touched by the same automation:
   those directories. **Commit the bump on the feature branch and let the
   PR merge it into `master` — do not tag or push the tag yourself.**
   `.github/workflows/publish.yml` watches every push to `master` that
-  changes `package.json`, diffs the version before/after that push, and
-  when it changed: tags `v<version>`, runs `npm publish`, and creates the
-  GitHub release, all on the runner's own token. A tag pushed by hand
-  ahead of the merge collides with that workflow's own `git push origin
-  "$TAG"` and fails the release (see git history around 2026-08-14 for
-  the incident this rule comes from). If a tag was pushed by mistake,
-  delete it (`git push origin --delete v<version>`) before the PR merges
-  so the workflow can create it fresh, pointing at the actual merge
-  commit.
+  changes `package.json`, diffs the version from before the push (however
+  many commits it carries) against after, and when it changed: tags
+  `v<version>`, runs `npm publish`, and creates the GitHub release, all on
+  the runner's own token. It also carries a `workflow_dispatch` trigger for
+  a manual run — there, with no push to read a prior state from, "before"
+  is whatever version is currently live on npm, so a manual run still only
+  acts when the committed version and the published version actually
+  differ. A tag pushed by hand ahead of the merge collides with that
+  workflow's own `git push origin "$TAG"` and fails the release (see git
+  history around 2026-08-14 for the incident this rule comes from). If a
+  tag was pushed by mistake, delete it (`git push origin --delete
+  v<version>`) before the PR merges so the workflow can create it fresh,
+  pointing at the actual merge commit.
 - `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`'s
   `version` fields (kept identical to each other) — the Claude Code
   plugin (`claude plugin install hedgehog`), whose payload is `skills/`


### PR DESCRIPTION
## What broke

`v5.0.0`'s merge to `master` landed as a rebase merge — nine commits applied
individually rather than one squashed commit. `.github/workflows/publish.yml`'s
version-diff step read `git show HEAD^:package.json`, comparing only the tip
commit against its immediate parent. The version bump was seven commits behind
the tip, so `HEAD^` already had `5.0.0` too — `before` and `after` came out
identical, and the workflow skipped tagging, `npm publish`, and the GitHub
release entirely. Confirmed directly: `npm view @skyf0xx/hedgehog version` is
still `4.4.0`, no `v5.0.0` tag exists, and the job's steps past the version
check all show `skipped`.

## The fix

The version-diff step now reads `github.event.before` — the real pre-push
state of the branch, correct regardless of how many commits the push carries
— instead of `HEAD^`. `fetch-depth` widens from `2` to `0` so that SHA is
reachable.

A `workflow_dispatch` trigger is also added, so a push whose diff came out
wrong can be recovered by re-running the same job manually rather than by
publishing or tagging by hand. A manual run carries no push event to read a
prior state from, so it instead compares the committed version against
whatever is actually live on npm right now.

`CLAUDE.md`'s Releasing section is updated to describe both paths.

## Verification

```
npx js-yaml .github/workflows/publish.yml   → valid YAML
```

No functional test of the push path is possible without an actual push to
master — this is a CI-only change, verified by inspection and the failure
this fixes is fully diagnosed above with real command output.