### PR TITLE
docs: fix formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Screen
 
 A CLI, a library, a browser extension, a data pipeline, etc. gets its build order.
 
-Where possible, Hedgehog uses a battle-tested blueprint (in [`hedgehog-core-authored`](https://github.com/skyf0xx/hedgehog-core-authored)'s `hedgehog-core-design` skill) for the system's shape where one exists.
+Where possible, Hedgehog uses a battle-tested blueprint in [`hedgehog-core-authored`](https://github.com/skyf0xx/hedgehog-core-authored) for the system's shape where one exists.
 
 ### Existing codebases
 


### PR DESCRIPTION
## What does this change?

## Why?

## Checklist

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `ci:`, `chore:`)
- [ ] `npm run check` passes locally
- [ ] No direct edits to `vendor-skills/BMAD/` (use the `bmad-revendor` skill instead)
