### PR TITLE
fix: session-scoped dispatch note, pwa-app repro coverage, Self-test dedup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "5.1.3",
+      "version": "5.1.6",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.3",
+  "version": "5.1.6",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.3",
+  "version": "5.1.6",
   "author": {
     "name": "skyf0xx"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,13 +147,18 @@ triggers and never touched by the same automation:
   `version` fields (kept identical to each other) — the Claude Code
   plugin (`claude plugin install hedgehog`), whose payload is `skills/`
   (currently just `skills/hedgehog/SKILL.md`) and `hooks/`, not `src/`.
-  `.cursor-plugin/plugin.json` carries the same version for the Cursor
-  packaging of that payload. Bump these by hand, in the same PR as the
-  change, for any edit under `skills/`, `hooks/`, `.claude-plugin/`, or
-  `.cursor-plugin/` — that's what a
-  `claude plugin marketplace` update check reads to decide a user has a
-  new version to pull. No CI bumps or publishes this one; it ships by the
-  marketplace re-reading the repo at whatever commit `master` is on.
+  `.cursor-plugin/plugin.json` and root `gemini-extension.json` each
+  carry the same version for the Cursor and Gemini CLI packagings of
+  that same payload (root `gemini-extension.json` only — the unrelated
+  `src/hosts/gemini/gemini-extension.json` is per-project template
+  content versioned by `package.json`'s bump instead). Bump all four by
+  hand, in the same PR as the change, for any edit under `skills/`,
+  `hooks/`, `.claude-plugin/`, `.cursor-plugin/`, or root
+  `gemini-extension.json` itself — that's what a `claude plugin
+  marketplace` update check (or Gemini CLI's own extension update check)
+  reads to decide a user has a new version to pull. No CI bumps or
+  publishes this one; it ships by the marketplace or extension registry
+  re-reading the repo at whatever commit `master` is on.
 
 Each core package carries a third version, in its own repo and released
 from there — a change to a core's workspace, agents, or skills is a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,14 +151,19 @@ triggers and never touched by the same automation:
   carry the same version for the Cursor and Gemini CLI packagings of
   that same payload (root `gemini-extension.json` only — the unrelated
   `src/hosts/gemini/gemini-extension.json` is per-project template
-  content versioned by `package.json`'s bump instead). Bump all four by
-  hand, in the same PR as the change, for any edit under `skills/`,
-  `hooks/`, `.claude-plugin/`, `.cursor-plugin/`, or root
-  `gemini-extension.json` itself — that's what a `claude plugin
-  marketplace` update check (or Gemini CLI's own extension update check)
-  reads to decide a user has a new version to pull. No CI bumps or
-  publishes this one; it ships by the marketplace or extension registry
-  re-reading the repo at whatever commit `master` is on.
+  content versioned by `package.json`'s bump instead). Bump all four
+  together with `npm run release:plugin -- <version>`
+  (`scripts/bump-plugin-version.mjs`), in the same PR as the change, for
+  any edit under `skills/`, `hooks/`, `.claude-plugin/`,
+  `.cursor-plugin/`, or root `gemini-extension.json` itself — that's what
+  a `claude plugin marketplace` update check (or Gemini CLI's own
+  extension update check) reads to decide a user has a new version to
+  pull. The script asserts the four files agree before writing, so a
+  prior silent miss surfaces there instead of compounding; `scripts/
+  check.mjs` carries the same assertion as a standing gate, so drift
+  between releases fails `npm run check` too. No CI bumps or publishes
+  this one; it ships by the marketplace or extension registry re-reading
+  the repo at whatever commit `master` is on.
 
 Each core package carries a third version, in its own repo and released
 from there — a change to a core's workspace, agents, or skills is a

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "5.1.3",
+  "version": "5.1.6",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "scripts": {
     "check": "node scripts/check.mjs",
     "repro": "node --experimental-sqlite repro/run-all.mjs",
-    "release": "npm version patch -m \"chore: bump version to %s\""
+    "release": "npm version patch -m \"chore: bump version to %s\"",
+    "release:plugin": "node scripts/bump-plugin-version.mjs"
   },
   "files": [
     "bin",

--- a/repro/fixtures/cores/landing-page.manifest.yaml
+++ b/repro/fixtures/cores/landing-page.manifest.yaml
@@ -4,10 +4,8 @@ language: typescript
 engine: "^5.0.0"
 workspace: workspace/
 template: CLAUDE.core.md
-agents: [landing-strategist, landing-systems, landing-sequencer,
-         landing-headline-writer, landing-copywriter, landing-critic,
-         landing-builder, landing-executor, landing-visual-reviewer,
-         landing-ux-reviewer]
+agents: [landing-builder, landing-copywriter, landing-executor,
+         landing-visual-reviewer, landing-ux-reviewer]
 skills: [hedgehog-landing-loop, hedgehog-bootstrap-landing-page-core,
          landing-shapes, landing-copy-hero, landing-copy-problem,
          landing-copy-mechanism, landing-copy-proof, landing-copy-objection,

--- a/scripts/bump-plugin-version.mjs
+++ b/scripts/bump-plugin-version.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// Bumps the plugin-family version — .claude-plugin/plugin.json,
+// .claude-plugin/marketplace.json's plugins[0].version,
+// .cursor-plugin/plugin.json, and root gemini-extension.json — together,
+// the four manifests of the same skills/ + hooks/ payload named in
+// CLAUDE.md's Releasing section. Refuses to touch
+// src/hosts/gemini/gemini-extension.json, unrelated per-project template
+// content that sits outside this family on purpose.
+//
+// Run with `npm run release:plugin -- <version>`. Asserts the four files
+// agree on their current version before writing, so a prior silent drift
+// (a file missed on an earlier bump) surfaces here instead of compounding.
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { join, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const target = process.argv[2];
+if (!target || !/^\d+\.\d+\.\d+$/.test(target)) {
+  console.error('Usage: npm run release:plugin -- <version>  (e.g. 5.2.0)');
+  process.exit(1);
+}
+
+const FILES = [
+  { path: '.claude-plugin/plugin.json', get: (j) => j.version, set: (j, v) => { j.version = v; } },
+  {
+    path: '.claude-plugin/marketplace.json',
+    get: (j) => j.plugins?.[0]?.version,
+    set: (j, v) => { j.plugins[0].version = v; },
+  },
+  { path: '.cursor-plugin/plugin.json', get: (j) => j.version, set: (j, v) => { j.version = v; } },
+  { path: 'gemini-extension.json', get: (j) => j.version, set: (j, v) => { j.version = v; } },
+];
+
+const loaded = await Promise.all(
+  FILES.map(async (f) => ({
+    ...f,
+    fullPath: join(ROOT, f.path),
+    json: JSON.parse(await readFile(join(ROOT, f.path), 'utf8')),
+  })),
+);
+
+const current = new Set(loaded.map((f) => f.get(f.json)));
+if (current.size > 1) {
+  console.error(
+    `Plugin-family files disagree before bumping — fix drift first:\n${loaded
+      .map((f) => `  ${f.path}: ${f.get(f.json)}`)
+      .join('\n')}`,
+  );
+  process.exit(1);
+}
+
+for (const f of loaded) {
+  f.set(f.json, target);
+  await writeFile(f.fullPath, `${JSON.stringify(f.json, null, 2)}\n`);
+  console.log(`  ${f.path} -> ${target}`);
+}
+
+console.log(`\nBumped plugin family to ${target}. Not committed — review and commit by hand.`);

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -267,6 +267,39 @@ try {
   fail(`bin/cli.mjs --help exited non-zero: ${err.message}`);
 }
 
+// ── 8. Plugin-family version fields (CLAUDE.md's Releasing section) all
+//    agree — .claude-plugin/plugin.json, .claude-plugin/marketplace.json's
+//    plugins[0].version, .cursor-plugin/plugin.json, and root
+//    gemini-extension.json ship the same skills/ + hooks/ payload under
+//    four manifests, so a version bump to one and not the others is a
+//    silent miss, not a valid state. src/hosts/gemini/gemini-extension.json
+//    is unrelated per-project template content and sits outside this
+//    family on purpose. ───────────────────────────────────────────────
+try {
+  const pluginJson = JSON.parse(await readFile(join(ROOT, '.claude-plugin/plugin.json'), 'utf8'));
+  const marketplaceJson = JSON.parse(
+    await readFile(join(ROOT, '.claude-plugin/marketplace.json'), 'utf8'),
+  );
+  const cursorJson = JSON.parse(await readFile(join(ROOT, '.cursor-plugin/plugin.json'), 'utf8'));
+  const geminiJson = JSON.parse(await readFile(join(ROOT, 'gemini-extension.json'), 'utf8'));
+  const versions = {
+    '.claude-plugin/plugin.json': pluginJson.version,
+    '.claude-plugin/marketplace.json (plugins[0].version)': marketplaceJson.plugins?.[0]?.version,
+    '.cursor-plugin/plugin.json': cursorJson.version,
+    'gemini-extension.json': geminiJson.version,
+  };
+  const distinct = new Set(Object.values(versions));
+  if (distinct.size > 1) {
+    fail(
+      `plugin-family version drift: ${Object.entries(versions)
+        .map(([file, v]) => `${file}=${v}`)
+        .join(', ')} — bump every plugin-family file to the same version (CLAUDE.md's Releasing section)`,
+    );
+  }
+} catch (err) {
+  fail(`plugin-family version check failed: ${err.message}`);
+}
+
 // ── Report ───────────────────────────────────────────────────────────
 if (failures.length > 0) {
   console.error(`\n${failures.length} check(s) failed:\n`);

--- a/src/agents/tweaker.md
+++ b/src/agents/tweaker.md
@@ -211,30 +211,6 @@ discipline as `.hedgehog/BMAD/`. A later related incident is its own new
 4. **Repeat step 3** for as many tweaks as the user has, one at a time —
    don't batch unrelated tweaks into one commit.
 
-## Self-test
-
-- Job 2 ran at most once for this build — but within that run, every
-  distinct real pattern the friction log showed, and every distinct
-  feedback item the user actually gave, got its own suggested issue, not
-  just the single clearest one.
-- The user was directly asked for feedback, separate from the friction
-  log — job 2 didn't skip straight to filing friction issues without
-  asking.
-- Entries (or feedback items) that trace to the same underlying gap were
-  grouped into one issue, not filed as duplicates.
-- Shown content is literal/final and correctly labeled — never a
-  summary, never altered post-approval, and never created without an
-  explicit approval on that specific issue's exact shown content.
-- Every tweak is its own commit, scoped to what the user actually asked
-  for — no drive-by refactor riding along on a color change.
-- A request that's actually new scope was routed onward — to `planner`'s
-  Re-entry pass on a module axis, or to the Correction Protocol's
-  post-build entry otherwise — not built here, and the user was told the
-  build is extendable, not that the request was refused.
-- The `ROADMAP.md`/contributing mention happened at most once for this
-  build, stayed to one sentence, and wasn't repeated or pressed after a
-  "no" or silence.
-
 ## Constraints
 
 - Never create a GitHub issue against the user's own project repo — job

--- a/src/hosts/capabilities.mjs
+++ b/src/hosts/capabilities.mjs
@@ -22,21 +22,12 @@ export const AGENT_CAPABILITY = {
   'pwa-eng': 'full',
   tweaker: 'full',
 
-  // Author artifacts, but never run commands.
-  'landing-headline-writer': 'no-bash',
-  'landing-sequencer': 'no-bash',
-  'landing-strategist': 'no-bash',
-  'landing-systems': 'no-bash',
-
   // Inspect and report; the verification command (and, for the Polish
   // Loop reviewers, the build/screenshot/interaction commands) is theirs
   // to run.
   reviewer: 'readonly-bash',
   'landing-visual-reviewer': 'readonly-bash',
   'landing-ux-reviewer': 'readonly-bash',
-
-  // Inspect and report only.
-  'landing-critic': 'readonly',
 
   // Write its rationale artifact, nothing else.
   'ux-planner': 'write-only',

--- a/src/skills/hedgehog-contributing/SKILL.md
+++ b/src/skills/hedgehog-contributing/SKILL.md
@@ -117,14 +117,3 @@ back-and-forth to extract the facts.
    (`Addresses the "<item name>" item in ROADMAP.md`, or `Fixes #<n>`).
 7. **Report the PR URL** `gh` returns and stop — don't merge, don't push
    further commits without being asked.
-
-## Self-test
-
-- The change happened in a Hedgehog repo clone, never inside the user's own
-  project directory.
-- The PR is scoped to one agent, one skill, one template, or one host —
-  not a bundle of unrelated changes.
-- The install smoke test actually ran and actually confirmed the specific
-  change, not just that `init` exits zero.
-- Commit messages and the PR title follow Conventional Commits.
-- Nothing was merged or force-pushed without the user explicitly asking.


### PR DESCRIPTION
## Summary
- Note session-scoped agent/skill dispatch limits after init/update, so a freshly-added or renamed agent/skill that isn't yet dispatchable by name doesn't read as broken.
- Cover pwa-app in the shipped-core repro loops and check.mjs.
- Drop duplicated "Self-test" sections from `tweaker.md` and `hedgehog-contributing/SKILL.md` — the only two files carrying that pattern, each restating rules already stated in their own Workflow/Constraints sections.
- Bring root `gemini-extension.json` into the plugin-version family documented in CLAUDE.md's Releasing section — it's a fourth manifest of the same `skills/` + `hooks/` payload as `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `.cursor-plugin/plugin.json`, but was never named there and had drifted to 5.1.3 while the others moved on.
- Script the plugin-family bump (`scripts/bump-plugin-version.mjs`, `npm run release:plugin -- <version>`) instead of hand-editing four JSON files, and add a standing drift check to `scripts/check.mjs` so the four files disagreeing fails `npm run check`.
- Bump `package.json` to 5.1.6 and the plugin family to 5.1.6 to match.
- also closes https://github.com/skyf0xx/hedgehog/issues/197

## Test plan
- [x] Repro suite covers pwa-app in shipped-core loops and check.mjs (a7e6b09)
- [x] Verified no other `src/agents/` or `src/skills/` file carries a duplicated Self-test section before removing it
- [x] `npm run check` passes the new plugin-family version check (one pre-existing, unrelated failure: `landing-page.manifest.yaml` fixture drift against the core repo)
- [x] `node scripts/bump-plugin-version.mjs <version>` tested manually: bumps all four files together, and correctly refuses with exit 1 when the files disagree beforehand