### PR TITLE
fix: deepseek-harness dogfooding friction — bundle FIRST ARRIVAL false positive, plural-id warning

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1302,9 +1302,10 @@ async function warnSingularModuleId(intent) {
 
   console.log(
     `\n${yellow(bold('Module id looks singular.'))} On this core the intent id is ${bold('{module}')} in\n` +
-      `every layer's scope, and the generators take it plural — so ${bold(intent.id)} compiles\n` +
-      `scope for ${bold(`${intent.id}/`)} while the scaffold command writes ${bold(`${intent.id}s/`)}.\n` +
-      `If ${bold(`${intent.id}s`)} is the name you meant, fix it now, before ${bold('hedgehog plan')}:\n` +
+      `every layer's scope. On some cores the generator pluralizes it, so ${bold(intent.id)} would\n` +
+      `compile scope for ${bold(`${intent.id}/`)} while the scaffold command writes ${bold(`${intent.id}s/`)} — worth\n` +
+      `checking this core's own generator before ${bold('hedgehog plan')}. If ${bold(`${intent.id}s`)} is the name you\n` +
+      `meant, it's still cheap to fix now:\n` +
       `  ${dim(`git mv ${INTENTS_DIR}/${intent.id}.json ${INTENTS_DIR}/${intent.id}s.json`)}\n` +
       `  ${dim(`# edit "id" and every ${intent.id.toUpperCase()}-* requirement id, then:`)}\n` +
       `  ${dim('hedgehog db rebuild')}\n`,
@@ -1352,11 +1353,12 @@ function warnSingularModuleIdsAtPlan(core, db) {
   console.log(
     `${yellow(bold(many ? `${singular.length} module ids look singular.` : 'Module id looks singular.'))} ` +
       `On this core an intent id is ${bold('{module}')} in\n` +
-      `every layer's scope, and the generators take it plural — so ${many ? 'each of these compiles' : 'this compiles'}\n` +
-      `scope for a directory the scaffold command will never write:\n` +
-      singular.map((id) => `  ${bold(id)} ${dim(`— scope ${id}/, scaffold writes ${id}s/`)}`).join('\n') +
+      `every layer's scope. On some cores the generator pluralizes it, so ${many ? 'each of these would compile' : 'this would compile'}\n` +
+      `scope for a directory the scaffold command might never write:\n` +
+      singular.map((id) => `  ${bold(id)} ${dim(`— scope ${id}/, generator may instead write ${id}s/`)}`).join('\n') +
       `\n\nThis is a naming convention, not a rule — ${bold('billing')} and ${bold('search')} are ` +
-      `legitimately\nsingular. If the plural is what you meant, it is still cheap to fix:\n` +
+      `legitimately\nsingular, and not every core's generator pluralizes at all — check this core's own\n` +
+      `generator before assuming it does. If the plural is what you meant, it is still cheap to fix:\n` +
       singular
         .map(
           (id) =>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/repro/plan-warns-singular-module-ids.mjs
+++ b/repro/plan-warns-singular-module-ids.mjs
@@ -171,7 +171,7 @@ console.log('repro: plan re-raises the singular module-id check\n');
     const planned = cli(dir, ['plan']);
     check('B2. plan succeeds', 0, planned.status);
     checkContains('B3. plan catches the replayed singular id', planned.stdout, 'Module id looks singular');
-    checkContains('B4. singular phrasing for exactly one id', planned.stdout, 'so this compiles');
+    checkContains('B4. singular phrasing for exactly one id', planned.stdout, 'so this would compile');
   } finally {
     cleanup(dir);
   }

--- a/src/db/next.mjs
+++ b/src/db/next.mjs
@@ -394,14 +394,29 @@ export function scopePackageRoot(glob, module) {
 // `exists` is injected so this module keeps no filesystem dependency of
 // its own; the CLI passes a real one and the packet degrades to no
 // section when a caller supplies none.
+//
+// A layer can carry more than one glob into the same real package — e.g.
+// `plugins/{module}/package.json` and `plugins/{module}/lib/**` both
+// belong to one package, but the second glob's own literal prefix ends
+// at `lib`, a build-output directory that never holds a `package.json`
+// of its own. Naively treating every such root as first-arrival would
+// flag `lib/` as a second package needing its own scaffold. A root
+// nested under another of this task's own roots is never a package
+// boundary — only the shallowest root in each chain is.
 export function firstArrivalPackages(task, exists) {
   if (!exists) return [];
-  const roots = new Set();
+  const allRoots = new Set();
+  const missing = new Set();
   for (const glob of JSON.parse(task.scope_globs)) {
     const root = scopePackageRoot(glob, task.module);
-    if (root && !exists(`${root}/package.json`)) roots.add(root);
+    if (!root) continue;
+    allRoots.add(root);
+    if (!exists(`${root}/package.json`)) missing.add(root);
   }
-  return [...roots].sort();
+  const outermost = [...missing].filter(
+    (root) => ![...allRoots].some((other) => other !== root && root.startsWith(`${other}/`)),
+  );
+  return outermost.sort();
 }
 
 function firstArrivalLines(task, roots) {

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Summary
- `firstArrivalPackages()` in `src/db/next.mjs` computed each scope glob's package root independently, so a layer whose scope spans a real package root plus a nested build-output glob (deepseek-harness's `bundle` layer: `plugins/{module}/package.json` + `plugins/{module}/lib/**`) wrongly flagged `lib/` as its own "first arrival" package needing a generator/vitest scaffold that doesn't exist on that core. A root nested under another root in the same task's scope is no longer treated as a package boundary.
- The singular/plural module-id advisory in `bin/cli.mjs` asserted as fact that "the generators take it plural" — true for `full-stack-app`-style cores, false for `deepseek-harness`'s tool generator (uses the id verbatim, no pluralization). This repo can't know a given core's actual generator behavior, so the message now reads as a heads-up to check the core's own generator rather than a false claim about what it does.
- Closes #218 and #226 (both already fixed: #218 upstream in `hedgehog-core-deepseek-harness#1`, #226 in PR #228) with closing comments — no code change needed for those here.

Fixes #211, #221 (dogfooding friction filed against the deepseek-harness core, #211-227).

## Test plan
- [x] `npm run repro` — all 57 reproductions pass, including the updated wording assertion in `plan-warns-singular-module-ids.mjs` and existing `first-arrival-in-packet.mjs` coverage
- [x] `npm run check` — pre-existing unrelated failure (stale `landing-page` manifest fixture) confirmed present on master too, not introduced here
- [x] Manually verified `firstArrivalPackages` against deepseek-harness's bundle scope (no false positive), full-stack-app's real first-arrival case (still fires), and two independent sibling packages in one task (both still flagged)