### PR TITLE
fix: mid-session dispatch note + pwa-app repro coverage

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -686,7 +686,11 @@ async function init({ force, core, host = DEFAULT_HOST, hostOnly = false }) {
     dim(
       `     Read ${bold(`${agents}/planner.md`)} and follow it — it runs planning\n` +
         `     intake (${skills}/hedgehog-planning-intake/SKILL.md), then hands\n` +
-        `     off to ${agents}/bootstrap.md.`,
+        `     off to ${agents}/bootstrap.md.\n` +
+        `     Some hosts register agents/skills once, at session start: if a\n` +
+        `     later dispatch by name reports one of these as not found, read\n` +
+        `     its file directly instead — it becomes dispatchable by name after\n` +
+        `     a session restart or a fresh context.`,
     ),
   );
   console.log();
@@ -809,6 +813,14 @@ async function update({ hosts }) {
       `${bootstraps}, the build graph, the core workspace, and the\n` +
         'vendored shelves are untouched — those carry project-specific or\n' +
         'write-once content.',
+    ),
+  );
+  console.log(
+    dim(
+      'Some hosts register agents/skills once, at session start: a renamed or\n' +
+        'newly-added one may not be dispatchable by name until this session\n' +
+        'restarts or a fresh context starts — read its file directly if a\n' +
+        'name-based dispatch reports it as not found.',
     ),
   );
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/repro/05-shipped-cores-unchanged.mjs
+++ b/repro/05-shipped-cores-unchanged.mjs
@@ -4,7 +4,7 @@
 // dependency rows, same requirement links, same intents table.
 //
 // The baseline in fixtures/shipped-cores-baseline.json is the compiled
-// graph both shipped cores are expected to produce. Regenerate it with:
+// graph every shipped core is expected to produce. Regenerate it with:
 //   node --experimental-sqlite repro/05-shipped-cores-unchanged.mjs --write-baseline
 // only after a deliberate edit to a shipped core.yaml, and only once the
 // printed diff has been read line by line — the baseline is what proves an
@@ -59,6 +59,7 @@ function compileShippedCore(coreName) {
 const actual = {
   'full-stack-app': compileShippedCore('full-stack-app'),
   'landing-page': compileShippedCore('landing-page'),
+  'pwa-app': compileShippedCore('pwa-app'),
 };
 
 if (WRITE) {

--- a/repro/core-without-requires.mjs
+++ b/repro/core-without-requires.mjs
@@ -4,15 +4,15 @@
 //
 // The failure this guards against is the obvious way to implement the
 // declaration — making `requires` a validated field — which would reject
-// every core.yaml written before it existed, including both shipped
-// shipped cores. It also pins the shape the rest of the fix relies on:
+// every core.yaml written before it existed, including every shipped
+// core. It also pins the shape the rest of the fix relies on:
 // an omitted `requires` parses to [] (not undefined), so consumers never
 // need a null check and a core that declares nothing can never report a
 // missing binary.
 //
 // Asserts:
-//   1. both shipped cores (repro/fixtures/cores/*.core.yaml) load and
-//      validate, with every other field unchanged;
+//   1. every shipped core (repro/fixtures/cores/*.core.yaml) loads and
+//      validates, with every other field unchanged;
 //   2. every layer of them exposes requires === [] — declaring nothing;
 //   3. a hand-written core.yaml with no requires: plans, and `hedgehog
 //      status` reports no missing binaries for it;
@@ -28,7 +28,7 @@ import { loadCore, validateCore } from '../src/db/core.mjs';
 console.log('repro: core-without-requires');
 
 // ── 1-2. shipped cores ────────────────────────────────────────────────
-for (const name of ['full-stack-app', 'landing-page']) {
+for (const name of ['full-stack-app', 'landing-page', 'pwa-app']) {
   const path = join(REPO_ROOT, 'repro/fixtures/cores', `${name}.core.yaml`);
   let core;
   try {

--- a/repro/fixtures/cores/pwa-app.core.yaml
+++ b/repro/fixtures/cores/pwa-app.core.yaml
@@ -1,0 +1,53 @@
+# Shipped core definition for pwa-app. Layer order, scope, and verify
+# commands are the same shape this package's skills/hedgehog-loop Domain
+# Module step tables describe in prose — this file is their data form.
+# {module} is filled in by the compiler with the domain module name a
+# task is generated for.
+#
+# Five layers, not six: `service` is folded into `repository` (see
+# .design-notes.md §3 / issue #172 §4) — a local-first app with no
+# server tier rarely has domain logic that doesn't fit naturally in
+# either the repository or the hook.
+#
+# Every per-module layer's scope carries {module} — module-disjoint by
+# construction (src/db/core.mjs's validateCore enforces this: a
+# module-axis core rejects any non-exclusive layer whose scope omits
+# {module}). `schema`'s scope additionally lists the shared
+# src/db/schema.ts barrel — every module's schema layer appends one
+# import + one .stores() line to it, the same append-only discipline
+# hedgehog-core-full-stack-app's packages/db/src/schema/index.ts barrel
+# uses. Two modules' schema tasks both listing schema.ts in scope means
+# the scheduler treats them as conflicting and serializes them — no
+# extra locking layer needed. join is exclusive: true and scoped to
+# everything, running the full verify chain once after every module's
+# layers land, the backstop that catches cross-module breakage (or a
+# Dexie version collision) that the parallel per-module layers can't see.
+id: pwa-app
+layers:
+  - id: schema
+    scope: ["src/features/{module}/data/{module}.schema.ts", "src/db/tables/{module}.table.ts", "src/db/schema.ts"]
+    verify: "pnpm vitest run src/features/{module}/data/{module}.schema"
+    commit: "feat({module}): schema"
+  - id: repository
+    depends_on: schema
+    scope: ["src/features/{module}/data/**"]
+    verify: "pnpm vitest run src/features/{module}/data/"
+    commit: "feat({module}): repository"
+  - id: hook
+    depends_on: repository
+    scope: ["src/features/{module}/hooks/**"]
+    verify: "pnpm vitest run src/features/{module}/hooks/"
+    commit: "feat({module}): hooks"
+  - id: screen
+    depends_on: hook
+    scope: ["src/features/{module}/components/**", "src/features/{module}/index.ts", "src/app/{module}/**"]
+    verify: "pnpm vitest run src/features/{module}/components/"
+    commit: "feat({module}): screen"
+  # Workspace-wide by design: the only gate that can see cross-module
+  # breakage, since every layer above is parallel and module-scoped.
+  - id: join
+    depends_on: screen
+    scope: ["**"]
+    verify: "pnpm typecheck && pnpm lint && pnpm vitest run && pnpm build"
+    exclusive: true
+    commit: "chore({module}): join"

--- a/repro/fixtures/shipped-cores-baseline.json
+++ b/repro/fixtures/shipped-cores-baseline.json
@@ -602,5 +602,241 @@
         "requirement_id": "ORDERS-RULE-1"
       }
     ]
+  },
+  "pwa-app": {
+    "intents": [
+      {
+        "id": "orders",
+        "goal": "build orders",
+        "outcome": "orders works",
+        "priority": 20,
+        "status": "active"
+      },
+      {
+        "id": "users",
+        "goal": "build users",
+        "outcome": "users works",
+        "priority": 10,
+        "status": "active"
+      }
+    ],
+    "tasks": [
+      {
+        "id": "ORDERS-HOOK",
+        "intent_id": "orders",
+        "module": "orders",
+        "layer": "hook",
+        "objective": "hook for orders",
+        "scope_globs": "[\"src/features/orders/hooks/**\"]",
+        "verify_command": "pnpm vitest run src/features/orders/hooks/",
+        "commit_message": "feat(orders): hooks",
+        "priority": 20,
+        "exclusive": 0,
+        "verify_radius": null,
+        "status": "planned"
+      },
+      {
+        "id": "ORDERS-JOIN",
+        "intent_id": "orders",
+        "module": "orders",
+        "layer": "join",
+        "objective": "join for orders",
+        "scope_globs": "[\"**\"]",
+        "verify_command": "pnpm typecheck && pnpm lint && pnpm vitest run && pnpm build",
+        "commit_message": "chore(orders): join",
+        "priority": 20,
+        "exclusive": 1,
+        "verify_radius": null,
+        "status": "planned"
+      },
+      {
+        "id": "ORDERS-REPOSITORY",
+        "intent_id": "orders",
+        "module": "orders",
+        "layer": "repository",
+        "objective": "repository for orders",
+        "scope_globs": "[\"src/features/orders/data/**\"]",
+        "verify_command": "pnpm vitest run src/features/orders/data/",
+        "commit_message": "feat(orders): repository",
+        "priority": 20,
+        "exclusive": 0,
+        "verify_radius": null,
+        "status": "planned"
+      },
+      {
+        "id": "ORDERS-SCHEMA",
+        "intent_id": "orders",
+        "module": "orders",
+        "layer": "schema",
+        "objective": "schema for orders",
+        "scope_globs": "[\"src/features/orders/data/orders.schema.ts\",\"src/db/tables/orders.table.ts\",\"src/db/schema.ts\"]",
+        "verify_command": "pnpm vitest run src/features/orders/data/orders.schema",
+        "commit_message": "feat(orders): schema",
+        "priority": 20,
+        "exclusive": 0,
+        "verify_radius": null,
+        "status": "planned"
+      },
+      {
+        "id": "ORDERS-SCREEN",
+        "intent_id": "orders",
+        "module": "orders",
+        "layer": "screen",
+        "objective": "screen for orders",
+        "scope_globs": "[\"src/features/orders/components/**\",\"src/features/orders/index.ts\",\"src/app/orders/**\"]",
+        "verify_command": "pnpm vitest run src/features/orders/components/",
+        "commit_message": "feat(orders): screen",
+        "priority": 20,
+        "exclusive": 0,
+        "verify_radius": null,
+        "status": "planned"
+      },
+      {
+        "id": "USERS-HOOK",
+        "intent_id": "users",
+        "module": "users",
+        "layer": "hook",
+        "objective": "hook for users",
+        "scope_globs": "[\"src/features/users/hooks/**\"]",
+        "verify_command": "pnpm vitest run src/features/users/hooks/",
+        "commit_message": "feat(users): hooks",
+        "priority": 10,
+        "exclusive": 0,
+        "verify_radius": null,
+        "status": "planned"
+      },
+      {
+        "id": "USERS-JOIN",
+        "intent_id": "users",
+        "module": "users",
+        "layer": "join",
+        "objective": "join for users",
+        "scope_globs": "[\"**\"]",
+        "verify_command": "pnpm typecheck && pnpm lint && pnpm vitest run && pnpm build",
+        "commit_message": "chore(users): join",
+        "priority": 10,
+        "exclusive": 1,
+        "verify_radius": null,
+        "status": "planned"
+      },
+      {
+        "id": "USERS-REPOSITORY",
+        "intent_id": "users",
+        "module": "users",
+        "layer": "repository",
+        "objective": "repository for users",
+        "scope_globs": "[\"src/features/users/data/**\"]",
+        "verify_command": "pnpm vitest run src/features/users/data/",
+        "commit_message": "feat(users): repository",
+        "priority": 10,
+        "exclusive": 0,
+        "verify_radius": null,
+        "status": "planned"
+      },
+      {
+        "id": "USERS-SCHEMA",
+        "intent_id": "users",
+        "module": "users",
+        "layer": "schema",
+        "objective": "schema for users",
+        "scope_globs": "[\"src/features/users/data/users.schema.ts\",\"src/db/tables/users.table.ts\",\"src/db/schema.ts\"]",
+        "verify_command": "pnpm vitest run src/features/users/data/users.schema",
+        "commit_message": "feat(users): schema",
+        "priority": 10,
+        "exclusive": 0,
+        "verify_radius": null,
+        "status": "planned"
+      },
+      {
+        "id": "USERS-SCREEN",
+        "intent_id": "users",
+        "module": "users",
+        "layer": "screen",
+        "objective": "screen for users",
+        "scope_globs": "[\"src/features/users/components/**\",\"src/features/users/index.ts\",\"src/app/users/**\"]",
+        "verify_command": "pnpm vitest run src/features/users/components/",
+        "commit_message": "feat(users): screen",
+        "priority": 10,
+        "exclusive": 0,
+        "verify_radius": null,
+        "status": "planned"
+      }
+    ],
+    "dependencies": [
+      {
+        "task_id": "ORDERS-HOOK",
+        "depends_on_task_id": "ORDERS-REPOSITORY"
+      },
+      {
+        "task_id": "ORDERS-HOOK",
+        "depends_on_task_id": "USERS-HOOK"
+      },
+      {
+        "task_id": "ORDERS-JOIN",
+        "depends_on_task_id": "ORDERS-SCREEN"
+      },
+      {
+        "task_id": "ORDERS-JOIN",
+        "depends_on_task_id": "USERS-JOIN"
+      },
+      {
+        "task_id": "ORDERS-REPOSITORY",
+        "depends_on_task_id": "ORDERS-SCHEMA"
+      },
+      {
+        "task_id": "ORDERS-REPOSITORY",
+        "depends_on_task_id": "USERS-REPOSITORY"
+      },
+      {
+        "task_id": "ORDERS-SCHEMA",
+        "depends_on_task_id": "USERS-SCHEMA"
+      },
+      {
+        "task_id": "ORDERS-SCREEN",
+        "depends_on_task_id": "ORDERS-HOOK"
+      },
+      {
+        "task_id": "ORDERS-SCREEN",
+        "depends_on_task_id": "USERS-SCREEN"
+      },
+      {
+        "task_id": "USERS-HOOK",
+        "depends_on_task_id": "USERS-REPOSITORY"
+      },
+      {
+        "task_id": "USERS-JOIN",
+        "depends_on_task_id": "USERS-SCREEN"
+      },
+      {
+        "task_id": "USERS-REPOSITORY",
+        "depends_on_task_id": "USERS-SCHEMA"
+      },
+      {
+        "task_id": "USERS-SCREEN",
+        "depends_on_task_id": "USERS-HOOK"
+      }
+    ],
+    "task_requirements": [
+      {
+        "task_id": "ORDERS-HOOK",
+        "requirement_id": "ORDERS-RULE-1"
+      },
+      {
+        "task_id": "ORDERS-JOIN",
+        "requirement_id": "ORDERS-RULE-1"
+      },
+      {
+        "task_id": "ORDERS-REPOSITORY",
+        "requirement_id": "ORDERS-RULE-1"
+      },
+      {
+        "task_id": "ORDERS-SCHEMA",
+        "requirement_id": "ORDERS-RULE-1"
+      },
+      {
+        "task_id": "ORDERS-SCREEN",
+        "requirement_id": "ORDERS-RULE-1"
+      }
+    ]
   }
 }

--- a/repro/plan-warns-singular-module-ids.mjs
+++ b/repro/plan-warns-singular-module-ids.mjs
@@ -201,4 +201,33 @@ console.log('repro: plan re-raises the singular module-id check\n');
   }
 }
 
+// --- D. the advisory fires on every module-axis core, not just
+//        full-stack-app's particular layer set -------------------------
+
+{
+  // pwa-app is module-axis too (every non-join layer's scope carries
+  // {module}), but its layer set (schema/repository/hook/screen/join)
+  // and file shapes are entirely different from full-stack-app's — this
+  // proves the check keys on "has {module} in scope", not on anything
+  // specific to full-stack-app's own layers.
+  const dir = makeProject(shippedCore('pwa-app'));
+  try {
+    const file = join(dir, 'task-input.json');
+    writeFileSync(
+      file,
+      `${JSON.stringify({ id: 'task', goal: 'build task', outcome: 'task works', acceptance: ['it works'] })}\n`,
+    );
+    const r = cli(dir, ['intent', 'add', '--file', file]);
+    if (r.status !== 0) throw new Error(`intent add --file task failed: ${r.stderr}`);
+
+    const planned = cli(dir, ['plan']);
+    check('D1. plan succeeds on pwa-app', 0, planned.status);
+    checkContains('D2. plan catches the singular id on pwa-app too', planned.stdout, 'Module id looks singular');
+    checkContains('D3. it names task', planned.stdout, 'task');
+    checkContains('D4. it points at db rebuild to re-derive', planned.stdout, 'hedgehog db rebuild');
+  } finally {
+    cleanup(dir);
+  }
+}
+
 report('plan re-raises the singular module-id advisory on every route');

--- a/repro/radius-covers-scope.mjs
+++ b/repro/radius-covers-scope.mjs
@@ -11,8 +11,8 @@
 // A radius that drops part of its scope silently deletes that detection
 // and the two tasks co-schedule.
 //
-// Expected after the fix: loadCore/validateCore rejects it, both shipped
-// cores still load, and a radius that does contain its scope still loads.
+// Expected after the fix: loadCore/validateCore rejects it, every shipped
+// core still loads, and a radius that does contain its scope still loads.
 //
 // No build graph, no sqlite — this is a core-definition-level defect.
 // Run: node repro/radius-covers-scope.mjs
@@ -56,6 +56,14 @@ const CONTAINMENT = {
     { scope: ['packages/db/src/schema/{module}/**'], radius: ['packages/db/**'], why: 'full-stack-app schema' },
     { scope: ['packages/hooks/src/{module}/**'], radius: ['packages/hooks/**'], why: 'full-stack-app hook' },
     { scope: ['apps/api/src/{module}/http/**', 'apps/api/src/app.module.ts'], radius: ['apps/api/**'], why: 'authored api layer' },
+    // pwa-app's join layer: scope is everything, declared radius is
+    // everything — the degenerate case of a workspace-wide, exclusive
+    // layer, not a narrower claim than its own scope.
+    { scope: ['**'], radius: ['**'], why: 'pwa-app join' },
+    // pwa-app's schema layer lists three files/globs in scope (two
+    // module-scoped, one shared barrel) with no declared radius at all —
+    // covered separately below (NO_RADIUS_MULTI_SCOPE), since that's an
+    // omitted-radius case, not a containment case.
     // The union covers it even though no single glob does — must not be
     // a hard failure, because rejecting it would be rejecting a core that
     // is actually fine.
@@ -103,6 +111,20 @@ layers:
     verify: "pnpm --filter api exec vitest run"
     verify_radius: ["apps/api/**"]
     commit: "feat({module}): api"
+`;
+
+// pwa-app's real schema layer shape: three scope globs (two
+// module-scoped, one shared src/db/schema.ts barrel every module's
+// schema layer appends to), no verify_radius declared at all. An
+// omitted radius falls back to scope itself, so this must load clean —
+// there is nothing narrower than scope for it to be narrower than.
+const PWA_SCHEMA_NO_RADIUS = `
+id: repro-pwa-schema
+layers:
+  - id: schema
+    scope: ["src/features/{module}/data/{module}.schema.ts", "src/db/tables/{module}.table.ts", "src/db/schema.ts"]
+    verify: "pnpm vitest run src/features/{module}/data/{module}.schema"
+    commit: "feat({module}): schema"
 `;
 
 async function loadYaml(dir, name, text) {
@@ -157,6 +179,17 @@ try {
     );
   }
 
+  // ── 3b. No false alarm: pwa-app's real multi-glob schema scope with
+  //    no declared radius (an omitted radius defaults to scope). ───────
+  const pwaSchema = await loadYaml(dir, 'pwa-schema', PWA_SCHEMA_NO_RADIUS);
+  if (!pwaSchema.ok) {
+    failures.push(
+      'repro-pwa-schema: pwa-app schema shape, multi-glob scope, no verify_radius\n' +
+        '      expected: loads clean — an omitted radius defaults to scope\n' +
+        `      actual:   rejected — ${pwaSchema.message}`,
+    );
+  }
+
   // ── 4. Containment, both directions. A radius sharing a literal
   //    prefix with the scope is not thereby covering it; and a radius
   //    that genuinely covers must still load. ─────────────────────────
@@ -202,9 +235,9 @@ try {
     }
   }
 
-  // ── 6. No false alarm: both shipped cores still load, and neither
+  // ── 6. No false alarm: every shipped core still loads, and none
   //    trips the "cannot prove" warning. ──────────────────────────────
-  for (const core of ['full-stack-app', 'landing-page']) {
+  for (const core of ['full-stack-app', 'landing-page', 'pwa-app']) {
     const path = join(ROOT, 'repro/fixtures/cores', `${core}.core.yaml`);
     try {
       const loaded = await loadCore(path);
@@ -235,5 +268,5 @@ if (failures.length > 0) {
 }
 console.log(
   `radius-covers-scope: ok — narrow/empty radii rejected, ${CONTAINMENT.reject.length} non-covering radii rejected, ` +
-    `${CONTAINMENT.accept.length} covering radii accepted, unprovable containment warned not thrown, both shipped cores clean`,
+    `${CONTAINMENT.accept.length} covering radii accepted, unprovable containment warned not thrown, every shipped core clean`,
 );

--- a/repro/verify-covers-radius.mjs
+++ b/repro/verify-covers-radius.mjs
@@ -145,11 +145,14 @@ for (const [label, text] of [
   }
 }
 
-// ── 5. No false alarms on either shipped core. full-stack-app's schema
+// ── 5. No false alarms on any shipped core. full-stack-app's schema
 //    and hook layers both declare a package-wide radius; their commands
 //    narrow by flag (`--testPathPattern={module}`), not by path, which
-//    is not evidence the check can read — it abstains. ────────────────
-for (const name of ['full-stack-app', 'landing-page']) {
+//    is not evidence the check can read — it abstains. pwa-app declares
+//    no verify_radius anywhere (every non-join layer's radius defaults
+//    to its own scope, and join is workspace-wide by declared scope), so
+//    there is no gap for this check to find. ───────────────────────────
+for (const name of ['full-stack-app', 'landing-page', 'pwa-app']) {
   const core = await loadCore(join(ROOT, 'repro/fixtures/cores', `${name}.core.yaml`));
   const warnings = lintCore(core);
   if (warnings.length !== 0) {
@@ -167,5 +170,5 @@ if (failures.length > 0) {
   process.exit(1);
 }
 console.log(
-  'verify-covers-radius: ok — anchored commands warned (2), whole-suite/ancestor/no-radius silent, both shipped cores clean',
+  'verify-covers-radius: ok — anchored commands warned (2), whole-suite/ancestor/no-radius silent, every shipped core clean',
 );

--- a/repro/verify-has-module-token.mjs
+++ b/repro/verify-has-module-token.mjs
@@ -16,7 +16,7 @@
 // stays silent the moment either {module} or a path argument shows up,
 // stays silent on a layer that declares verify_radius (that's a
 // different, already-checked claim — see verify-covers-radius.mjs), and
-// reports nothing on either shipped core.
+// reports nothing on any shipped core.
 //
 // No build graph, no sqlite — this is a core-definition-level defect.
 // Run: node repro/verify-has-module-token.mjs
@@ -157,8 +157,8 @@ for (const [label, text] of [
   }
 }
 
-// ── 8. No false alarms on either shipped core. ──────────────────────────
-for (const name of ['full-stack-app', 'landing-page']) {
+// ── 8. No false alarms on any shipped core. ──────────────────────────────
+for (const name of ['full-stack-app', 'landing-page', 'pwa-app']) {
   const core = await loadCore(join(ROOT, 'repro/fixtures/cores', `${name}.core.yaml`));
   const warnings = lintCore(core);
   if (warnings.length !== 0) {
@@ -176,5 +176,5 @@ if (failures.length > 0) {
   process.exit(1);
 }
 console.log(
-  'verify-has-module-token: ok — no-evidence deploy layer warned, module-token/path-argument/radius/once/exclusive/linear cases silent, both shipped cores clean',
+  'verify-has-module-token: ok — no-evidence deploy layer warned, module-token/path-argument/radius/once/exclusive/linear cases silent, every shipped core clean',
 );

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -181,13 +181,13 @@ for (const { label, text } of allEntries) {
   }
 }
 
-// ── 5. Both shipped core.yaml files load, validate, and lint cleanly.
+// ── 5. Every shipped core.yaml file loads, validates, and lints cleanly.
 //    The lint (core.mjs's lintCore) is heuristic and only warns in a
 //    project, but a shipped core is the worked example every authored
 //    core is written against, so a warning on one is a release blocker
 //    here — and a shipped core tripping it is also the evidence that the
 //    heuristic cries wolf. ────────────────────────────────────────────
-for (const core of ['full-stack-app', 'landing-page']) {
+for (const core of ['full-stack-app', 'landing-page', 'pwa-app']) {
   const path = join(ROOT, `repro/fixtures/cores/${core}.core.yaml`);
   try {
     const loaded = await loadCore(path);

--- a/src/hosts/claude/DISPATCH.md
+++ b/src/hosts/claude/DISPATCH.md
@@ -6,6 +6,14 @@ context with its own tool grant. The skills in `.claude/skills/` are
 available the same way; invoke one by name rather than reimplementing what
 it describes.
 
+Claude Code reads that registration once, at session start — an agent or
+skill file written mid-session (by `hedgehog init` or `hedgehog update`
+just now) is not yet dispatchable by name in this session. If a name-based
+dispatch reports it as not found, read the file directly from
+`.claude/agents/` or `.claude/skills/` and follow it inline instead of
+retrying the dispatch; it becomes dispatchable by name after a session
+restart or a fresh context.
+
 Clear context with `/clear` at the unit boundaries described above —
 `hedgehog boundary` tells you whether you're at one (exit 0), and
 `hedgehog boundary --handoff` is what the next session starts from.


### PR DESCRIPTION
## Summary
- Notes in `DISPATCH.md` and the CLI's `init`/`update` completion output that some hosts register agents/skills once at session start, so a file written mid-session isn't dispatchable by name until a session restart or fresh context — closes #190, closes #182
- Extends `repro/`'s shipped-core loops and `scripts/check.mjs` to cover `pwa-app` alongside `full-stack-app` and `landing-page`, backed by a real fixture and a regenerated compiled baseline — closes #178
- Bumps `package.json` to 5.1.5

## Test plan
- [x] `node --experimental-sqlite repro/run-all.mjs` — all 56 reproductions pass
- [x] `node scripts/check.mjs` — ok — 4 agents, 4 skills, 4 cores, tarball, CLI