### PR TITLE
docs: trim hedgehog-contributing skill, bump to 5.4.0, automate version bumps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,9 +128,11 @@ triggers and never touched by the same automation:
 
 - `package.json`'s `version` — the npm package (`bin/`, `src/`,
   `vendor-skills/`) that `npx @skyf0xx/hedgehog init`/`update` install.
-  Bump with `npm run release` (`npm version patch`) for any change under
-  those directories. **Commit the bump on the feature branch and let the
-  PR merge it into `master` — do not tag or push the tag yourself.**
+  Bump with `npm run release` (defaults to a patch bump; pass `--
+  minor`, `-- major`, or `-- x.y.z` for anything else) for any change
+  under those directories — never hand-edit the version field. **Commit
+  the bump on the feature branch and let the PR merge it into `master` —
+  do not tag or push the tag yourself.**
   `.github/workflows/publish.yml` watches every push to `master` that
   changes `package.json`, diffs the version from before the push (however
   many commits it carries) against after, and when it changed: tags
@@ -144,12 +146,12 @@ triggers and never touched by the same automation:
   history around 2026-08-14 for the incident this rule comes from). If a
   tag was pushed by mistake, delete it (`git push origin --delete
   v<version>`) before the PR merges so the workflow can create it fresh,
-  pointing at the actual merge commit. `npm version patch` only writes
-  `package.json`/`package-lock.json` — it does not touch
-  `src/hosts/gemini/gemini-extension.json`, so bump that file's `version`
-  to match by hand in the same commit. Nothing currently gates on the two
-  agreeing, so a missed bump here stays silent rather than failing `npm
-  run check`.
+  pointing at the actual merge commit. `npm run release`
+  (`scripts/bump-package-version.mjs`) is the only way to change this
+  version: it bumps `package.json`/`package-lock.json` and
+  `src/hosts/gemini/gemini-extension.json` together in one step.
+  `scripts/check.mjs` gates on the two agreeing, so a bump to only one
+  of them fails `npm run check`.
 - `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`'s
   `version` fields (kept identical to each other) — the Claude Code
   plugin (`claude plugin install hedgehog`), whose payload is `skills/`
@@ -158,11 +160,13 @@ triggers and never touched by the same automation:
   carry the same version for the Cursor and Gemini CLI packagings of
   that same payload (root `gemini-extension.json` only — the unrelated
   `src/hosts/gemini/gemini-extension.json` is per-project template
-  content versioned by `package.json`'s bump instead). Bump all four
-  together with `npm run release:plugin -- <version>`
-  (`scripts/bump-plugin-version.mjs`), in the same PR as the change, for
-  any edit under `skills/`, `hooks/`, `.claude-plugin/`,
-  `.cursor-plugin/`, or root `gemini-extension.json` itself — that's what
+  content versioned by `package.json`'s bump instead). `npm run
+  release:plugin` (`scripts/bump-plugin-version.mjs`) is the only way to
+  change this version: it bumps all four together — defaults to a patch
+  bump; pass `-- minor`, `-- major`, or `-- x.y.z` for anything else.
+  Run it in the same PR as the change, for any edit under `skills/`,
+  `hooks/`, `.claude-plugin/`, `.cursor-plugin/`, or root
+  `gemini-extension.json` itself — that's what
   a `claude plugin marketplace` update check (or Gemini CLI's own
   extension update check) reads to decide a user has a new version to
   pull. The script asserts the four files agree before writing, so a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "5.3.4",
+  "version": "5.4.0",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "check": "node scripts/check.mjs",
     "repro": "node --experimental-sqlite repro/run-all.mjs",
-    "release": "npm version patch -m \"chore: bump version to %s\"",
+    "release": "node scripts/bump-package-version.mjs",
     "release:plugin": "node scripts/bump-plugin-version.mjs"
   },
   "files": [

--- a/scripts/bump-package-version.mjs
+++ b/scripts/bump-package-version.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// Bumps the npm-package version — package.json (and package-lock.json,
+// via `npm version`) — together with src/hosts/gemini/gemini-extension.json,
+// the per-project template copy of that same version number a consuming
+// project's Gemini CLI install carries. CLAUDE.md's Releasing section
+// names this pair; `npm version patch` alone only ever wrote the first.
+//
+// Run with `npm run release` (patch) or `npm run release -- <bump>` for
+// any bump `npm version` accepts (minor, major, or an explicit x.y.z).
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const bump = process.argv[2] || 'patch';
+
+const output = execFileSync('npm', ['version', bump, '--no-git-tag-version'], {
+  cwd: ROOT,
+  encoding: 'utf8',
+});
+const version = output.trim().replace(/^v/, '');
+
+const templatePath = join(ROOT, 'src/hosts/gemini/gemini-extension.json');
+const templateJson = JSON.parse(await readFile(templatePath, 'utf8'));
+templateJson.version = version;
+await writeFile(templatePath, `${JSON.stringify(templateJson, null, 2)}\n`);
+
+console.log(`  package.json -> ${version}`);
+console.log(`  src/hosts/gemini/gemini-extension.json -> ${version}`);
+console.log(`\nBumped to ${version}. Not committed — review and commit by hand.`);

--- a/scripts/bump-plugin-version.mjs
+++ b/scripts/bump-plugin-version.mjs
@@ -7,9 +7,11 @@
 // src/hosts/gemini/gemini-extension.json, unrelated per-project template
 // content that sits outside this family on purpose.
 //
-// Run with `npm run release:plugin -- <version>`. Asserts the four files
-// agree on their current version before writing, so a prior silent drift
-// (a file missed on an earlier bump) surfaces here instead of compounding.
+// Run with `npm run release:plugin` (defaults to a patch bump), or
+// `npm run release:plugin -- <major|minor|patch|x.y.z>`. Asserts the four
+// files agree on their current version before writing, so a prior silent
+// drift (a file missed on an earlier bump) surfaces here instead of
+// compounding.
 
 import { readFile, writeFile } from 'node:fs/promises';
 import { join, dirname, resolve } from 'node:path';
@@ -18,9 +20,15 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
 
-const target = process.argv[2];
-if (!target || !/^\d+\.\d+\.\d+$/.test(target)) {
-  console.error('Usage: npm run release:plugin -- <version>  (e.g. 5.2.0)');
+const arg = process.argv[2] || 'patch';
+
+function nextVersion(current, spec) {
+  if (/^\d+\.\d+\.\d+$/.test(spec)) return spec;
+  const [major, minor, patch] = current.split('.').map(Number);
+  if (spec === 'major') return `${major + 1}.0.0`;
+  if (spec === 'minor') return `${major}.${minor + 1}.0`;
+  if (spec === 'patch') return `${major}.${minor}.${patch + 1}`;
+  console.error(`Usage: npm run release:plugin -- <major|minor|patch|x.y.z>  (e.g. 5.2.0)`);
   process.exit(1);
 }
 
@@ -52,6 +60,8 @@ if (current.size > 1) {
   );
   process.exit(1);
 }
+
+const target = nextVersion([...current][0], arg);
 
 for (const f of loaded) {
   f.set(f.json, target);

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -351,6 +351,27 @@ try {
   fail(`plugin-family version check failed: ${err.message}`);
 }
 
+// ── 9. package.json's version and src/hosts/gemini/gemini-extension.json's
+//    version agree. The latter is per-project template content a project's
+//    Gemini CLI install carries, versioned by the npm package's own bump
+//    (CLAUDE.md's Releasing section), so a bump to one and not the other
+//    is a silent miss, not a valid state. ───────────────────────────────
+try {
+  const pkgJson = JSON.parse(await readFile(join(ROOT, 'package.json'), 'utf8'));
+  const geminiTemplateJson = JSON.parse(
+    await readFile(join(ROOT, 'src/hosts/gemini/gemini-extension.json'), 'utf8'),
+  );
+  if (pkgJson.version !== geminiTemplateJson.version) {
+    fail(
+      `package version drift: package.json=${pkgJson.version}, ` +
+        `src/hosts/gemini/gemini-extension.json=${geminiTemplateJson.version} — ` +
+        `bump both to the same version (CLAUDE.md's Releasing section)`,
+    );
+  }
+} catch (err) {
+  fail(`package version check failed: ${err.message}`);
+}
+
 // ── Report ───────────────────────────────────────────────────────────
 if (failures.length > 0) {
   console.error(`\n${failures.length} check(s) failed:\n`);

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "5.3.4",
+  "version": "5.4.0",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }

--- a/src/skills/hedgehog-contributing/SKILL.md
+++ b/src/skills/hedgehog-contributing/SKILL.md
@@ -41,31 +41,24 @@ it.
 ## Writing the issue or PR
 
 Most of Hedgehog's inbound queue is read first by `inbound-triage`, an
-agent, before a human ever sees it. Write for both readers at once, not
-for one at the expense of the other:
+agent, before a human ever sees it — the same register `inbound-triage`
+uses when it comments back (see that skill's "Comment style" section).
+Write plainly for both readers at once:
 
-- Plain technical English. Short sentences, one claim each. No hedging
-  ("might possibly", "it seems like"), no filler ("just wanted to
-  mention"), no marketing language ("massively improves").
-- Lead with the concrete fact, not the framing. "`hedgehog init` writes
-  `.claude/agents/` twice on Windows" beats "I noticed there might be an
-  issue with how the installer handles paths."
-- State symptom, expected behavior, and exact repro steps as separate,
-  labeled facts — the bug report template's fields exist so a reader
-  (human or agent) can find each without parsing prose. Fill every field
-  the template asks for; don't collapse them into one paragraph.
-- Cite `file:line` for anything about existing behavior. A claim without
-  a citation is a hypothesis, and both readers have to go re-derive it.
-- One issue, one problem. One PR, one change. A bundle forces the reader
-  to split it back apart before they can judge any piece of it.
-- Say what you verified, not what you assume. "Ran `node bin/cli.mjs
+- Plain technical English, one claim per sentence, no hedging or
+  marketing language.
+- Lead with the concrete fact: "`hedgehog init` writes `.claude/agents/`
+  twice on Windows" beats "I noticed there might be an issue with how
+  the installer handles paths."
+- Fill every field the bug-report template asks for as its own labeled
+  fact (symptom, expected behavior, exact repro steps) rather than one
+  collapsed paragraph.
+- Cite `file:line` for anything about existing behavior — an
+  uncited claim is a hypothesis both readers have to re-derive.
+- One issue, one problem; one PR, one change.
+- Say what you verified, not what you assume: "Ran `node bin/cli.mjs
   init` in a scratch dir, `.claude/skills/` is missing the new
   directory" beats "this probably breaks the install."
-
-This is the same register `inbound-triage` uses when it comments back —
-see that skill's "Comment style" section. Writing this way isn't just
-politeness; it's what makes an item triageable in one pass instead of a
-back-and-forth to extract the facts.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary
- Trims redundant prose in `hedgehog-contributing`'s "Writing the issue or PR" section without changing what it instructs (119 → 112 lines).
- Bumps `package.json` to 5.4.0 (minor) per `CLAUDE.md`'s Releasing rules — a change under `src/skills/`.
- Adds `scripts/bump-package-version.mjs` so `npm run release` bumps `package.json`/`package-lock.json` and `src/hosts/gemini/gemini-extension.json` together, closing the silent-drift gap `CLAUDE.md` previously called out. `scripts/check.mjs` now gates on the two agreeing.
- Aligns `scripts/bump-plugin-version.mjs` to accept `major`/`minor`/`patch`/`x.y.z` the same way, instead of requiring an explicit version string.
- Updates `CLAUDE.md`'s Releasing section to describe both scripts as the only way to change their respective versions.

## Test plan
- [x] `npm run check` passes
- [x] Manually ran `node scripts/bump-package-version.mjs patch` and `node scripts/bump-plugin-version.mjs minor` in a scratch pass, confirmed correct output, then reverted (not part of this PR's actual version change)
- [x] Verified `scripts/check.mjs`'s new gate fails when `package.json` and `src/hosts/gemini/gemini-extension.json` versions are made to disagree