### PR TITLE
fix: correction Protocol reopen gap and missing deepseek-harness intake mapping

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -37,6 +37,7 @@ import {
   releaseTask,
   renewLease,
   retryTask,
+  reopenTask,
   reapExpiredLeases,
 } from '../src/db/claim.mjs';
 import { readyTasks, formatReady } from '../src/db/ready.mjs';
@@ -499,7 +500,9 @@ ${bold('Usage')}
   npx @skyf0xx/hedgehog update                    refresh the installed agents + skills
   npx @skyf0xx/hedgehog update --check            report whether a newer release is published
   npx @skyf0xx/hedgehog db init                   create .hedgehog/hedgehog.db if absent
-  npx @skyf0xx/hedgehog db rebuild                re-derive the build graph from committed intents + git history
+  npx @skyf0xx/hedgehog db rebuild                re-derive the build graph from committed intents + git history;
+                                                   also reconciles graph state after a hand-committed fix landed
+                                                   outside 'hedgehog verify' — run it to mark that work complete
   npx @skyf0xx/hedgehog plan                      compile pending intents into tasks + dependencies
                                                    (starts no graph server; --no-open says so explicitly)
   npx @skyf0xx/hedgehog plan --open               also start the graph server and open it, if anything compiled
@@ -515,6 +518,8 @@ ${bold('Usage')}
   npx @skyf0xx/hedgehog claim --owner <owner> [--count <n>]   atomically claim up to n ready tasks
   npx @skyf0xx/hedgehog claim <task-id> --owner <owner>   claim one specific task (breaks a starvation tie)
   npx @skyf0xx/hedgehog retry <task-id>           return a blocked task to planned, so it can be rebuilt
+  npx @skyf0xx/hedgehog reopen <task-id> --confirm   return a complete task (and its complete dependents) to
+                                                   planned, for a Correction Protocol fix to an already-shipped layer
   npx @skyf0xx/hedgehog release <task-id> --owner <owner>   hand a claimed task back to ready
   npx @skyf0xx/hedgehog renew <task-id> --owner <owner> [--minutes <n>]   extend a held lease
   npx @skyf0xx/hedgehog verify <task-id> --owner <owner>   run scope + verify checks, commit on pass
@@ -1927,6 +1932,84 @@ async function retryCommand(args) {
   console.log(`  ${dim('claim it with')}  hedgehog claim ${taskId} --owner <owner>`);
 }
 
+// `hedgehog reopen <task-id> --confirm` — the transition out of
+// `complete`, for a Correction Protocol fix: a downstream layer reveals
+// an upstream one (already verified, committed, and possibly built upon)
+// was wrong. `retry` only returns a `blocked` task to `planned`; nothing
+// else in the CLI moves a `complete` task backward, which left a
+// Correction Protocol fix with no path but a hand-authored commit
+// outside `hedgehog verify` entirely (see the issue this command closes).
+//
+// `--confirm` is required and is the whole difference from `retry`'s
+// UX: retrying a blocked task undoes nothing that shipped, but reopening
+// a complete task does, transitively, for everything built on top of it
+// — that's consequential enough to need the caller to say so explicitly
+// rather than default to it.
+async function reopenCommand(args) {
+  await ensureDb();
+
+  const taskId = args[0] && !args[0].startsWith('--') ? args[0] : undefined;
+  const confirmed = args.includes('--confirm');
+  if (!taskId) {
+    console.error(`${red('Usage:')} hedgehog reopen <task-id> --confirm\n`);
+    process.exitCode = 1;
+    return;
+  }
+  if (!confirmed) {
+    console.error(
+      `${red('Refused.')} Reopening ${bold(taskId)} undoes a completed, committed layer and\n` +
+        `every completed layer built on top of it. Re-run with ${bold('--confirm')} to proceed:\n\n` +
+        `  hedgehog reopen ${taskId} --confirm\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!(await exists(DB_PATH))) {
+    console.error(`${red('No build graph found.')} Run ${bold('hedgehog db init')} first.\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  printDbTarget();
+
+  const db = openDb();
+  let result;
+  try {
+    result = reopenTask(db, taskId);
+  } finally {
+    db.close();
+  }
+
+  if (!result.reopened) {
+    process.exitCode = 1;
+    if (result.reason === 'no_such_task') {
+      console.error(`${red('No such task:')} ${bold(taskId)}${dim(` (in ${dbAbsPath()})`)}\n`);
+      return;
+    }
+    console.error(
+      `${red('Not reopened.')} Task ${bold(taskId)} is ${bold(result.task.status)}, not ${bold('complete')}.\n`,
+    );
+    return;
+  }
+
+  console.log(
+    `${green(bold('Reopened.'))} ${bold(result.reopenedIds.length)} task(s) back to ${bold('planned')}: ${result.reopenedIds.join(', ')}`,
+  );
+  console.log(`  ${dim('claim the fix with')}  hedgehog claim ${taskId} --owner <owner>`);
+  if (result.stillInFlight.length > 0) {
+    console.log(
+      `\n${yellow(bold('Downstream, not reopened'))} (not complete — nothing shipped yet to invalidate):`,
+    );
+    for (const t of result.stillInFlight) {
+      console.log(`  ${bold(t.id)}   ${t.status}`);
+    }
+  }
+  console.log(
+    `\n${dim('Hand-committing the fix instead of running it through')} ${bold('hedgehog verify')}${dim('? Reconcile graph state afterward with')} ${bold('hedgehog db rebuild')}${dim('.')}`,
+  );
+}
+
 // `hedgehog show <task-id>` — the same packet `next` prints, for a task
 // named by id whatever its status. Read-only: claims nothing, changes
 // nothing.
@@ -2919,6 +3002,11 @@ async function main() {
 
   if (cmd === 'retry') {
     await retryCommand(args.slice(1));
+    return;
+  }
+
+  if (cmd === 'reopen') {
+    await reopenCommand(args.slice(1));
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/repro/10-reopen-complete-for-correction-protocol.mjs
+++ b/repro/10-reopen-complete-for-correction-protocol.mjs
@@ -1,0 +1,123 @@
+// A Correction Protocol fix discovers, downstream, that an already
+// `complete` layer was wrong. Before `hedgehog reopen`, nothing in the
+// CLI moved a `complete` task backward: `retry` only accepts `blocked`,
+// `release` only accepts `building`, `verify` only accepts a task leased
+// to the caller. The only way to land the fix was a hand-authored commit
+// outside `hedgehog verify` entirely, bypassing the build graph.
+//
+// Two things this command must get right:
+//   A. Reopening an upstream layer must reopen every already-complete
+//      layer built on top of it too — a dependent's completion is only
+//      honest relative to what it was built against, and a stale
+//      dependent left `complete` would report the build done while it
+//      still reflects the un-fixed upstream output.
+//   B. It must require `--confirm` — this undoes verified, committed,
+//      possibly-built-upon work, which is a different order of
+//      consequence than retrying a task the loop itself just blocked.
+
+import {
+  makeProject,
+  addIntent,
+  cli,
+  commitTaskSubject,
+  rebuildFromScratch,
+  taskStatuses,
+  cleanup,
+  check,
+  checkContains,
+  report,
+} from './_lib.mjs';
+
+// A straight three-layer chain on one module: schema -> api -> smoke.
+const CORE = `
+id: reopen-fixture
+layers:
+  - id: schema
+    scope: ["libs/{module}/schema/**"]
+    verify: "true"
+    commit: "feat({module}): schema"
+  - id: api
+    depends_on: schema
+    scope: ["apps/api/{module}/**"]
+    verify: "true"
+    commit: "feat({module}): api"
+  - id: smoke
+    depends_on: api
+    scope: ["tests/{module}/**"]
+    verify: "true"
+    commit: "test({module}): smoke"
+`;
+
+const dir = makeProject(CORE, { git: true });
+try {
+  addIntent(dir, 'sassy');
+  check('plan exits 0', 0, cli(dir, ['plan']).status);
+
+  for (const id of ['SASSY-SCHEMA', 'SASSY-API', 'SASSY-SMOKE']) {
+    commitTaskSubject(dir, id);
+  }
+  check('rebuild after the chain lands exits 0', 0, rebuildFromScratch(dir).status);
+  check(
+    'the whole chain is complete before the correction',
+    { 'SASSY-API': 'complete', 'SASSY-SCHEMA': 'complete', 'SASSY-SMOKE': 'complete' },
+    taskStatuses(dir),
+  );
+
+  // Reopen refuses without --confirm, and changes nothing.
+  const unconfirmed = cli(dir, ['reopen', 'SASSY-SCHEMA']);
+  check('reopen without --confirm exits non-zero', true, unconfirmed.status !== 0);
+  checkContains(
+    'reopen without --confirm names the flag it needs',
+    `${unconfirmed.stdout}${unconfirmed.stderr}`,
+    '--confirm',
+  );
+  check(
+    'nothing moved without --confirm',
+    { 'SASSY-API': 'complete', 'SASSY-SCHEMA': 'complete', 'SASSY-SMOKE': 'complete' },
+    taskStatuses(dir),
+  );
+
+  // retry refuses a complete task outright — it only accepts blocked.
+  const retried = cli(dir, ['retry', 'SASSY-SCHEMA']);
+  check('retry on a complete task exits non-zero', true, retried.status !== 0);
+
+  // Reopening the schema layer must cascade to api and smoke, both
+  // already complete and built on top of it.
+  const reopened = cli(dir, ['reopen', 'SASSY-SCHEMA', '--confirm']);
+  check('reopen --confirm exits 0', 0, reopened.status);
+  checkContains('reopen reports the transition', reopened.stdout, 'Reopened');
+  check(
+    'the fixed layer and every complete dependent go back to planned',
+    { 'SASSY-API': 'planned', 'SASSY-SCHEMA': 'planned', 'SASSY-SMOKE': 'planned' },
+    taskStatuses(dir),
+  );
+
+  // The loop closes normally from here: claim, verify, and the chain is
+  // complete again — reopening is not a ratchet. Claiming picks the one
+  // ready task (SASSY-SCHEMA, nothing else has a satisfied dependency
+  // set yet); verifying it unlocks SASSY-API to `ready` in turn.
+  check('claim after reopen exits 0', 0, cli(dir, ['claim', '--owner', 'ag1']).status);
+  check(
+    'verify after reopen exits 0',
+    0,
+    cli(dir, ['verify', 'SASSY-SCHEMA', '--owner', 'ag1']).status,
+  );
+  check(
+    'the fixed layer is complete again and its dependent is unlocked',
+    { 'SASSY-SCHEMA': 'complete', 'SASSY-API': 'ready' },
+    { 'SASSY-SCHEMA': taskStatuses(dir)['SASSY-SCHEMA'], 'SASSY-API': taskStatuses(dir)['SASSY-API'] },
+  );
+
+  // A no-op reopen: reopening a task that isn't complete refuses cleanly.
+  const reopenAgain = cli(dir, ['reopen', 'SASSY-API', '--confirm']);
+  check('reopening a task that is not complete refuses', true, reopenAgain.status !== 0);
+  checkContains(
+    "refusal names the task's actual status",
+    `${reopenAgain.stdout}${reopenAgain.stderr}`,
+    'ready',
+  );
+} finally {
+  cleanup(dir);
+}
+
+report('10 — reopen returns a complete task and its complete dependents to planned');

--- a/src/agents/planner.md
+++ b/src/agents/planner.md
@@ -256,11 +256,20 @@ the first-run shape; on re-entry, run `hedgehog-planning-intake`'s
   owns `.hedgehog/chain/00-brief.md` and this core's own Confirm & Lock
   stage; `.hedgehog/BMAD/` is written by the shared Phase 0 in
   `hedgehog-planning-intake`.
+- **`deepseek-harness`** → no BMAD shelf runs on this core, and none of
+  `hedgehog-planning-intake` applies. Intake is mechanical, owned
+  entirely by `hedgehog-dsh-loop`'s own Planning intake section: confirm
+  the plugin name and goal with the user, one intent per plugin named
+  directly, `hedgehog intent add`, `hedgehog plan`, commit, hand off to
+  `bootstrap`. There is no subject/audience/job to mine and no brief to
+  lock — open that skill's section rather than looking for the shape
+  above here.
 
 Either way, this is the mechanical procedure; the judgment — what's
 actually in scope, where a table becomes a module (full-stack-app,
 pwa-app) or what the page's single job actually is (landing-page) —
-stays yours throughout.
+stays yours throughout, except on deepseek-harness, where the procedure
+itself is the judgment call: which plugin, named directly with the user.
 
 ## The Add-ons decision (full-stack-app only)
 

--- a/src/db/claim.mjs
+++ b/src/db/claim.mjs
@@ -401,6 +401,94 @@ export function retryTask(db, taskId) {
   });
 }
 
+// The full transitive closure of tasks that depend on `taskId`, directly
+// or through another dependent — the same walk verify.mjs's
+// loadDirectDependents feeds one layer at a time, extended to every
+// layer downstream. A Correction Protocol reopen has to see this whole
+// chain: an upstream task built on wrong output can have several
+// already-complete layers stacked on it, and every one of them was
+// built against the thing that's about to change.
+function loadTransitiveDependents(db, taskId) {
+  const directDependents = db.prepare(
+    'SELECT task_id AS id FROM dependencies WHERE depends_on_task_id = ?',
+  );
+  const seen = new Set([taskId]);
+  const downstream = [];
+  let frontier = [taskId];
+  while (frontier.length > 0) {
+    const next = [];
+    for (const id of frontier) {
+      for (const row of directDependents.all(id)) {
+        if (seen.has(row.id)) continue;
+        seen.add(row.id);
+        downstream.push(row.id);
+        next.push(row.id);
+      }
+    }
+    frontier = next;
+  }
+  return downstream;
+}
+
+// Reopens `taskId` for a Correction Protocol fix: moves a `complete` task
+// (and every `complete` task downstream of it, transitively) back to
+// `planned`, so the fix and every layer built on top of it are rebuilt
+// and re-verified in dependency order, the same as any other `planned`
+// task.
+//
+// This is deliberately not folded into `retryTask` as an automatic extra
+// case: `retry` returns a task the loop itself put into `blocked` —
+// expected, low-stakes, no confirmation needed. Reopening a `complete`
+// task undoes a task the loop already verified and committed, and can
+// invalidate everything built against it since, which is why the CLI
+// requires an explicit `--confirm` before calling this — see
+// `reopenCommand`.
+//
+// A downstream task not yet `complete` (still `planned`, `ready`,
+// `building`, `blocked`) is left exactly where it is: it hasn't shipped
+// anything for the fix to invalidate, and its own lease (if any) is not
+// this command's to touch. Only `complete` tasks — upstream's own status
+// plus every `complete` descendant — move; anything else downstream is
+// reported back so the caller can decide what to do about in-flight
+// work sitting on top of a reopened dependency.
+export function reopenTask(db, taskId) {
+  return inTransaction(db, () => {
+    reapExpiredLeases(db);
+    const task = loadTask(db, taskId);
+    if (task === undefined) return { reopened: false, reason: 'no_such_task' };
+    if (task.status !== 'complete') {
+      return { reopened: false, reason: 'not_complete', task };
+    }
+
+    const downstreamIds = loadTransitiveDependents(db, taskId);
+    const downstreamTasks = downstreamIds.map((id) => loadTask(db, id));
+    const toReopen = [task, ...downstreamTasks.filter((t) => t.status === 'complete')];
+    const stillInFlight = downstreamTasks.filter((t) => t.status !== 'complete');
+
+    const reopenOne = db.prepare(
+      `
+      UPDATE tasks SET status = 'planned', blocked_reason = NULL,
+        lease_owner = NULL, lease_expires_at = NULL, leased_at = NULL,
+        claim_snapshot = NULL
+      WHERE id = ? AND status = 'complete'
+      RETURNING id
+    `,
+    );
+    const reopenedIds = [];
+    for (const t of toReopen) {
+      const result = reopenOne.get(t.id);
+      if (result !== undefined) reopenedIds.push(result.id);
+    }
+
+    return {
+      reopened: true,
+      reopenedIds,
+      stillInFlight,
+      task: loadTask(db, taskId),
+    };
+  });
+}
+
 // Releases `taskId` back to `ready` if `owner` currently holds its lease.
 // Scoped to `status = 'building'` — `verifying` is the engine's own
 // transient lease during verifyTask, not something an external release

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Summary

Two fixes from the deepseek-harness dogfooding friction log (skyf0xx/hedgehog#210-227):

- **`hedgehog reopen <task-id> --confirm`** — a Correction Protocol fix discovered downstream (a later layer breaks, traces back to an earlier layer that already verified and committed as `complete`) had no CLI path back to `planned`. `retry` only accepts a `blocked` task. This adds `reopen`, which moves a `complete` task and every already-`complete` task transitively downstream of it back to `planned`, requiring an explicit `--confirm` since it undoes shipped, committed work. Also documents `hedgehog db rebuild` as the existing (previously undocumented) way to reconcile graph state after a hand-authored commit.
- **`planner.md`'s Phase 1 intake mapping** never mentioned `deepseek-harness`, even though it has its own documented, deliberately non-BMAD intake procedure. Added a fourth bullet matching the existing three cores' style, pointing to `hedgehog-dsh-loop`'s own Planning intake section as the owner.

Version bumped 5.2.0 → 5.3.0 (`package.json`, synced to `src/hosts/gemini/gemini-extension.json` per this repo's release convention — no `skills/`/`hooks/`/`.claude-plugin/` changes, so the plugin version is untouched).

Fixes #220, #226

## Test plan
- [x] `node --experimental-sqlite repro/run-all.mjs` — all reproductions pass, including new `repro/10-reopen-complete-for-correction-protocol.mjs`
- [x] `npm run check` — clean except one pre-existing, unrelated failure (landing-page manifest fixture drift), confirmed present on master before this branch