### PR TITLE
feat: add DeepSeek Harness core to registry and README

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "5.1.7",
+      "version": "5.1.8",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "author": {
     "name": "skyf0xx"
   },

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,7 +20,7 @@ Tool grants are defense in depth. The enforcement is `hedgehog verify`, which ch
 
 ## Core resolution
 
-`src/agents/` and `src/skills/` above are shared by every core. Each core's own build agents, skills, and (for `full-stack-app`, `pwa-app`, and `landing-page`) pre-built workspace ship in that core's own npm package rather than in this repo.
+`src/agents/` and `src/skills/` above are shared by every core. Each core's own build agents, skills, and (for `full-stack-app`, `pwa-app`, `landing-page`, and `deepseek-harness`) pre-built workspace ship in that core's own npm package rather than in this repo.
 
 `src/registry/cores.json` is the fixed table naming every core: its npm package, the version range `init` resolves, its install flag, its GitHub repository, and the `selects_when` prose `planner` reads aloud in Phase 0 to choose one. `init` resolves the requested core against that table (`src/registry/index.mjs`), then fetches the package with `npm pack` and extracts it (`src/registry/fetch.mjs`), caching the extraction at `~/.hedgehog/cores/<name>/<version>/` so a repeat install on the same version needs no network. The extracted package carries a `hedgehog-core.yaml` manifest at its root (`src/registry/manifest.mjs`) naming which agents, skills, vendored shelves, workspace, and CLAUDE.md section it contributes; the installer writes those into the consuming project alongside the shared agents and skills above. `installed.mjs` records which core and version a project installed, so `update` refreshes that core from the same package rather than re-resolving the registry.
 
@@ -28,11 +28,12 @@ Tool grants are defense in depth. The enforcement is `hedgehog verify`, which ch
 
 ### Keeping a shipped core's workspace current
 
-A core that ships a pre-built `workspace/` (`full-stack-app`, `pwa-app`, `landing-page`) owns the staleness of its own dependencies the same way it owns everything else about that workspace — this repo has no visibility into any core's dependency tree. Each such core's repo runs its own scheduled dependency-update workflow, shaped to what that workspace actually needs to stay coherent, gated on that workspace's real build/test/lint targets (not a stub), opening a PR for human review rather than merging or publishing on its own:
+A core that ships a pre-built `workspace/` (`full-stack-app`, `pwa-app`, `landing-page`, `deepseek-harness`) owns the staleness of its own dependencies the same way it owns everything else about that workspace — this repo has no visibility into any core's dependency tree. Each such core's repo runs its own scheduled dependency-update workflow, shaped to what that workspace actually needs to stay coherent, gated on that workspace's real build/test/lint targets (not a stub), opening a PR for human review rather than merging or publishing on its own:
 
 - `full-stack-app` runs `nx migrate latest` on a schedule, because Nx requires `nx` and every `@nx/*` plugin to be the exact same version — an ordinary per-package dependency bot would land them one PR at a time and break the workspace on every partial state. That gate also regenerates one throwaway domain module through all seven layer generators and typechecks/builds the result, since a migration can silently break generator output in a way that only surfaces the next time a consuming project scaffolds a module.
 - `pwa-app` runs the same `nx migrate latest` shape for the same coupled-version reason, gated on `typecheck`/`lint`/`test`/`build` plus a throwaway module scaffolded through all three generators (`feature`, `entity`, `integration`) and rebuilt, since a migration can just as easily break generator output here.
 - `landing-page` has no coupled version matrix (Astro, Tailwind, and the rest resolve independently), so its update workflow is an ordinary grouped dependency bump gated on `astro check`, `eslint`, and `astro build`.
+- `deepseek-harness` has no coupled version matrix, so its update workflow is an ordinary grouped dependency bump gated on scaffolding a throwaway plugin through `generate:tool` and running `verify-scaffold.mjs` against it.
 - `authored` ships no pre-built workspace — its stack is chosen per-project at design time, not pinned in the package — so it has no workspace dependencies to keep current.
 
 A new core that ships a pre-built workspace should add the equivalent: a scheduled workflow that updates that workspace's dependencies as a single reviewable PR, gated on real targets run against the real workspace, never merging or publishing itself.
@@ -117,13 +118,32 @@ Method: nothing here is a default reached for out of habit.
 | Texture/grain | CSS `mask-image` + noise pattern | Materiality layer, no SVG filter needed. |
 | 3D | React Three Fiber | Only when the subject is genuinely spatial; skipped by default. |
 
+## `deepseek-harness` core
+
+Package and source: [`skyf0xx/hedgehog-core-deepseek-harness`](https://github.com/skyf0xx/hedgehog-core-deepseek-harness).
+
+For building a plugin, tool, hook, or extension for DeepSeek Harness
+(DSH), a Cordis-based agent framework — not for building an application.
+
+| Layer | Choice | Why |
+| --- | --- | --- |
+| Runtime | `@deepseek-ai/dsh` + `@deepseek-ai/cordis` | The framework a plugin actually loads into; nothing to substitute. |
+| Tooling | `@deepseek-ai/dsh-tools` | The one supported way to define and register a tool DSH agents can call. |
+| Package manager | pnpm | Matches every other core. |
+| Scaffold generator | `workspace/tools/generators/` (`generate:tool`) | One plugin's boilerplate per intent, not hand-authored per plugin. |
+
+Six layers, one plugin per intent: `scaffold → logic → wiring → smoke →
+bundle → join`. A `cordis.patch.yml` manifest and `ctx.tools.register`
+calls are the concrete signals `planner` reads to route here instead of
+`authored`; see this core's `selects_when` in `src/registry/cores.json`.
+
 ## `authored` core
 
 Package and source: [`skyf0xx/hedgehog-core-authored`](https://github.com/skyf0xx/hedgehog-core-authored).
 
-Unlike `full-stack-app` and `landing-page`, this core ships no pre-built
-workspace and no fixed stack table — `hedgehog-core-design` picks the
-stack and derives the layer sequence per project, then generates and
-verifies the workspace live. The same package also carries the design
-for adopting Hedgehog's discipline into an existing repo without
-bootstrapping a workspace at all.
+Unlike `full-stack-app`, `landing-page`, and `deepseek-harness`, this core
+ships no pre-built workspace and no fixed stack table —
+`hedgehog-core-design` picks the stack and derives the layer sequence per
+project, then generates and verifies the workspace live. The same package
+also carries the design for adopting Hedgehog's discipline into an
+existing repo without bootstrapping a workspace at all.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,12 @@ triggers and never touched by the same automation:
   history around 2026-08-14 for the incident this rule comes from). If a
   tag was pushed by mistake, delete it (`git push origin --delete
   v<version>`) before the PR merges so the workflow can create it fresh,
-  pointing at the actual merge commit.
+  pointing at the actual merge commit. `npm version patch` only writes
+  `package.json`/`package-lock.json` — it does not touch
+  `src/hosts/gemini/gemini-extension.json`, so bump that file's `version`
+  to match by hand in the same commit. Nothing currently gates on the two
+  agreeing, so a missed bump here stays silent rather than failing `npm
+  run check`.
 - `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`'s
   `version` fields (kept identical to each other) — the Claude Code
   plugin (`claude plugin install hedgehog`), whose payload is `skills/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,10 @@ discipline's stance and rationale.
 
 This repo is the engine: the CLI, the build graph, the host adapters, the
 core registry, and the agents and skills every core shares. Each core —
-`full-stack-app`, `pwa-app`, `landing-page`, `authored` — ships as its own
-npm package holding that core's workspace, agents, skills, and CLAUDE.md
-section. `src/registry/cores.json` names them; `init` fetches the one a
-project asks for.
+`full-stack-app`, `pwa-app`, `landing-page`, `deepseek-harness`, `authored`
+— ships as its own npm package holding that core's workspace, agents,
+skills, and CLAUDE.md section. `src/registry/cores.json` names them;
+`init` fetches the one a project asks for.
 
 ## Layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,10 +54,11 @@ follow:
 ## Stack changes
 
 Each core locks its own stack, in its own repo — `full-stack-app`'s,
-`pwa-app`'s, and `landing-page`'s tables live in `ARCHITECTURE.md` here,
-but the workspace, agents, and skills that implement them live in that
-core's own npm package (`hedgehog-core-full-stack-app`,
-`hedgehog-core-pwa-app`, `hedgehog-core-landing-page`).
+`pwa-app`'s, `landing-page`'s, and `deepseek-harness`'s tables live in
+`ARCHITECTURE.md` here, but the workspace, agents, and skills that
+implement them live in that core's own npm package
+(`hedgehog-core-full-stack-app`, `hedgehog-core-pwa-app`,
+`hedgehog-core-landing-page`, `hedgehog-core-deepseek-harness`).
 A stack is locked because it's what makes that core's build order
 mechanically enforced (Nx boundaries, phase gates, lefthook) rather than
 a convention the AI is asked to follow. Proposing a stack swap for an

--- a/README.md
+++ b/README.md
@@ -153,6 +153,24 @@ Hook
 Screen
 ```
 
+### DeepSeek Harness plugins
+
+Tools, hooks, and extensions for DSH's Cordis-based agent framework:
+
+``` text
+Scaffold
+  ↓
+Logic
+  ↓
+Wiring
+  ↓
+Smoke
+  ↓
+Bundle
+  ↓
+Join
+```
+
 ### Anything else
 
 A CLI, a library, a browser extension, a data pipeline, etc. gets its build order.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -38,8 +38,9 @@ consuming project installs. The interesting boundaries:
   from untrusted content, or that weakens a gate a project relies on,
   is a supply-chain issue.
 - **The core registry and fetcher** (`src/registry/`) — each core
-  (`full-stack-app`, `pwa-app`, `landing-page`, `authored`) ships as its
-  own npm package that `init` resolves and fetches; a bug here that lets
+  (`full-stack-app`, `pwa-app`, `landing-page`, `deepseek-harness`,
+  `authored`) ships as its own npm package that `init` resolves and fetches;
+  a bug here that lets
   a core install from an unintended source, or that skips validating
   what it fetched, is the same class of supply-chain issue as the
   payload above.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -193,8 +193,12 @@ entity or two (a points balance, a reward ledger) can live in an otherwise
 local-first `pwa-app` build. `full-stack-app` is for server-side logic across
 most of the app: authorization beyond row-level security, background jobs or
 webhooks as the app's primary function, server-rendered or SEO-critical pages,
-or a working set too large for a device. Judge a request against the core
-that fits it, not against a single core's shape.
+or a working set too large for a device. `deepseek-harness` fits a request to
+build a plugin, tool, hook, or extension for DeepSeek Harness (DSH) — a
+Cordis-based agent framework — or to extend an existing DSH installation via
+its plugin/bundle system; `DSH`, `Cordis`, `defineTool`, `ctx.tools.register`,
+or a `cordis.patch.yml` manifest are strong signals. Judge a request against
+the core that fits it, not against a single core's shape.
 
 This project does not have it installed (no `.hedgehog/` directory).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "5.1.8",
+  "version": "5.2.0",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/skills/hedgehog/SKILL.md
+++ b/skills/hedgehog/SKILL.md
@@ -39,6 +39,11 @@ Run the matching command:
   for headline, hero, problem, mechanism, objection, proof, and CTA, plus
   signature-element design and a review loop. A page that needs better
   positioning or copy is this core's central case.
+- DeepSeek Harness plugin: `npx @skyf0xx/hedgehog init --deepseek-harness`
+  — for building a tool, hook, or extension for DSH's Cordis-based agent
+  framework, or otherwise extending an existing DSH installation via its
+  plugin/bundle system. `DSH`, `Cordis`, `defineTool`, `ctx.tools.register`,
+  or a `cordis.patch.yml` manifest are strong signals.
 - Anything else — CLI, library, browser extension, data pipeline, an
   existing codebase, or not yet clear from the conversation:
   `npx @skyf0xx/hedgehog init` with no core flag. Planning intake decides

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "5.1.3",
+  "version": "5.2.0",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Summary
- Registers the new `deepseek-harness` core in `src/registry/cores.json`, pointing at `hedgehog-core-deepseek-harness`
- Documents the DeepSeek Harness plugin build pipeline (Scaffold → Logic → Wiring → Smoke → Bundle → Join) in the README's "What Hedgehog builds" section
- Bumps `package.json` to 5.2.0 (minor) for the new registered core

## Test plan
- [ ] `npx @skyf0xx/hedgehog init --deepseek-harness` resolves and installs the new core package