### PR TITLE
fix: restore version to 5.1.0 regressed by prior hooks-fix merge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "1.4.3",
+      "version": "5.1.0",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "1.4.3",
+  "version": "5.1.0",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "1.4.3",
+  "version": "5.1.0",
   "author": {
     "name": "skyf0xx"
   },


### PR DESCRIPTION
## Summary
- PR #175 fixed a real hooks-manifest bug but was cut from a stale base (before the `chore: bump version to 5.1.0` commit landed on master). Its merge carried the branch's hardcoded `1.4.3` version string forward, silently regressing master's version from 5.1.0 back to 1.4.3.
- This restores `version` to `5.1.0` in all three manifests (`.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.cursor-plugin/plugin.json`) without touching the hooks fix itself.

Note: there's an unreleased `feat(planner)` commit on master on top of the 5.1.0 bump with no version bump of its own — leaving that versioning decision to you rather than guessing at a number.

## Test plan
- [x] `claude plugin validate .` passes
- [x] After merge, refresh and update the plugin locally, confirm version and no load errors