### PR TITLE
fix: init crash + install-time prerequisite check

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "5.1.8",
+      "version": "5.1.9",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "author": {
     "name": "skyf0xx"
   },

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 .pytest_cache/
 .hedgehog
+.tight-skills.md

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -609,7 +609,7 @@ function ensureGitRepo() {
 
 // `core` is the fetched core — `{ manifest, root, version }` — or null on
 // a deferred install, where planner picks one later.
-async function init({ force, core, host = DEFAULT_HOST, hostOnly = false }) {
+async function init({ force, core, host = DEFAULT_HOST, hostOnly = false, globalInstall = null }) {
   ensureGitRepo();
 
   // Resolve the full list of writes up front so we can detect conflicts

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -45,7 +45,11 @@ import { graphStatus, formatStatus } from '../src/db/status.mjs';
 import { boundaryState, formatBoundary, formatPosition, formatHandoff } from '../src/db/boundary.mjs';
 import { commitGateStatus, formatCommitGate } from '../src/db/gate.mjs';
 import { detectDrift, recompileTasks, formatRecompile } from '../src/db/drift.mjs';
-import { coreMissingRequirements, missingBinaries } from '../src/db/requires.mjs';
+import {
+  coreMissingRequirements,
+  missingBinaries,
+  formatMissingRequirements,
+} from '../src/db/requires.mjs';
 import { whyPath, formatWhy } from '../src/db/why.mjs';
 import { addFriction, listFriction } from '../src/db/friction.mjs';
 import { addDebt, listDebt } from '../src/db/debt.mjs';
@@ -673,6 +677,26 @@ async function init({ force, core, host = DEFAULT_HOST, hostOnly = false, global
       `${written} created${overwritten ? `, ${overwritten} overwritten` : ''}`,
     )}\n`,
   );
+
+  // Same declared-binary check `status` runs, moved up to install time for
+  // a core that ships a workspace (root core.yaml lands with it — see
+  // resolveCorePath). Catching "this core needs terraform" here means the
+  // agent following "Next steps" sees it before ever running a verify
+  // command, rather than discovering it as an exit 127 mid-build.
+  const installedCorePath = await resolveCorePath();
+  if (installedCorePath) {
+    try {
+      const installedCoreDef = await loadCore(installedCorePath);
+      const missing = coreMissingRequirements(installedCoreDef);
+      const lines = formatMissingRequirements(missing);
+      if (lines.length) console.log(lines.join('\n') + '\n');
+    } catch {
+      // Unparseable this early is surfaced by the next `hedgehog status`
+      // instead — init has already written every file successfully, so
+      // failing the run over a report-only check would be the wrong call.
+    }
+  }
+
   console.log('Next steps:');
   // This install itself just fetched globalInstall.latest to run, so the
   // global binary is already ahead of the version this run scaffolded

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "5.1.8",
+  "version": "5.1.9",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -177,28 +177,11 @@ agents and skills that gives a project a planned module sequence, a build
 graph, and phase gates, in place of ad-hoc scaffolding.
 
 What the discipline consists of differs by core, and a core is not just
-scaffolding. The `landing-page` core is a copy-and-conversion discipline: it
-ships structured skills for headline, hero, problem, mechanism, objection,
-proof, and CTA, plus signature-element design and a review loop. A page whose
-problem is "the copy is weak" or "it doesn't convert" is that core's central
-case, not an edge case — positioning and copy are exactly what it is made of.
-`full-stack-app` and `pwa-app` are the two module-sequencing cores, split by
-where the data lives. `pwa-app` fits an app whose data model fits on the
-user's device and whose reads and writes are the user's own — a tracker,
-journal, notebook, planner, offline reference, or utility; offline capability
-or installability named explicitly is a strong signal. Sharing, accounts, and
-multi-device sync do not push a project to `full-stack-app` by themselves —
-`pwa-app` covers those through Dexie Cloud, and even a server-authoritative
-entity or two (a points balance, a reward ledger) can live in an otherwise
-local-first `pwa-app` build. `full-stack-app` is for server-side logic across
-most of the app: authorization beyond row-level security, background jobs or
-webhooks as the app's primary function, server-rendered or SEO-critical pages,
-or a working set too large for a device. `deepseek-harness` fits a request to
-build a plugin, tool, hook, or extension for DeepSeek Harness (DSH) — a
-Cordis-based agent framework — or to extend an existing DSH installation via
-its plugin/bundle system; `DSH`, `Cordis`, `defineTool`, `ctx.tools.register`,
-or a `cordis.patch.yml` manifest are strong signals. Judge a request against
-the core that fits it, not against a single core's shape.
+scaffolding — `landing-page` sequences copy and conversion, `full-stack-app`
+and `pwa-app` sequence modules split by where the data lives, and
+`deepseek-harness` fits a DSH plugin/tool/hook build. The `hedgehog` skill
+carries the full per-core selection criteria; judge a request against the
+core that actually fits it, not against a single core's shape.
 
 This project does not have it installed (no `.hedgehog/` directory).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Summary
- **Bug fix (urgent):** `init()` referenced `globalInstall` as a free variable instead of a destructured parameter. `main()` passes it via an options object, but the signature never named it, so the lookup fell through to module scope and threw `ReferenceError` right after "Hedgehog installed." — every real `hedgehog init` writes its files successfully, then crashes before ever printing "Next steps." This is live in the published `5.4.0` package right now.
- **Feature:** moves the declared-binary check (`core.yaml`'s `requires:`, already used by `status`/`verify`) up to install time, so a core needing e.g. Docker or Terraform reports it right after `init` instead of only surfacing on a later `status` call or an exit 127 mid-build. No shipped core declares `requires:` yet, so this is currently a no-op everywhere — it activates the first time a core opts in.
- **Docs:** dedupes `hooks/session-start`'s gate text, which restated the same per-core selection criteria `skills/hedgehog/SKILL.md` already owns, against the single-owning-file rule in this repo's own `CLAUDE.md`.
- Bumps both version families: package to `5.4.1` (bin/cli.mjs changes), plugin to `5.1.9` (hooks/session-start change).

## Test plan
- [x] `npm run check` passes
- [x] `node --check bin/cli.mjs`
- [x] Ran `hedgehog init` (no core flag) end-to-end in a scratch repo — completes without crashing, full "Next steps" output prints
- [x] Ran `hedgehog init --pwa-app` end-to-end — full install with a real core completes cleanly, no missing-binaries report (expected, no core declares `requires:` yet)
- [x] Verified the missing-binaries reporting path directly against a synthetic `core.yaml` with a fake `requires:` entry — correctly flags the missing binary and leaves a real one (`node`) unreported