### PR TITLE
docs: update section title in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Instead of asking AI to remember your entire project, Hedgehog encodes the plan 
 
 The codebase carries the context, not the model.
 
-## Cleaner code, fewer tokens, faster builds ⭐⭐⭐⭐
+## HEDGEHOG Writes Cleaner Code, with Fewer Tokens and Faster builds ⭐⭐⭐⭐
 
 ![Hedgehog - build software the right way, one step at a time](https://raw.githubusercontent.com/skyf0xx/hedgehog/master/docs/images/hero.png)
 


### PR DESCRIPTION
## What does this change?

## Why?

## Checklist

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `ci:`, `chore:`)
- [ ] `npm run check` passes locally
- [ ] No direct edits to `vendor-skills/BMAD/` (use the `bmad-revendor` skill instead)
