### PR TITLE
fix: make plugin update notice a stop gate, not an aside

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "5.1.6",
+      "version": "5.1.7",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "author": {
     "name": "skyf0xx"
   },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "5.1.6",
+  "version": "5.1.7",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -128,7 +128,7 @@ plugin_update_notice() {
     # The marketplace name is read from the install path rather than
     # hardcoded, so a plugin installed from a fork or a differently-named
     # marketplace still gets a command that works.
-    printf '# Hedgehog plugin update available\n\nThe installed Hedgehog plugin is version %s; version %s is published.\n\nMention this to the user once, briefly. If they authorize it, run both\nlines yourself via Bash:\n\n    claude plugin marketplace update %s\n    claude plugin update hedgehog@%s\n\nBoth are needed: the first fetches the new version, the second installs\nit, and it takes effect on restart. Do not run them without the user\nauthorizing it first, and do not repeat this notice later in the\nsession.\n' \
+    printf '# Hedgehog plugin update available\n\nThe installed Hedgehog plugin is version %s; version %s is published.\n\nMention this to the user once, briefly, before doing anything else this\nsession. Then STOP: wait for their reply before starting any other work,\neven work they already asked for earlier in the same message. Treat the\nunanswered notice as blocking, not as a remark to append before moving on.\n\nIf they authorize it, run both lines yourself via Bash:\n\n    claude plugin marketplace update %s\n    claude plugin update hedgehog@%s\n\nBoth are needed: the first fetches the new version, the second installs\nit, and it takes effect on restart. Do not run them without the user\nauthorizing it first. If they decline or say to proceed without updating,\ncarry on with their original request and do not repeat this notice later\nin the session.\n' \
         "$installed_version" "$latest" "$marketplace" "$marketplace"
 }
 


### PR DESCRIPTION
## Summary
- The SessionStart hook's plugin-update notice told the model to mention an available update "briefly," but never instructed it to wait for a reply before continuing — so in practice it would mention the update and immediately proceed with the user's original request instead of pausing for authorization.
- Adds an explicit stop-and-wait instruction to the notice text: mention the update, then stop and wait for the user's reply before starting any other work, even work already requested earlier in the same message.
- Bumps the plugin family version (5.1.6 → 5.1.7) per `.claude-plugin/`, `.cursor-plugin/`, and `gemini-extension.json` since this is a `hooks/` change.

## Test plan
- [x] `npm run check` passes (plugin version consistency across the four manifest files)
- [x] Manually verify in a Claude Code session with an outdated installed plugin that the model stops and waits after surfacing the notice, rather than continuing with other work