### PR TITLE
fix: surface pwa-app core in session-start offer gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "author": {
     "name": "skyf0xx"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,17 @@ only bumps the plugin version; a change touching both (as most
 `src/skills/hedgehog-*` fixes end up also touching the top-level
 `skills/hedgehog` offer skill) bumps both, in the same PR.
 
+Adding or changing a core in `src/registry/cores.json` also touches a set
+of places that enumerate cores by hand rather than reading the registry,
+and each one drifts silently if skipped — no error surfaces, the text just
+goes stale. Sweep all of them in the same PR as the registry change:
+`skills/hedgehog/SKILL.md`, `hooks/session-start`'s gate text, `CLAUDE.md`,
+`SECURITY.md`, `ARCHITECTURE.md`, `ROADMAP.md`, `CONTRIBUTING.md`, and the
+code comments in `src/registry/` and `src/db/`. `hooks/session-start` is
+easy to miss because it isn't under `skills/`, but it ships as part of the
+plugin payload and needs the same plugin-version bump as everything else
+in this list.
+
 ## Working in this repo
 
 This repo's own content is the product. Changes here are edits to the

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -182,8 +182,19 @@ ships structured skills for headline, hero, problem, mechanism, objection,
 proof, and CTA, plus signature-element design and a review loop. A page whose
 problem is "the copy is weak" or "it doesn't convert" is that core's central
 case, not an edge case — positioning and copy are exactly what it is made of.
-`full-stack-app` is the module-sequencing one. Judge a request against the
-core that fits it, not against a single core's shape.
+`full-stack-app` and `pwa-app` are the two module-sequencing cores, split by
+where the data lives. `pwa-app` fits an app whose data model fits on the
+user's device and whose reads and writes are the user's own — a tracker,
+journal, notebook, planner, offline reference, or utility; offline capability
+or installability named explicitly is a strong signal. Sharing, accounts, and
+multi-device sync do not push a project to `full-stack-app` by themselves —
+`pwa-app` covers those through Dexie Cloud, and even a server-authoritative
+entity or two (a points balance, a reward ledger) can live in an otherwise
+local-first `pwa-app` build. `full-stack-app` is for server-side logic across
+most of the app: authorization beyond row-level security, background jobs or
+webhooks as the app's primary function, server-rendered or SEO-critical pages,
+or a working set too large for a device. Judge a request against the core
+that fits it, not against a single core's shape.
 
 This project does not have it installed (no `.hedgehog/` directory).
 
@@ -227,10 +238,10 @@ Hedgehog.
 **The user named Hedgehog.** Consent is already in the request — "build me a
 todo app with Hedgehog" is a yes, not an opening to ask for one. Do not ask
 whether to install. Invoke the `hedgehog` skill and follow it. Use what the
-user already said to pick the core (full-stack app, landing page, or an
-existing codebase to adopt); if the core is genuinely unclear from the
-conversation, ask about that alone, and prefer the no-flag install that lets
-planning intake decide over stalling on a question.
+user already said to pick the core (full-stack app, PWA/local-first app,
+landing page, or an existing codebase to adopt); if the core is genuinely
+unclear from the conversation, ask about that alone, and prefer the no-flag
+install that lets planning intake decide over stalling on a question.
 
 **The user did not name Hedgehog.** Ask directly: "Want me to set up Hedgehog
 here?" Say briefly what it means — a build discipline of agents and skills,
@@ -249,10 +260,10 @@ Once the user has asked for it, build it that way. This section is the one to
 re-read at the moment skipping starts to look reasonable.
 
 - **Never propose a thinner version of what the user asked for.** If they
-  describe an app that stores things, that is `full-stack-app` with a real
-  database — do not float localStorage, an in-memory array, or a single HTML
-  file as the easier option, and do not present one as a starting point to
-  migrate off later. That migration is the debt.
+  describe an app that stores things, that is `full-stack-app` or `pwa-app`
+  with a real persistence layer — do not float localStorage, an in-memory
+  array, or a single HTML file as the easier option, and do not present one
+  as a starting point to migrate off later. That migration is the debt.
 - **Skipping the discipline is itself the thinnest version**, even when the
   artifact you would build without it looks identical on screen. What goes
   missing is the core's own skills, loops, and gates — and nothing errors to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary
- `hooks/session-start`'s injected gate text still described only `full-stack-app` and `landing-page` as the module-sequencing cores, so an agent following it would route a local-first app (tracker, journal, notebook, planner) to `full-stack-app` instead of `pwa-app`, even though `pwa-app` has been live in `src/registry/cores.json` for a while.
- The prior pwa-app docs sync (#177) swept `SKILL.md` and the other hand-enumerated docs but missed this file, since it isn't under `skills/`.
- Brings the gate text's core description, "how to offer" core list, and "never propose a thinner version" bullet in line with `pwa-app`'s actual `selects_when` criteria.
- Adds a note to `CLAUDE.md`'s Releasing section listing every place a core addition needs to be swept by hand, so this doesn't get missed a third time.
- Bumps `package.json`, both plugin manifests, and the marketplace manifest from 5.1.1 to 5.1.2.

## Test plan
- [x] `node scripts/check.mjs` passes (`ok — 4 agents, 4 skills, 4 cores, tarball, CLI`)
- [x] `bash -n hooks/session-start` passes (heredoc edits didn't break syntax)
- [x] Confirm a fresh session in a `pwa-app`-shaped project now offers `pwa-app` correctly (manual verification once merged/published)