### PR TITLE
docs: cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,14 +227,15 @@ Hedgehog uses a fixed stack and build order for each core. The tooling enforces 
 
 See [ARCHITECTURE.md](ARCHITECTURE.md) for the full design.
 
-## Authoring a new core
-
+<details>
+<summary>Authoring a new core</summary>
 A core is an npm package carrying a pre-built, pre-verified workspace plus the agents and skills that build it. The package contract, at the package root:
 
 - `hedgehog-core.yaml` — the manifest naming the core (matching its registry entry), its language, and where each contributed piece lives in the package: `workspace/` (the scaffold, omitted by a core that scaffolds nothing), `CLAUDE.core.md` (fills the installed `CLAUDE.md` shell's core section), `agents/<name>.md`, `skills/<name>/`, and any `vendor_skills/<name>/`. Its `engine` key states the engine line the core's agents and skills are written against, as a caret range over a three-part version (`engine: "^5.0.0"`); an older CLI refuses the core rather than landing a payload it cannot drive.
 - `core.yaml` — the layer sequence and per-layer verify commands, in the same shape `src/db/core.mjs` loads for an authored core.
 
 Adding the package to the CLI's `init` menu is one entry in `src/registry/cores.json`: the package name, the version range to resolve, an install flag, and the `selects_when` prose. That entry owns the selection prose — `planner` reads it in Phase 0, before any core package is fetched — so the manifest leaves it out; a `selects_when` in a manifest is never read.
+</details>
 
 ## Credits
 


### PR DESCRIPTION
Added details on authoring a new core, including package structure and CLI integration.

## What does this change?

## Why?

## Checklist

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `ci:`, `chore:`)
- [ ] `npm run check` passes locally
- [ ] No direct edits to `vendor-skills/BMAD/` (use the `bmad-revendor` skill instead)
