### PR TITLE
docs: clarify core selection is an override, not a required step

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,23 +195,6 @@ npx @skyf0xx/hedgehog update
 
 This refreshes the installed agents and skills in a specific repo (note, not vendor skills)
 
-### Choosing a core yourself
-
-`init` with no flag lets planning intake pick the core by describing what
-you want to build — the normal path above. Pass `--core` to skip that
-and install a specific one directly:
-
-``` bash
-npx @skyf0xx/hedgehog init --core full-stack-app
-npx @skyf0xx/hedgehog cores list   # every core this release can install, and what each is for
-```
-
-Each named core ships as its own npm package:
-
-- [`@skyf0xx/hedgehog-core-full-stack-app`](https://github.com/skyf0xx/hedgehog-core-full-stack-app)
-- [`@skyf0xx/hedgehog-core-landing-page`](https://github.com/skyf0xx/hedgehog-core-landing-page)
-- [`@skyf0xx/hedgehog-core-authored`](https://github.com/skyf0xx/hedgehog-core-authored)
-
 ## Why Hedgehog
 
 Most AI coding tools improve prompting.

--- a/README.md
+++ b/README.md
@@ -195,7 +195,11 @@ npx @skyf0xx/hedgehog update
 
 This refreshes the installed agents and skills in a specific repo (note, not vendor skills)
 
-### Installing a specific core
+### Choosing a core yourself
+
+`init` with no flag lets planning intake pick the core by describing what
+you want to build — the normal path above. Pass `--core` to skip that
+and install a specific one directly:
 
 ``` bash
 npx @skyf0xx/hedgehog init --core full-stack-app


### PR DESCRIPTION
## Summary
- The manual `--core` install path sat under `## Install` with no framing, right after the normal path already told users to just describe what they want to build — reading as a required extra step rather than an override
- States plainly that `init` with no flag already lets planning intake pick the core from the project description, and `--core` is only for skipping that

## Test plan
- [x] Doc-only change; no code affected
- [x] Verified `no-history-in-output` compliance