### PR TITLE
fix: dogfooding friction on deepseek-harness (#238, #239, #242, #244)

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -674,6 +674,16 @@ async function init({ force, core, host = DEFAULT_HOST, hostOnly = false }) {
     )}\n`,
   );
   console.log('Next steps:');
+  // This install itself just fetched globalInstall.latest to run, so the
+  // global binary is already ahead of the version this run scaffolded
+  // with. Printed as step 0 here rather than left for `status`'s passive
+  // nudge to surface later, mixed in with routine output well into the
+  // build.
+  if (globalInstall?.updated) {
+    console.log(
+      `  0. ${bold(`npx @skyf0xx/hedgehog@latest update`)} ${dim(`(picks up ${globalInstall.latest} before intake begins)`)}`,
+    );
+  }
   // A core that landed a workspace landed its root package.json with it,
   // so there are dependencies to install before the first commit.
   if (core?.manifest.workspace) {
@@ -1450,8 +1460,15 @@ async function noteAvailableUpdate() {
 // The install/update itself always runs regardless of `quiet` — silence
 // governs only whether this prints, matching `boundary --quiet`'s "exit
 // code only, nothing on either stream" contract for shell hooks.
+// Returns `{ updated, latest }` — `updated` true only when this call
+// actually installed a newer global version this run is not yet running
+// on. `init` uses that to put the update command explicitly in its own
+// "Next steps" rather than leaving it to be discovered later via
+// `status`'s passive nudge, since by the time `init` prints its own
+// output the global binary is already ahead of the version this run used
+// to scaffold the project.
 async function ensureGlobalInstall({ quiet = false } = {}) {
-  if (process.env.HEDGEHOG_NO_UPDATE_CHECK) return;
+  if (process.env.HEDGEHOG_NO_UPDATE_CHECK) return { updated: false };
   try {
     const globalRoot = execFileSync('npm', ['root', '-g'], {
       encoding: 'utf8',
@@ -1459,8 +1476,8 @@ async function ensureGlobalInstall({ quiet = false } = {}) {
     }).trim();
     const runningFromGlobal = PKG_ROOT === join(globalRoot, '@skyf0xx/hedgehog');
     const { latest, stale } = await checkBinaryStaleness(DEST_ROOT, PKG_VERSION);
-    if (runningFromGlobal && !stale) return;
-    if (!latest) return;
+    if (runningFromGlobal && !stale) return { updated: false };
+    if (!latest) return { updated: false };
 
     execFileSync('npm', ['install', '-g', `@skyf0xx/hedgehog@${latest}`], {
       stdio: 'ignore',
@@ -1475,9 +1492,11 @@ async function ensureGlobalInstall({ quiet = false } = {}) {
         )}`,
       );
     }
+    return { updated: runningFromGlobal, latest };
   } catch {
     // Advisory only — a failed check or install is never worth failing a
     // command over.
+    return { updated: false };
   }
 }
 
@@ -2901,7 +2920,7 @@ async function main() {
     console.log(PKG_VERSION);
     return;
   }
-  await ensureGlobalInstall({ quiet: args.includes('--quiet') });
+  const globalInstall = await ensureGlobalInstall({ quiet: args.includes('--quiet') });
   const cmd = args[0];
   const force = args.includes('--force') || args.includes('-f');
 
@@ -2972,7 +2991,7 @@ async function main() {
     // the first host; the rest add only what differs per host.
     const targets = hosts.length ? hosts : [DEFAULT_HOST];
     for (const [i, host] of targets.entries()) {
-      await init({ force, core, host, hostOnly: i > 0 });
+      await init({ force, core, host, hostOnly: i > 0, globalInstall });
     }
     return;
   }

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -585,9 +585,33 @@ the @latest tag matters, since a bare npx may reuse a cached older CLI.
 `);
 }
 
+// The entire Hedgehog discipline is commit-per-layer/step — every loop
+// skill's own enforcement mechanism assumes `git commit` works in this
+// directory. Checked here rather than left to surface as a failed commit
+// several planning-intake steps later, after work with nowhere to land
+// as history has already happened. Run unattended, the same as
+// ensureGlobalInstall: this binary has no stdin channel to prompt on in
+// the general case, and `init` already writes every other file without
+// confirmation.
+function ensureGitRepo() {
+  try {
+    execFileSync('git', ['rev-parse', '--is-inside-work-tree'], {
+      stdio: 'ignore',
+      timeout: 5_000,
+    });
+    return;
+  } catch {
+    // Not inside a work tree — fall through to init one.
+  }
+  execFileSync('git', ['init'], { stdio: 'ignore', timeout: 5_000 });
+  console.log(dim('  (no git repository found here — ran `git init`, since every later step commits)'));
+}
+
 // `core` is the fetched core — `{ manifest, root, version }` — or null on
 // a deferred install, where planner picks one later.
 async function init({ force, core, host = DEFAULT_HOST, hostOnly = false }) {
+  ensureGitRepo();
+
   // Resolve the full list of writes up front so we can detect conflicts
   // before touching anything. A deferred install plans against `null` —
   // the shared agents/skills/build-graph payload only.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/repro/11-friction-logged-mid-layer-does-not-block-verify.mjs
+++ b/repro/11-friction-logged-mid-layer-does-not-block-verify.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// `hedgehog-*-loop` instructs logging friction the moment it's hit,
+// mid-layer — before the task's own verify runs. `friction add` appends
+// to `.hedgehog/friction/log.md`, which then sits dirty in the working
+// tree at verify time. That path is build-graph state, committed by
+// `friction add` itself, never by a layer — verify's scope gate must not
+// attribute it to whatever task happens to be building.
+
+import { writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { makeProject, hedgehog, readTask, assert, assertIncludes, runRepro } from './lib.mjs';
+
+await runRepro('friction logged mid-layer does not block verify', async () => {
+  const { dir, dbPath, cleanup } = await makeProject();
+  try {
+    hedgehog(dir, ['claim', '--owner', 'ag1']);
+
+    await mkdir(join(dir, 'src/alpha'), { recursive: true });
+    await writeFile(join(dir, 'src/alpha/schema.txt'), 'schema\n');
+
+    hedgehog(dir, ['friction', 'add', 'hit a snag mid-layer', '--task', 'ALPHA-SCHEMA']);
+
+    const verified = hedgehog(dir, ['verify', 'ALPHA-SCHEMA', '--owner', 'ag1']);
+    assertIncludes(verified.out, 'Verified', 'mid-layer friction must not trip the scope gate');
+
+    const task = readTask(dbPath, 'ALPHA-SCHEMA');
+    assert(task.status === 'complete', `expected complete, got ${task.status}`);
+  } finally {
+    await cleanup();
+  }
+});

--- a/repro/first-arrival-in-packet.mjs
+++ b/repro/first-arrival-in-packet.mjs
@@ -27,7 +27,11 @@ import {
 // Both shapes the full-stack-app core uses: a package root ABOVE the
 // {module} segment (packages/contracts/src/{module}), and one BELOW it
 // (libs/{module}/repository), which is why the root cannot simply be
-// "everything left of the first wildcard".
+// "everything left of the first wildcard". A third layer's scope is a
+// single literal file with no wildcard at all, deepseek-harness's own
+// shape (`.hedgehog/dsh-smoke/{module}.md`) — its parent directory is
+// never a package (no generator will ever write a package.json there),
+// so it must never be flagged as a first arrival.
 const CORE = `
 id: first-arrival-fixture
 layers:
@@ -40,6 +44,11 @@ layers:
     scope: ["libs/{module}/repository/**"]
     verify: "true"
     commit: "feat({module}): repository"
+  - id: prompt
+    depends_on: repository
+    scope: [".fixture/prompts/{module}.md"]
+    verify: "true"
+    commit: "feat({module}): prompt"
 `;
 
 const dir = makeProject(CORE, { git: true });
@@ -79,6 +88,15 @@ try {
     'a root below {module} is named with the module substituted in',
     repo.stdout,
     'libs/tasks/repository does not exist yet',
+  );
+
+  // A literal-file scope (no wildcard) never has a package root, so its
+  // packet carries no FIRST ARRIVAL section at all — not even a false one.
+  const prompt = cli(dir, ['show', 'TASKS-PROMPT']);
+  check(
+    'a single-file scope with no wildcard is never a first arrival',
+    false,
+    prompt.stdout.includes('FIRST ARRIVAL'),
   );
 
   // The package landing is what clears it — module two through the same

--- a/repro/fixtures/cores/landing-page.manifest.yaml
+++ b/repro/fixtures/cores/landing-page.manifest.yaml
@@ -7,6 +7,4 @@ template: CLAUDE.core.md
 agents: [landing-builder, landing-copywriter, landing-executor,
          landing-visual-reviewer, landing-ux-reviewer]
 skills: [hedgehog-landing-loop, hedgehog-bootstrap-landing-page-core,
-         landing-shapes, landing-copy-hero, landing-copy-problem,
-         landing-copy-mechanism, landing-copy-proof, landing-copy-objection,
-         landing-copy-headline, landing-copy-cta]
+         landing-shapes, landing-copy]

--- a/src/db/next.mjs
+++ b/src/db/next.mjs
@@ -374,7 +374,12 @@ const HONESTY = [
 export function scopePackageRoot(glob, module) {
   const segments = glob.replace('{module}', module).split('/');
   const wildcard = segments.findIndex((s) => s.includes('*'));
-  const literal = wildcard === -1 ? segments.slice(0, -1) : segments.slice(0, wildcard);
+  // No wildcard means the glob names one literal file, not a directory
+  // tree — a single prompt/config file (e.g. `.hedgehog/dsh-smoke/{module}.md`)
+  // never holds a `package.json` of its own, so its parent directory is
+  // never a package root a generator could be first into.
+  if (wildcard === -1) return null;
+  const literal = segments.slice(0, wildcard);
   const src = literal.indexOf('src');
   const root = src === -1 ? literal : literal.slice(0, src);
   // A package root is at least `<area>/<name>`; anything shallower is the

--- a/src/db/verify.mjs
+++ b/src/db/verify.mjs
@@ -61,6 +61,24 @@ import { DB_PATH } from './init.mjs';
 import { withCommitLock, LOCK_PATH } from './commitLock.mjs';
 import { reapExpiredLeases, pathFingerprint } from './claim.mjs';
 import { ensureTaskColumns } from './schema.mjs';
+import { FRICTION_DIR } from './friction.mjs';
+import { OVERRIDES_DIR } from './overrides.mjs';
+import { INTENTS_DIR } from './intent.mjs';
+
+// Build-graph state directories: written by their own command
+// (`friction add`, `override add`, `intent add`/`db rebuild`), committed
+// by that command's own next step, never by a layer's verify_command. A
+// layer's own work never lands here, so a path under one of these is
+// never this task's doing regardless of when it changed relative to
+// claim time — unlike attributedToTask's fingerprint check, which only
+// excludes a path unchanged since claim and so still attributes a
+// friction note logged mid-layer (exactly what the loop skill instructs)
+// to whichever task happened to be building when it was logged.
+const BUILD_GRAPH_STATE_DIRS = [FRICTION_DIR, OVERRIDES_DIR, INTENTS_DIR];
+
+function isBuildGraphStatePath(path) {
+  return BUILD_GRAPH_STATE_DIRS.some((dir) => path === dir || path.startsWith(`${dir}/`));
+}
 
 // The build graph file and the commit lock are engine state, written
 // only by this CLI, never by an agent — both are excluded from every
@@ -69,7 +87,12 @@ import { ensureTaskColumns } from './schema.mjs';
 // check they're performing. Covers SQLite's journal/WAL/SHM sidecar
 // files too.
 function isEngineStatePath(path) {
-  return path === DB_PATH || path.startsWith(`${DB_PATH}-`) || path === LOCK_PATH;
+  return (
+    path === DB_PATH ||
+    path.startsWith(`${DB_PATH}-`) ||
+    path === LOCK_PATH ||
+    isBuildGraphStatePath(path)
+  );
 }
 
 // Runs git with an argv array and no shell, so every element of `args`

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Summary

Fixes the four hedgehog-engine-side issues from the deepseek-harness dogfooding round (issues #237-#247; the remaining 8 are core-side, fixed in a companion PR on `hedgehog-core-deepseek-harness`).

- **#242** — `scopePackageRoot` treated a glob with no wildcard (a single literal file, e.g. `.hedgehog/dsh-smoke/{module}.md`) as a directory, so its parent kept getting flagged as a "first arrival" package on every task that touched it — not just once, since that directory never gets a `package.json`.
- **#244** — `verify`'s scope gate now excludes `.hedgehog/friction`, `.hedgehog/overrides`, and `.hedgehog/intents` outright, the same way it already excluded the sqlite db and commit lock. Friction logged mid-layer (as every loop skill instructs) was tripping the very next `verify` call.
- **#239** — `hedgehog init` now checks for a git repository and runs `git init` itself when none exists, since every later planning-intake step assumes commits work.
- **#238** — `ensureGlobalInstall` now returns whether it updated the global binary; `init` prints that as an explicit step 0 in its own "Next steps" instead of leaving it to `status`'s passive nudge, discovered later.
- Also syncs `src/hosts/gemini/gemini-extension.json`'s version with the `package.json` bump, per this repo's release convention.

`#237` was already fixed upstream by a prior commit (`6aa7484`) before this round started — no action needed here.

## Test plan
- [x] `npm run repro` — full suite passes (58 reproductions, including a new one for #242's regression and one for #244)
- [x] `npm run check` — passes except a pre-existing, unrelated `landing-page` core fixture drift (confirmed present on `master` too, before this branch)
- [x] Manually verified `hedgehog init` auto-creates a git repo in a fresh non-git directory, and doesn't touch an already-git directory