### PR TITLE
docs: rename 'PWAs' section to 'Web Apps/ PWAs'

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Sequence
 Artifact
 ```
 
-### PWAs
+### Web Apps/ PWAs
 
 Local-first simple mobile compatible web  apps: trackers, journals, planners, etc:
 


### PR DESCRIPTION
Updated section title from 'PWAs' to 'Web Apps/ PWAs' for clarity.

## What does this change?

## Why?

## Checklist

- [x] PR title follows Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `ci:`, `chore:`)
- [x] `npm run check` passes locally
- [x] No direct edits to `vendor-skills/BMAD/` (use the `bmad-revendor` skill instead)
