### PR TITLE
fix: engine-side dogfooding friction from deepseek-harness (#249, #252)

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1296,11 +1296,15 @@ async function intentCommand(args) {
 }
 
 // On a module-axis core the intent id becomes {module} in every layer's
-// scope glob and verify command, and the generators the packet points at
-// take the module name plural. A singular id compiles a whole graph
-// scoped to a directory the generator will never write, and nothing
-// downstream catches it: plan compiles it, claim hands out a packet whose
-// own scaffold command contradicts its ALLOWED SCOPE.
+// scope glob and verify command, and on a core whose generator pluralizes
+// it (core.yaml's `pluralizes`, default true), a singular id compiles a
+// whole graph scoped to a directory the generator will never write, and
+// nothing downstream catches it: plan compiles it, claim hands out a
+// packet whose own scaffold command contradicts its ALLOWED SCOPE. A core
+// that declares `pluralizes: false` never has this failure mode, so
+// warnSingularModuleId and warnSingularModuleIdsAtPlan both skip it —
+// see core.pluralizes in src/db/core.mjs for why that lives on the core
+// rather than as a hardcoded exception here.
 //
 // A warning rather than a refusal: plenty of real modules are singular
 // (`billing`, `search`), so the convention cannot be enforced without
@@ -1332,6 +1336,7 @@ async function warnSingularModuleId(intent) {
     return;
   }
   if (!isModuleAxis(core)) return;
+  if (core.pluralizes === false) return;
   if (!looksSingular(intent.id)) return;
 
   console.log(
@@ -1360,6 +1365,7 @@ async function warnSingularModuleId(intent) {
 // recovery is still per-id, so those lines are listed one per name.
 function warnSingularModuleIdsAtPlan(core, db) {
   if (!isModuleAxis(core)) return;
+  if (core.pluralizes === false) return;
 
   // Every intent whose tasks have all yet to start, not just the ones
   // this run compiled. `db rebuild` replays the committed intent files

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/repro/first-arrival-in-packet.mjs
+++ b/repro/first-arrival-in-packet.mjs
@@ -115,4 +115,73 @@ try {
   cleanup(dir);
 }
 
+// deepseek-harness's own `bundle` layer shape: a literal `package.json`
+// glob sibling to a `lib/**` build-output glob. The package.json glob has
+// no wildcard at all, so it used to be dropped by scopePackageRoot before
+// it ever reached allRoots — leaving the outermost filter with no sibling
+// root to recognise `lib` as nested under, and `lib` got flagged as its
+// own first-arrival package even though the real package root already
+// had a package.json on disk. Issue #252.
+{
+  const BUNDLE_CORE = `
+id: bundle-shape-fixture
+layers:
+  - id: bundle
+    scope: ["plugins/{module}/package.json", "plugins/{module}/lib/**"]
+    verify: "true"
+    commit: "feat({module}): bundle"
+`;
+
+  const dir = makeProject(BUNDLE_CORE, { git: true });
+  try {
+    addIntent(dir, 'nope-bot');
+    check('plan exits 0', 0, cli(dir, ['plan']).status);
+
+    // The package already exists, committed by an earlier step outside
+    // this layer's own scope — the exact deepseek-harness scenario.
+    mkdirSync(join(dir, 'plugins/nope-bot'), { recursive: true });
+    writeFileSync(join(dir, 'plugins/nope-bot/package.json'), '{}\n');
+
+    const packet = cli(dir, ['show', 'NOPE-BOT-BUNDLE']);
+    check('show exits 0', 0, packet.status);
+    check(
+      'no FIRST ARRIVAL when the package.json glob\'s own root already exists',
+      false,
+      packet.stdout.includes('FIRST ARRIVAL'),
+    );
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// The genuine first-arrival case for the same shape: nothing on disk yet
+// names the real package root (plugins/nope-bot), not the lib/ glob's
+// own root, and the widening it prints covers the package root.
+{
+  const BUNDLE_CORE = `
+id: bundle-shape-fixture
+layers:
+  - id: bundle
+    scope: ["plugins/{module}/package.json", "plugins/{module}/lib/**"]
+    verify: "true"
+    commit: "feat({module}): bundle"
+`;
+
+  const dir = makeProject(BUNDLE_CORE, { git: true });
+  try {
+    addIntent(dir, 'nope-bot');
+    check('plan exits 0', 0, cli(dir, ['plan']).status);
+
+    const packet = cli(dir, ['show', 'NOPE-BOT-BUNDLE']);
+    checkContains('it names the real package root', packet.stdout, 'plugins/nope-bot does not exist yet');
+    check(
+      'it does not name the lib/ build-output directory as its own package',
+      false,
+      packet.stdout.includes('plugins/nope-bot/lib does not exist'),
+    );
+  } finally {
+    cleanup(dir);
+  }
+}
+
 report('the packet states a first arrival instead of leaving it to a failed verify');

--- a/repro/plan-warns-singular-module-ids.mjs
+++ b/repro/plan-warns-singular-module-ids.mjs
@@ -230,4 +230,69 @@ console.log('repro: plan re-raises the singular module-id check\n');
   }
 }
 
+// --- E. a core that declares pluralizes: false is never flagged --------
+
+{
+  // deepseek-harness's tool generator uses the module id verbatim, so the
+  // advisory is a permanent false positive there — the fix is a core-level
+  // fact (`pluralizes: false`), not a per-core hardcoded exception in this
+  // file. Issue #249.
+  const NON_PLURALIZING_CORE = `
+id: non-pluralizing-fixture
+pluralizes: false
+layers:
+  - id: scaffold
+    scope: ["plugins/{module}/**"]
+    verify: "true"
+    commit: "feat({module}): scaffold"
+`;
+
+  const dir = makeProject(NON_PLURALIZING_CORE);
+  try {
+    const r = cli(dir, ['intent', 'add', '--id', 'nope-bot', '--goal', 'g', '--outcome', 'o']);
+    check('E1. intent add succeeds', 0, r.status);
+    check(
+      'E2. intent add does not warn when the core declares pluralizes: false',
+      false,
+      /singular/i.test(r.stdout),
+    );
+
+    const planned = cli(dir, ['plan']);
+    check('E3. plan succeeds', 0, planned.status);
+    check(
+      'E4. plan does not warn either, on the same core',
+      false,
+      /singular/i.test(planned.stdout),
+    );
+  } finally {
+    cleanup(dir);
+  }
+}
+
+// --- F. a core with no pluralizes field defaults to true, unchanged ----
+
+{
+  // Every core written before this field existed has no `pluralizes` key
+  // at all — it must keep warning exactly as it always has.
+  const dir = makeProject(shippedCore('full-stack-app'));
+  try {
+    const file = join(dir, 'task-input.json');
+    writeFileSync(
+      file,
+      `${JSON.stringify({ id: 'task', goal: 'g', outcome: 'o', acceptance: ['a'] })}\n`,
+    );
+    const r = cli(dir, ['intent', 'add', '--file', file]);
+    if (r.status !== 0) throw new Error(`intent add --file task failed: ${r.stderr}`);
+
+    const planned = cli(dir, ['plan']);
+    checkContains(
+      'F1. a core with no pluralizes field still warns (defaults to true)',
+      planned.stdout,
+      'Module id looks singular',
+    );
+  } finally {
+    cleanup(dir);
+  }
+}
+
 report('plan re-raises the singular module-id advisory on every route');

--- a/src/db/core.mjs
+++ b/src/db/core.mjs
@@ -182,6 +182,7 @@ function indentOf(line) {
 
 // Parses the narrow subset of YAML a core definition needs:
 //   id: <scalar>
+//   pluralizes: <bool>            # optional, default true
 //   layers:
 //     - id: <scalar>
 //       depends_on: <scalar>          # optional
@@ -201,7 +202,7 @@ export function parseCoreYaml(text) {
     lines.push({ indent: indentOf(noComment), text: noComment.trim() });
   }
 
-  const core = { id: undefined, layers: [] };
+  const core = { id: undefined, pluralizes: true, layers: [] };
   let i = 0;
 
   while (i < lines.length && lines[i].indent === 0) {
@@ -214,6 +215,15 @@ export function parseCoreYaml(text) {
     if (!match) throw new Error(`unparseable line: ${line.text}`);
     const [, key, value] = match;
     if (key === 'id') core.id = parseScalar(value);
+    // Whether this core's own generator takes a module id plural — a
+    // fixed, known fact about that generator, not a per-project unknown.
+    // Absent means true, so every core written before this field existed
+    // keeps warning exactly as it always has; a core whose generator
+    // never pluralizes (deepseek-harness's tool generator uses the id
+    // verbatim) declares `pluralizes: false` once and the singular-id
+    // advisory stops firing on it for good, rather than every user of
+    // that core re-discovering the same false positive.
+    if (key === 'pluralizes') core.pluralizes = parseScalar(value) === 'true';
     i++;
   }
 

--- a/src/db/next.mjs
+++ b/src/db/next.mjs
@@ -375,10 +375,19 @@ export function scopePackageRoot(glob, module) {
   const segments = glob.replace('{module}', module).split('/');
   const wildcard = segments.findIndex((s) => s.includes('*'));
   // No wildcard means the glob names one literal file, not a directory
-  // tree — a single prompt/config file (e.g. `.hedgehog/dsh-smoke/{module}.md`)
-  // never holds a `package.json` of its own, so its parent directory is
-  // never a package root a generator could be first into.
-  if (wildcard === -1) return null;
+  // tree. Most such files are a single prompt/config file (e.g.
+  // `.hedgehog/dsh-smoke/{module}.md`) whose parent directory never holds
+  // a `package.json` of its own, so it is never a package root a
+  // generator could be first into — except when the literal file IS
+  // `package.json`: a layer whose own scope names that file directly
+  // (deepseek-harness's `bundle`: `plugins/{module}/package.json`) is
+  // naming its package root exactly as surely as a wildcard glob under
+  // that root would, and its parent directory is that root.
+  if (wildcard === -1) {
+    if (segments.at(-1) !== 'package.json') return null;
+    const literal = segments.slice(0, -1);
+    return literal.length >= 2 ? literal.join('/') : null;
+  }
   const literal = segments.slice(0, wildcard);
   const src = literal.indexOf('src');
   const root = src === -1 ? literal : literal.slice(0, src);
@@ -389,12 +398,13 @@ export function scopePackageRoot(glob, module) {
 
 // A task is the first arrival in its package when the package the scope
 // points into has no package.json on disk yet: the generator that
-// scaffolds this layer will create the package shell (package.json,
-// tsconfig*.json, vitest.config.mts, src/index.ts) alongside the module's
-// own files, and every one of those lands outside a {module}-bearing
-// glob. Detected here rather than left to be discovered from a failed
-// verify, which is where the override stops being available and the
-// recovery becomes a five-command round trip.
+// scaffolds this layer will create the package shell (package.json plus
+// whatever else this core scaffolds alongside it — tsconfig, test
+// config, src/index.ts) alongside the module's own files, and every one
+// of those lands outside a {module}-bearing glob. Detected here rather
+// than left to be discovered from a failed verify, which is where the
+// override stops being available and the recovery becomes a
+// five-command round trip.
 //
 // `exists` is injected so this module keeps no filesystem dependency of
 // its own; the CLI passes a real one and the packet degrades to no
@@ -429,11 +439,11 @@ function firstArrivalLines(task, roots) {
   return [
     'FIRST ARRIVAL',
     `  ${roots.join(', ')} ${roots.length > 1 ? 'do' : 'does'} not exist yet, so this task's`,
-    "  generator also creates the package shell (package.json, tsconfig*.json,",
-    '  vitest.config.mts, src/index.ts) plus any package-wide source it writes',
-    '  at the src/ root. All of that lands OUTSIDE the scope above. Widen this',
-    '  one task before building it, or verify will reject those paths and',
-    '  block the task:',
+    '  generator also creates the package shell (package.json plus whatever else',
+    '  this core scaffolds alongside it — tsconfig, test config, src/index.ts)',
+    '  plus any package-wide source it writes at the src/ root. All of that',
+    '  lands OUTSIDE the scope above. Widen this one task before building it,',
+    '  or verify will reject those paths and block the task:',
     '',
     `  hedgehog override add ${task.id} \\`,
     ...scopes.map((s) => `    --scope '${s}' \\`),

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Summary

Two engine-level fixes from the first deepseek-harness dogfooding round.

- **#249** — the "module id looks singular" warning was a permanent false positive on cores (like `deepseek-harness`) whose generator never pluralizes module names. A prior fix (`6aa7484`) only softened the wording; the maintainer's own comment on the issue said a real fix was still needed. Adds a `pluralizes` boolean to the compiled `core.yaml` schema (defaults to `true`, so every existing core keeps warning exactly as before) and gates both warning call sites in `bin/cli.mjs` on it.
- **#252** — `hedgehog claim`'s FIRST ARRIVAL note fired incorrectly on the `bundle` layer even though the real package root already existed on disk. Root cause: `scopePackageRoot` treated any wildcard-free glob (e.g. `plugins/{module}/package.json`) as "not a package root," so the sibling `lib/**` glob's root had no recognized parent to be excluded by the existing nested-root filter. Fixed by special-casing a literal `package.json` glob as its parent directory being a real package root. Also softened the note's hardcoded `vitest.config.mts` claim, since not every core uses vitest.

Closes #249, closes #252.

## Test plan
- [x] `npm run check` passes
- [x] Full repro suite (`repro/run-all.mjs`, 58 scripts including 2 new ones covering these exact bugs) passes