### PR TITLE
docs: update bot support to include Telegram

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ the cost of a pre-built workspace.
    server init, tool-list handlers, tool-call handlers, transport setup),
    which is exactly what a layered build order plus a tool-definition
    generator eliminates.
-2. **Slack/Discord bot** — event subscription, command routing, and the
+2. **Slack/Discord bot/Telegram** — event subscription, command routing, and the
    OAuth install flow are fixed enough across projects to lock into a
    workspace rather than re-derive per project. Demand is concrete and
    current: AI-powered bots that answer from company docs, summarize


### PR DESCRIPTION
## What does this change?
Needed an addition to roadmap

## Why?
complete bot ecosystem

## Checklist

- [x] PR title follows Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `ci:`, `chore:`)
- [x] `npm run check` passes locally
- [x] No direct edits to `vendor-skills/BMAD/` (use the `bmad-revendor` skill instead)
