### PR TITLE
fix: capitalization in README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Instead of asking AI to remember your entire project, Hedgehog encodes the plan 
 
 The codebase carries the context, not the model.
 
-## HEDGEHOG writes Cleaner Code, with Fewer Tokens and Faster builds ⭐⭐⭐⭐
+## HEDGEHOG writes Cleaner Code, with Fewer Tokens and Faster Builds ⭐⭐⭐⭐
 
 ![Hedgehog - build software the right way, one step at a time](https://raw.githubusercontent.com/skyf0xx/hedgehog/master/docs/images/hero.png)
 


### PR DESCRIPTION
## What does this change?

## Why?

## Checklist

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `ci:`, `chore:`)
- [ ] `npm run check` passes locally
- [ ] No direct edits to `vendor-skills/BMAD/` (use the `bmad-revendor` skill instead)
