### PR TITLE
fix: surface pwa-app core in install skill and cross-repo docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "author": {
     "name": "skyf0xx"
   },

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,7 +20,7 @@ Tool grants are defense in depth. The enforcement is `hedgehog verify`, which ch
 
 ## Core resolution
 
-`src/agents/` and `src/skills/` above are shared by every core. Each core's own build agents, skills, and (for `full-stack-app` and `landing-page`) pre-built workspace ship in that core's own npm package rather than in this repo.
+`src/agents/` and `src/skills/` above are shared by every core. Each core's own build agents, skills, and (for `full-stack-app`, `pwa-app`, and `landing-page`) pre-built workspace ship in that core's own npm package rather than in this repo.
 
 `src/registry/cores.json` is the fixed table naming every core: its npm package, the version range `init` resolves, its install flag, its GitHub repository, and the `selects_when` prose `planner` reads aloud in Phase 0 to choose one. `init` resolves the requested core against that table (`src/registry/index.mjs`), then fetches the package with `npm pack` and extracts it (`src/registry/fetch.mjs`), caching the extraction at `~/.hedgehog/cores/<name>/<version>/` so a repeat install on the same version needs no network. The extracted package carries a `hedgehog-core.yaml` manifest at its root (`src/registry/manifest.mjs`) naming which agents, skills, vendored shelves, workspace, and CLAUDE.md section it contributes; the installer writes those into the consuming project alongside the shared agents and skills above. `installed.mjs` records which core and version a project installed, so `update` refreshes that core from the same package rather than re-resolving the registry.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@ discipline's stance and rationale.
 
 This repo is the engine: the CLI, the build graph, the host adapters, the
 core registry, and the agents and skills every core shares. Each core —
-`full-stack-app`, `landing-page`, `authored` — ships as its own npm
-package holding that core's workspace, agents, skills, and CLAUDE.md
+`full-stack-app`, `pwa-app`, `landing-page`, `authored` — ships as its own
+npm package holding that core's workspace, agents, skills, and CLAUDE.md
 section. `src/registry/cores.json` names them; `init` fetches the one a
 project asks for.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,10 +53,11 @@ follow:
 
 ## Stack changes
 
-Each core locks its own stack, in its own repo — `full-stack-app`'s and
-`landing-page`'s tables live in `ARCHITECTURE.md` here, but the workspace,
-agents, and skills that implement them live in that core's own npm
-package (`hedgehog-core-full-stack-app`, `hedgehog-core-landing-page`).
+Each core locks its own stack, in its own repo — `full-stack-app`'s,
+`pwa-app`'s, and `landing-page`'s tables live in `ARCHITECTURE.md` here,
+but the workspace, agents, and skills that implement them live in that
+core's own npm package (`hedgehog-core-full-stack-app`,
+`hedgehog-core-pwa-app`, `hedgehog-core-landing-page`).
 A stack is locked because it's what makes that core's build order
 mechanically enforced (Nx boundaries, phase gates, lefthook) rather than
 a convention the AI is asked to follow. Proposing a stack swap for an

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -90,20 +90,20 @@ blueprint (`cli.md`) rather than the longest. Lands as a PR against
 
 ### A generator layer as a quality bar for new opinionated cores
 
-`full-stack-app` is the only core with a scaffold layer of its own —
-`workspace/tools/generators/` (Nx generators for schema, contract,
-repository, service, controller, hook, and screen), driven by the
-`nx-generate` skill instead of an agent writing that boilerplate
-freehand. A core proposing a new pre-built workspace (one of the
-candidates above, or any future one) should propose what it generates
-alongside the workspace itself, not add a generator layer later as an
-afterthought — this is a first-class part of what makes a core's build
-order mechanically enforced rather than convention the AI is asked to
-follow.
+`full-stack-app` and `pwa-app` each carry a scaffold layer of their own —
+`workspace/tools/generators/`, driven by the `nx-generate` skill instead
+of an agent writing that boilerplate freehand: seven generators (schema,
+contract, repository, service, controller, hook, screen) on
+`full-stack-app`, three (feature, entity, integration) on `pwa-app`. A
+core proposing a new pre-built workspace (one of the candidates above, or
+any future one) should propose what it generates alongside the workspace
+itself, not add a generator layer later as an afterthought — this is a
+first-class part of what makes a core's build order mechanically
+enforced rather than convention the AI is asked to follow.
 Scope for any single such proposal: identify the repeatable per-module
 boilerplate the new core's build order produces, and design the
-generator(s) for it modeled on `full-stack-app`'s, as part of the same
-PR that proposes the workspace.
+generator(s) for it modeled on `full-stack-app`'s or `pwa-app`'s, as part
+of the same PR that proposes the workspace.
 
 ### New host support
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,11 +38,11 @@ consuming project installs. The interesting boundaries:
   from untrusted content, or that weakens a gate a project relies on,
   is a supply-chain issue.
 - **The core registry and fetcher** (`src/registry/`) — each core
-  (`full-stack-app`, `landing-page`, `authored`) ships as its own npm
-  package that `init` resolves and fetches; a bug here that lets a core
-  install from an unintended source, or that skips validating what it
-  fetched, is the same class of supply-chain issue as the payload
-  above.
+  (`full-stack-app`, `pwa-app`, `landing-page`, `authored`) ships as its
+  own npm package that `init` resolves and fetches; a bug here that lets
+  a core install from an unintended source, or that skips validating
+  what it fetched, is the same class of supply-chain issue as the
+  payload above.
 - **Prompt injection reaching an agent** through content it reads — a
   file in the working tree, a fetched page, an issue body. Reports here
   are welcome and are treated as real, not theoretical.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/skills/hedgehog/SKILL.md
+++ b/skills/hedgehog/SKILL.md
@@ -23,8 +23,17 @@ has already said yes — install rather than asking again.
 Run the matching command:
 
 - Full-stack app: `npx @skyf0xx/hedgehog init --ts-full-stack-app` — the
-  module-sequencing core, for persistent domain data with its own
-  lifecycle.
+  module-sequencing core, for server-side logic across most of the app:
+  authorization beyond row-level policies, background jobs or webhooks as
+  the app's primary function, server-rendered or SEO-critical pages, or a
+  working set too large for a device.
+- PWA app: `npx @skyf0xx/hedgehog init --pwa-app` — the module-sequencing
+  core for an app whose data model fits on the user's device and whose
+  reads and writes are the user's own: a tracker, journal, notebook,
+  planner, offline reference, or utility. Offline capability or
+  installability named explicitly is a strong signal. Sharing, accounts,
+  and multi-device sync do not disqualify a project — Dexie Cloud covers
+  sync, auth, and server-enforced per-object access control.
 - Landing page: `npx @skyf0xx/hedgehog init --landing-page` — a
   copy-and-conversion core, not just page scaffolding: structured skills
   for headline, hero, problem, mechanism, objection, proof, and CTA, plus
@@ -33,7 +42,7 @@ Run the matching command:
 - Anything else — CLI, library, browser extension, data pipeline, an
   existing codebase, or not yet clear from the conversation:
   `npx @skyf0xx/hedgehog init` with no core flag. Planning intake decides
-  from there, so prefer this over guessing between the two shipped cores.
+  from there, so prefer this over guessing between the shipped cores.
 
 Add a host flag when the user is on Cursor or Gemini CLI rather than
 Claude Code: `--cursor`, `--gemini`, `--host=claude,cursor`, or

--- a/src/db/plan.mjs
+++ b/src/db/plan.mjs
@@ -3,12 +3,12 @@
 // hedgehog-persistent-build-graph.md, "The build graph" and "Task
 // lifecycle", plus the readiness SELECT under "Schema".
 //
-// full-stack-app: one task per layer per intent (an intent is a domain
-// module — see the core definition's `{module}` placeholder). landing-page:
-// one task per phase, no module axis. Both are the same operation — walk
-// a core definition's layer chain once per intent — because a linear
-// chain is the degenerate case of the layer graph (spec: MVP scope
-// item 5).
+// full-stack-app and pwa-app: one task per layer per intent (an intent is
+// a domain module — see the core definition's `{module}` placeholder).
+// landing-page: one task per phase, no module axis. All three are the
+// same operation — walk a core definition's layer chain once per intent
+// — because a linear chain is the degenerate case of the layer graph
+// (spec: MVP scope item 5).
 //
 // Layer cardinality: a layer marked `once: true` in the core definition
 // opts out of that per-intent multiplication and compiles a single task

--- a/src/registry/index.mjs
+++ b/src/registry/index.mjs
@@ -1,9 +1,9 @@
 // Core package registry. One entry per Hedgehog core — full-stack-app,
-// landing-page, authored — naming the npm package that ships its agents,
-// skills, and (for the two shipped cores) scaffold, plus the CLI flag
-// `hedgehog init` accepts for it and the prose `planner` reads aloud in
-// Phase 0 to choose one. A fixed table, one entry per core, discovered by
-// name or flag rather than convention.
+// pwa-app, landing-page, authored — naming the npm package that ships its
+// agents, skills, and (for the three shipped cores) scaffold, plus the CLI
+// flag `hedgehog init` accepts for it and the prose `planner` reads aloud
+// in Phase 0 to choose one. A fixed table, one entry per core, discovered
+// by name or flag rather than convention.
 //
 // `authored` carries no flag — it is never selected off a fixed list at
 // install time. hedgehog-core-design chooses it during planning, from the


### PR DESCRIPTION
## Summary

`skills/hedgehog/SKILL.md` — the instructions an agent follows to run `hedgehog init` — hardcoded only `--ts-full-stack-app` and `--landing-page` as options, so an agent would never select `--pwa-app` even though the core is fully registered and live in `src/registry/cores.json`. `hedgehog init --pwa-app` itself worked correctly the whole time; the bug was that agent-facing guidance duplicating the core list by hand never got updated when `pwa-app` was registered.

Fixes that entry point, then sweeps every other place the two original shipped cores were enumerated by hand and brings `pwa-app` into each: `CLAUDE.md`, `SECURITY.md`, `ARCHITECTURE.md`, `ROADMAP.md`, `CONTRIBUTING.md`, and code comments in `src/registry/index.mjs` and `src/db/plan.mjs`. `planner.md` and `hedgehog-planning-intake/SKILL.md` were already current and needed no change.

Out of scope: `repro/` test fixtures and `scripts/check.mjs`'s shipped-core loops still iterate only the original two cores. Extending those to `pwa-app` needs real pwa-app fixtures and test cases authored deliberately, which is separate test-coverage work rather than a docs/instructions sync.

Bumps `package.json`, `.claude-plugin/plugin.json`, `.cursor-plugin/plugin.json`, and `.claude-plugin/marketplace.json` from 5.1.0 → 5.1.1 (patch — no behavior change to the CLI or registry).

## Test plan

- [x] `node scripts/check.mjs` — passes (`4 agents, 4 skills, 4 cores, tarball, CLI`)
- [x] `node --experimental-sqlite repro/run-all.mjs` — all 56 reproductions pass
- [x] Manually confirmed `src/registry/cores.json` already listed `pwa-app` correctly before this change — the registry was never the problem