### PR TITLE
fix: --version flag, better error hints, Cursor dispatch parity

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1222,7 +1222,9 @@ async function intentCommand(args) {
   try {
     intent = await addIntent(db, record);
   } catch (err) {
-    console.error(`${red('Failed to add intent:')} ${err.message}\n`);
+    console.error(
+      `${red('Failed to add intent:')} ${err.message}\n\nUsage: hedgehog intent add --id <id> --goal <goal> --outcome <outcome> [--rule <r>]... [--depends-on <id>]...\n   or: hedgehog intent add --file <path.json>\n`,
+    );
     process.exitCode = 1;
     return;
   } finally {
@@ -2612,7 +2614,9 @@ async function debtCommand(args) {
     try {
       entry = addDebt(db, { taskId, note });
     } catch (err) {
-      console.error(`${red('Failed to declare debt:')} ${err.message}\n`);
+      console.error(
+        `${red('Failed to declare debt:')} ${err.message}\n\nRun ${bold('hedgehog status')} to see valid task ids.\n`,
+      );
       process.exitCode = 1;
       return;
     } finally {
@@ -2696,6 +2700,10 @@ async function main() {
   const args = process.argv.slice(2);
   if (args.includes('--help') || args.includes('-h') || args.length === 0) {
     await help();
+    return;
+  }
+  if (args.includes('--version') || args.includes('-v')) {
+    console.log(PKG_VERSION);
     return;
   }
   const cmd = args[0];

--- a/src/hosts/cursor/DISPATCH.md
+++ b/src/hosts/cursor/DISPATCH.md
@@ -5,6 +5,9 @@ one, read its file and follow it for that task, passing the `hedgehog
 next` packet in full. Where a subagent is available, pass the file's
 entire body as that subagent's prompt — the file is the role.
 
+Independent steps can go out as several concurrent tool calls in one
+response. Steps that depend on each other stay sequential.
+
 Each agent file opens with the tools that role may use. Honor it: Cursor
 grants tools per session, so the constraint is yours to keep. `hedgehog
 verify` checks the touched files against the packet's ALLOWED SCOPE and


### PR DESCRIPTION
## Summary
- `hedgehog --version`/`-v` now works — `PKG_VERSION` was already loaded and used by `update`/`status`, but `main()` had no version handler, so it fell through to "Unknown command".
- `intent add` and `debt add` error messages now point to the next step (usage string / `hedgehog status`) instead of printing a bare error.
- Cursor's `DISPATCH.md` now states independent steps can dispatch as concurrent tool calls, matching guidance Gemini's `DISPATCH.md` already had (Claude Code's doesn't need it — parallel tool calls are a general capability there, not dispatch-specific).


## Test plan
- [x] `node bin/cli.mjs --version` and `-v` print the package version
- [x] `intent add` with a missing required flag prints the usage string
- [x] `debt add` with an unknown task id prints a pointer to `hedgehog status`
- [x] Verified Cursor's plugin install path (`~/.cursor/plugins/local/hedgehog`) against current Cursor docs — confirmed correct, no change needed there