### PR TITLE
docs: fix stale core-design blueprint paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Artifact
 
 ### Anything else
 
-A CLI, a library, a browser extension, a data pipeline, etc. fitting neither shape gets its own build order, designed at intake rather than chosen from a menu — starting from a [battle-tested blueprint](src/skills/hedgehog-core-design/blueprints) for the system's shape where one exists.
+A CLI, a library, a browser extension, a data pipeline, etc. fitting neither shape gets its own build order, designed at intake rather than chosen from a menu — starting from a battle-tested blueprint (in [`hedgehog-core-authored`](https://github.com/skyf0xx/hedgehog-core-authored)'s `hedgehog-core-design` skill) for the system's shape where one exists.
 
 Run `init` with no core flag: planning intake names the system shape, picks
 the stack, derives the layers, and locks them to `.hedgehog/core.yaml`,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -55,15 +55,17 @@ this only serves the project's own public presence.
 
 ### New core-design blueprints
 
-`src/skills/hedgehog-core-design/blueprints/` covers nine shapes (CLI,
-library/SDK, browser extension, desktop app, game, data pipeline,
-bot/agent, compiler/language tool, infra/deploy tool) — each one a single
-25–60 line markdown file read at planning intake for a system shape that
-isn't `full-stack-app` or `landing-page`. Shapes not yet covered: an MCP
-server, a Slack/Discord bot, a monorepo-of-services, a static site
-generator plugin. Adding one is scoped to one new file plus a routing
-entry — model it on the shortest existing blueprint (`cli.md`) rather
-than the longest.
+`hedgehog-core-design`'s `blueprints/` (in the
+[`hedgehog-core-authored`](https://github.com/skyf0xx/hedgehog-core-authored)
+repo) covers nine shapes (CLI, library/SDK, browser extension, desktop app,
+game, data pipeline, bot/agent, compiler/language tool, infra/deploy tool)
+— each one a single 25–60 line markdown file read at planning intake for a
+system shape that isn't `full-stack-app` or `landing-page`. Shapes not yet
+covered: an MCP server, a Slack/Discord bot, a monorepo-of-services, a
+static site generator plugin. Adding one is scoped to one new file plus a
+routing entry — model it on the shortest existing blueprint (`cli.md`)
+rather than the longest. Lands as a PR against `hedgehog-core-authored`,
+not this repo.
 
 ### A generator layer as a quality bar for new opinionated cores
 


### PR DESCRIPTION
## Summary
- README and ROADMAP linked to `src/skills/hedgehog-core-design/blueprints`, a path that only existed before `authored` split into its own package (`hedgehog-core-authored`)
- Both now point at the blueprints directory in `hedgehog-core-authored`, and the ROADMAP item notes contributions there land as a PR against that repo, not this one

## Test plan
- [x] Grepped for remaining stale `src/skills/hedgehog-core-design` references — none left