### PR TITLE
fix: allow authorized self-update of Hedgehog plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "5.1.2",
+      "version": "5.1.3",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "author": {
     "name": "skyf0xx"
   },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "1.0.0",
+  "version": "5.1.3",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -128,7 +128,7 @@ plugin_update_notice() {
     # The marketplace name is read from the install path rather than
     # hardcoded, so a plugin installed from a fork or a differently-named
     # marketplace still gets a command that works.
-    printf '# Hedgehog plugin update available\n\nThe installed Hedgehog plugin is version %s; version %s is published.\n\nMention this to the user once, briefly, and tell them to run both lines:\n\n    claude plugin marketplace update %s\n    claude plugin update hedgehog@%s\n\nBoth are needed: the first fetches the new version, the second installs\nit, and it takes effect on restart. Do not run them yourself and do not\nrepeat this later in the session.\n' \
+    printf '# Hedgehog plugin update available\n\nThe installed Hedgehog plugin is version %s; version %s is published.\n\nMention this to the user once, briefly. If they authorize it, run both\nlines yourself via Bash:\n\n    claude plugin marketplace update %s\n    claude plugin update hedgehog@%s\n\nBoth are needed: the first fetches the new version, the second installs\nit, and it takes effect on restart. Do not run them without the user\nauthorizing it first, and do not repeat this notice later in the\nsession.\n' \
         "$installed_version" "$latest" "$marketplace" "$marketplace"
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "1.0.0",
+  "version": "5.1.3",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Summary
- The session-start update notice told the agent to only ever relay the two update commands for the user to run manually, with an unconditional "do not run them yourself." This blocked the agent from running the update even when the user explicitly authorized it in-session.
- Notice now instructs the agent to run both commands itself once the user authorizes it.
- Bumps plugin version to 5.1.3 across all manifests (package.json, Claude/Cursor plugin manifests, marketplace.json, and both gemini-extension.json copies), since 5.1.2 is already published without this fix.

## Test plan
- [x] `bash -n hooks/session-start` passes
- [x] All edited JSON files validated with `python3 -m json.load`
- [ ] Manual: trigger session start against a stale local install and confirm the agent offers to run the update when authorized