### PR TITLE
fix: self-heal a stale or missing global hedgehog install

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -17,7 +17,7 @@ import { cp, mkdir, access, readdir, stat, rm, readFile, writeFile } from 'node:
 import { constants, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, relative, resolve } from 'node:path';
-import { spawn } from 'node:child_process';
+import { spawn, execFileSync } from 'node:child_process';
 import { dbInit, DB_PATH, dbAbsPath, openDb } from '../src/db/init.mjs';
 import { loadCore, lintCore, isModuleAxis } from '../src/db/core.mjs';
 import { planTasks, CORE_INTENT_ID } from '../src/db/plan.mjs';
@@ -52,7 +52,12 @@ import { rebuildDb } from '../src/db/rebuild.mjs';
 import { loadOverrides, addOverride, orphanedOverrides, OVERRIDES_DIR } from '../src/db/overrides.mjs';
 import { HOSTS, HOST_FLAGS, DEFAULT_HOST, availableHosts } from '../src/hosts/index.mjs';
 import { recordHosts, installedHosts } from '../src/hosts/installed.mjs';
-import { recordVersion, checkForUpdate, installedVersion } from '../src/hosts/version.mjs';
+import {
+  recordVersion,
+  checkForUpdate,
+  checkBinaryStaleness,
+  installedVersion,
+} from '../src/hosts/version.mjs';
 import { loadRegistry, resolveCore } from '../src/registry/index.mjs';
 import { fetchCore, cachedCore, cachedVersions } from '../src/registry/fetch.mjs';
 import { recordCore, installedCore } from '../src/registry/installed.mjs';
@@ -1363,14 +1368,67 @@ async function noteAvailableUpdate() {
   if (process.env.HEDGEHOG_NO_UPDATE_CHECK) return;
   try {
     const { installed, latest, stale } = await checkForUpdate(DEST_ROOT);
-    if (!stale) return;
+    if (stale) {
+      console.error(
+        `\n${yellow(bold('Hedgehog update available.'))} ${dim(
+          `${installed} → ${latest}. Run \`npx @skyf0xx/hedgehog@latest update\` to refresh this project's agents and skills.`,
+        )}`,
+      );
+    }
+  } catch {
+    // Advisory only — a failed check is never worth failing a command over.
+  }
+}
+
+// Hedgehog runs as a global install: every host (Claude Code, Cursor,
+// Gemini CLI) drives it through the `hedgehog` binary on PATH, and `npx
+// @skyf0xx/hedgehog` is expected to arrive at that same global install
+// rather than an ephemeral, unmanaged copy. This makes both halves of
+// that true on every invocation, before any command's real work starts:
+//
+// - **No global install yet** (a fresh `npx` fetch, or a dev checkout
+//   run directly): install the latest release globally now.
+// - **A global install exists but is behind latest** (the running code's
+//   own version, not any project's stamped `.hedgehog/version.json` —
+//   that stamp answers a different question, whether a project's payload
+//   is current): update it to latest now.
+//
+// Either way this reuses `latestVersion`'s day-long cache, so it costs a
+// network round trip at most once a day, not on every invocation. Runs
+// unattended — `npm install -g`, no confirmation prompt. Every caller of
+// this binary is either an agent driving it non-interactively or a human
+// who ran a command expecting it to just work, and there is no stdin
+// channel to prompt on in the general case. A failure here (offline,
+// permission-restricted global dir, npm itself missing) is swallowed the
+// same as a failed staleness check — the current process keeps running on
+// whatever code it already loaded rather than failing the command over
+// an advisory step.
+async function ensureGlobalInstall() {
+  if (process.env.HEDGEHOG_NO_UPDATE_CHECK) return;
+  try {
+    const globalRoot = execFileSync('npm', ['root', '-g'], {
+      encoding: 'utf8',
+      timeout: 5_000,
+    }).trim();
+    const runningFromGlobal = PKG_ROOT === join(globalRoot, '@skyf0xx/hedgehog');
+    const { latest, stale } = await checkBinaryStaleness(DEST_ROOT, PKG_VERSION);
+    if (runningFromGlobal && !stale) return;
+    if (!latest) return;
+
+    execFileSync('npm', ['install', '-g', `@skyf0xx/hedgehog@${latest}`], {
+      stdio: 'ignore',
+      timeout: 60_000,
+    });
     console.error(
-      `\n${yellow(bold('Hedgehog update available.'))} ${dim(
-        `${installed} → ${latest}. Run \`npx @skyf0xx/hedgehog@latest update\` to refresh this project's agents and skills.`,
+      `\n${dim(
+        runningFromGlobal
+          ? `Updated hedgehog ${PKG_VERSION} → ${latest}. This run continues on ${PKG_VERSION}; the next command picks up ${latest}.`
+          : `Installed hedgehog ${latest} globally. Future commands resolve to it directly.`,
       )}`,
     );
   } catch {
-    // Advisory only — a failed check is never worth failing a command over.
+    // Advisory only — a failed check or install is never worth failing a
+    // command over.
   }
 }
 
@@ -2716,6 +2774,7 @@ async function main() {
     console.log(PKG_VERSION);
     return;
   }
+  await ensureGlobalInstall();
   const cmd = args[0];
   const force = args.includes('--force') || args.includes('-f');
 

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1403,7 +1403,11 @@ async function noteAvailableUpdate() {
 // same as a failed staleness check — the current process keeps running on
 // whatever code it already loaded rather than failing the command over
 // an advisory step.
-async function ensureGlobalInstall() {
+//
+// The install/update itself always runs regardless of `quiet` — silence
+// governs only whether this prints, matching `boundary --quiet`'s "exit
+// code only, nothing on either stream" contract for shell hooks.
+async function ensureGlobalInstall({ quiet = false } = {}) {
   if (process.env.HEDGEHOG_NO_UPDATE_CHECK) return;
   try {
     const globalRoot = execFileSync('npm', ['root', '-g'], {
@@ -1419,13 +1423,15 @@ async function ensureGlobalInstall() {
       stdio: 'ignore',
       timeout: 60_000,
     });
-    console.error(
-      `\n${dim(
-        runningFromGlobal
-          ? `Updated hedgehog ${PKG_VERSION} → ${latest}. This run continues on ${PKG_VERSION}; the next command picks up ${latest}.`
-          : `Installed hedgehog ${latest} globally. Future commands resolve to it directly.`,
-      )}`,
-    );
+    if (!quiet) {
+      console.error(
+        `\n${dim(
+          runningFromGlobal
+            ? `Updated hedgehog ${PKG_VERSION} → ${latest}. This run continues on ${PKG_VERSION}; the next command picks up ${latest}.`
+            : `Installed hedgehog ${latest} globally. Future commands resolve to it directly.`,
+        )}`,
+      );
+    }
   } catch {
     // Advisory only — a failed check or install is never worth failing a
     // command over.
@@ -2774,7 +2780,7 @@ async function main() {
     console.log(PKG_VERSION);
     return;
   }
-  await ensureGlobalInstall();
+  await ensureGlobalInstall({ quiet: args.includes('--quiet') });
   const cmd = args[0];
   const force = args.includes('--force') || args.includes('-f');
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/src/hosts/version.mjs
+++ b/src/hosts/version.mjs
@@ -152,3 +152,26 @@ export async function checkForUpdate(root, { force = false } = {}) {
     stale: Boolean(installed && latest && isNewer(latest, installed)),
   };
 }
+
+/**
+ * Whether the CLI binary actually executing right now — `binaryVersion`,
+ * read from this package's own package.json, not from any project's
+ * `.hedgehog/version.json` — is behind the newest published release.
+ *
+ * This is a distinct question from `checkForUpdate`: that one compares a
+ * *project's* stamped version against latest, so a shadowed, stale global
+ * install (a `hedgehog` binary resolved from PATH ahead of the scoped
+ * `npx @skyf0xx/hedgehog` package) reads its own old code, sees the
+ * project's stamp already at-or-past whatever it thinks "latest" is, and
+ * says nothing — the exact case this function exists to catch instead, by
+ * comparing the running code's own version rather than a file the running
+ * code could itself be stale relative to.
+ */
+export async function checkBinaryStaleness(root, binaryVersion, { force = false } = {}) {
+  const latest = await latestVersion(root, { force });
+  return {
+    binaryVersion,
+    latest,
+    stale: Boolean(binaryVersion && latest && isNewer(latest, binaryVersion)),
+  };
+}


### PR DESCRIPTION
## Summary

- A `hedgehog` binary resolved from PATH ahead of npm's own package resolution (e.g. a prior `npm install -g @skyf0xx/hedgehog` left behind after newer releases shipped) runs silently on old code — a stale core registry (a newly-added core like `pwa-app` goes unrecognized), stale routing logic, no error signal.
- `checkForUpdate` (the existing per-project staleness notice) can't catch this: it compares a project's `.hedgehog/version.json` stamp against latest, and a stale binary can easily be reading a stamp a newer binary already satisfied.
- Adds `checkBinaryStaleness` (`src/hosts/version.mjs`), which compares the running binary's own `package.json` version against latest, independent of any project file.
- Adds `ensureGlobalInstall` (`bin/cli.mjs`), which runs at the start of every command (skipped for `--help`/`--version`): installs the package globally if missing, or updates the existing global install to latest if it's behind. Unattended, no confirmation prompt — most callers are agents with no stdin channel to prompt on. Reuses the existing day-long registry-check cache, so this costs a network round trip at most once a day. Advisory on failure, same as the existing update-notice machinery.

## Test plan

- [x] `node --check bin/cli.mjs` / `node --check src/hosts/version.mjs`
- [x] `node scripts/check.mjs` passes
- [x] Simulated "no global install" (uninstalled global, ran the local checkout directly): installs globally, prints notice, command proceeds
- [x] Simulated "global exists but stale" (installed `@5.0.0` globally, ran a checkout at `5.1.3`): updates the global install to latest, prints notice, command proceeds
- [x] Already-current, running from the global install: no-op, no output, no extra `npm install` call