### PR TITLE
docs: update cta

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Adding the package to the CLI's `init` menu is one entry in `src/registry/cores.
 
 ## Support Hedgehog
 
-If Hedgehog helps you build better software with AI, **give it a ⭐ on GitHub**, or [buy me a coffee on Ko-fi](https://ko-fi.com/skyf0xx).
+If Hedgehog helps you build better software with AI, **give it a ⭐ on GitHub**.
 
 [![GitHub stars](https://raw.githubusercontent.com/skyf0xx/hedgehog/master/badges/github-stars.svg)](https://github.com/skyf0xx/hedgehog/stargazers)
 [![Total downloads](https://raw.githubusercontent.com/skyf0xx/hedgehog/master/badges/npm-downloads.svg)](https://www.npmjs.com/package/@skyf0xx/hedgehog)


### PR DESCRIPTION
Removed the link to buy coffee on Ko-fi from the support section.

## What does this change?

## Why?

## Checklist

- [x] PR title follows Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `ci:`, `chore:`)
- [x] `npm run check` passes locally
- [x] No direct edits to `vendor-skills/BMAD/` (use the `bmad-revendor` skill instead)
