### PR TITLE
fix: deepseek-harness stuck on 0.1.0 due to caret range on a 0.x pin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,17 @@ Each core package carries a third version, in its own repo and released
 from there — a change to a core's workspace, agents, or skills is a
 release of that package, not of this one. `src/registry/cores.json` names
 the version range `init` resolves for each, so widening a core's range is
-the one edit here that a core release calls for. Each core repo carries
+the one edit here that a core release calls for — and a core's version
+bump is not, on its own, sufficient for `init`/`update` to reach it: a
+caret range only resolves within the pinned major (or, below `1.0.0`,
+within the pinned minor — `^0.1.0` never resolves to `0.2.0` even after
+`0.2.0` ships), so a core crossing that boundary needs its range in
+`cores.json` widened and a new `hedgehog` release cut, or every consumer
+stays pinned to the old version with no error anywhere (`npm run check`
+catches this — it queries each core's actual latest published version
+against its pinned range and fails on a mismatch — but the range still
+has to be widened by hand, not just left for the next check run to
+complain about). Each core repo carries
 its own `.github/workflows/publish.yml`, structured the same way as this
 repo's: a version bump to that core's own `package.json`, committed and
 merged to that repo's own `main`, is the trigger — the workflow diffs the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -145,6 +145,57 @@ for (const core of cores) {
   }
 }
 
+// ── 2c. Every core's pinned version range can still resolve to that
+//    core's actual latest published version. A caret range on a 0.x
+//    version (`^0.1.0`) only ever satisfies patches within that minor —
+//    it silently cannot advance to 0.2.0 even after 0.2.0 ships, so a
+//    core release and this repo's own release can drift apart with no
+//    error anywhere (see #235). Network-dependent, so it only runs when
+//    npm is reachable — CI always has it; an offline local run degrades
+//    to skipping this one check rather than failing on connectivity. ────
+{
+  const skipReason = process.env.HEDGEHOG_SKIP_REGISTRY_VERSION_CHECK;
+  if (!skipReason) {
+    for (const core of cores) {
+      if (!core.package || !core.version) continue;
+      let latest;
+      try {
+        latest = execFileSync('npm', ['view', core.package, 'version'], {
+          encoding: 'utf8',
+          timeout: 15000,
+        }).trim();
+      } catch {
+        continue; // offline or registry unreachable — not this check's failure to report
+      }
+      if (!latest) continue;
+      // `npm view <pkg>@<range> version` prints every version the range
+      // satisfies, not just the highest — ascending order, so the last
+      // line is the one `npm pack`/`npm install` would actually resolve.
+      let resolved = '';
+      try {
+        const raw = execFileSync(
+          'npm',
+          ['view', `${core.package}@${core.version}`, 'version', '--json'],
+          { encoding: 'utf8', timeout: 15000 },
+        ).trim();
+        const parsed = JSON.parse(raw);
+        resolved = Array.isArray(parsed) ? parsed.at(-1) : parsed;
+      } catch {
+        resolved = '';
+      }
+      if (resolved !== latest) {
+        fail(
+          `src/registry/cores.json: core "${core.name}" is pinned to "${core.version}", ` +
+            `which resolves to ${resolved || 'nothing'} — but ${core.package}'s latest ` +
+            `published version is ${latest}. Widen the pin (e.g. ">=X.0.0 <Y.0.0" spanning ` +
+            `the current major) so a future release of that core doesn't require a new ` +
+            `hedgehog release just to reach it.`,
+        );
+      }
+    }
+  }
+}
+
 // ── 3. Cross-references: every agent named in AGENT_CAPABILITY exists,
 //    and every agent file exists in AGENT_CAPABILITY (capabilities.mjs
 //    fails closed to 'readonly' for unknown agents, so a silently

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }

--- a/src/registry/cores.json
+++ b/src/registry/cores.json
@@ -31,7 +31,7 @@
       "name": "deepseek-harness",
       "flag": "--deepseek-harness",
       "package": "@skyf0xx/hedgehog-core-deepseek-harness",
-      "version": "^0.1.0",
+      "version": ">=0.1.0 <1.0.0",
       "language": "typescript",
       "repository": "https://github.com/skyf0xx/hedgehog-core-deepseek-harness",
       "selects_when": "The description names building a plugin, tool, hook, or extension for DeepSeek Harness (DSH) — a Cordis-based agent framework — or otherwise extending an existing DSH installation with new capabilities via its plugin/bundle system. Concrete signals: DSH, DeepSeek Harness, Cordis, `defineTool`, `ctx.tools.register`, a `cordis.patch.yml` manifest, or a request to add a tool that a DSH agent can call. This is the core most often confused with authored: authored fits when no shipped core matches and the planner must design a system shape from scratch, but a DSH plugin already has a fixed, battle-tested shape (the six-layer scaffold → logic → wiring → smoke → bundle → join sequence, one plugin per intent) that authored's from-scratch design would only reinvent worse. Route here whenever the target of the work is a DSH plugin, not a general \"no other core fits\" fallback."


### PR DESCRIPTION
## Summary
- `src/registry/cores.json` pinned `deepseek-harness` to `^0.1.0`. Under semver, a caret range on a `0.x` version only allows patch bumps within that minor (`>=0.1.0 <0.2.0`) — it could never resolve to `0.2.0`, regardless of how long `0.2.0` had been published. Every `init`/`update` stayed stuck on 0.1.0 with no error anywhere. Widened to `>=0.1.0 <1.0.0`; confirmed via `npm pack` that this now resolves to `0.2.0`.
- Added a standing check to `scripts/check.mjs` (already wired into `publish.yml` as a pre-`npm publish` gate) that queries each registry entry's actual latest published npm version against its pinned range and fails the build on a mismatch. This closes the whole class of bug, not just this one core — the same caret trap will otherwise resurface for any of the other cores the moment they cross a major version boundary.
- Added a note to root `CLAUDE.md`'s Releasing section explaining the caret-on-0.x trap and pointing at the new `check.mjs` gate, next to the existing "widening a core's range is the one edit here a core release calls for" line.

Fixes #235.

## Test plan
- [x] `npm run check` — passes for all 5 registry entries; manually reverted the pin back to `^0.1.0` and confirmed the new check catches it with a clear message, then restored the fix
- [x] `npm run repro` — all 57 reproductions pass
- [x] `npm pack "@skyf0xx/hedgehog-core-deepseek-harness@>=0.1.0 <1.0.0"` — confirms the widened range resolves to 0.2.0 in production's actual resolution path (`npm pack`, same as `fetch.mjs`'s `packSpec`)