### PR TITLE
feat: support adopting Hedgehog onto existing repos

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "5.1.13",
+      "version": "5.1.14",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.13",
+  "version": "5.1.14",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "5.1.13",
+  "version": "5.1.14",
   "author": {
     "name": "skyf0xx"
   },

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -141,9 +141,11 @@ calls are the concrete signals `planner` reads to route here instead of
 
 Package and source: [`skyf0xx/hedgehog-core-authored`](https://github.com/skyf0xx/hedgehog-core-authored).
 
-Unlike `full-stack-app`, `landing-page`, and `deepseek-harness`, this core
-ships no pre-built workspace and no fixed stack table —
-`hedgehog-core-design` picks the stack and derives the layer sequence per
-project, then generates and verifies the workspace live. The same package
-also carries the design for adopting Hedgehog's discipline into an
-existing repo without bootstrapping a workspace at all.
+Two paths. **From-scratch design** (`hedgehog-core-design`): unlike
+`full-stack-app`, `landing-page`, and `deepseek-harness`, this core ships no
+pre-built workspace and no fixed stack table — `hedgehog-core-design` picks
+the stack and derives the layer sequence per project, then generates and
+verifies the workspace live. **Brownfield adoption** (`hedgehog-adopt`):
+brings Hedgehog's discipline to a repo that already exists without
+bootstrapping a workspace, installing agents/skills and the build graph
+alongside the existing code structure. Both paths ship in this same package.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -141,11 +141,11 @@ calls are the concrete signals `planner` reads to route here instead of
 
 Package and source: [`skyf0xx/hedgehog-core-authored`](https://github.com/skyf0xx/hedgehog-core-authored).
 
-Two paths. **From-scratch design** (`hedgehog-core-design`): unlike
-`full-stack-app`, `landing-page`, and `deepseek-harness`, this core ships no
-pre-built workspace and no fixed stack table — `hedgehog-core-design` picks
+**From-scratch design** (`hedgehog-core-design`): unlike other cores, this one picks
 the stack and derives the layer sequence per project, then generates and
-verifies the workspace live. **Brownfield adoption** (`hedgehog-adopt`):
+verifies the workspace live.
+
+**Brownfield adoption** (`hedgehog-adopt`):
 brings Hedgehog's discipline to a repo that already exists without
 bootstrapping a workspace, installing agents/skills and the build graph
-alongside the existing code structure. Both paths ship in this same package.
+alongside the existing code structure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,11 @@ discipline's stance and rationale.
 
 This repo is the engine: the CLI, the build graph, the host adapters, the
 core registry, and the agents and skills every core shares. Each core —
-`full-stack-app`, `pwa-app`, `landing-page`, `deepseek-harness`, `authored`
-— ships as its own npm package holding that core's workspace, agents,
-skills, and CLAUDE.md section. `src/registry/cores.json` names them;
-`init` fetches the one a project asks for.
+`full-stack-app`, `pwa-app`, `landing-page`, `deepseek-harness`, and
+`authored` (brownfield adoption) — ships as its own npm package holding
+that core's workspace, agents, skills, and CLAUDE.md section.
+`src/registry/cores.json` names them; `init` fetches the one a project asks
+for.
 
 ## Layout
 
@@ -90,16 +91,20 @@ skills, and CLAUDE.md section. `src/registry/cores.json` names them;
   This is the live source of truth every loop skill and its agents query
   and mutate for what's next and what's done.
 - `bin/cli.mjs` — the `hedgehog` CLI installed by `npx @skyf0xx/hedgehog`:
-  `init` (installer) plus the subcommands (`status`, `next`, `verify`,
-  `claim`, `intent add`, `plan`, `friction add`/`list`, …) that read and
-  write `src/db/`'s build graph.
+  `init` (installer), `core record-adopted` (lands the `authored` core's
+  agents/skills and records them for `hedgehog-adopt`, which has no `init`
+  step of its own to call from), and the subcommands (`status`, `next`,
+  `verify`, `claim`, `intent add`, `plan`, `friction add`/`list`, …) that
+  read and write `src/db/`'s build graph.
 - `src/hosts/` — one entry per coding agent Hedgehog installs into
   (Claude Code, Cursor, Gemini CLI): where the payload lands, which
   instructions file that agent loads, and how to emit the agent files
   when its format differs from the canonical one. `capabilities.mjs`
   owns the agent → tool-grant fact for hosts that can't register a
   per-agent grant; `routing.mjs` generates the root `AGENTS.md` index
-  from the agents' and skills' own frontmatter. `version.mjs` owns
+  from the agents' and skills' own frontmatter; `claude-md-merge.mjs`
+  safely merges a core's CLAUDE.md section into a repo's hand-written
+  root instructions file (adoption case). `version.mjs` owns
   payload-staleness detection: `init` and `update` stamp the version they
   wrote into `.hedgehog/version.json`, and that stamp is compared against
   the newest published release. See

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,8 +64,10 @@ mechanically enforced (Nx boundaries, phase gates, lefthook) rather than
 a convention the AI is asked to follow. Proposing a stack swap for an
 existing core means proposing an equivalent enforcement mechanism in the
 new tooling, not just a preference, and lands as a PR against that core's
-own repo rather than this one. `authored` has no locked stack table —
-`hedgehog-core-design` picks the stack per project instead.
+own repo rather than this one. `authored` has no locked stack table for
+its from-scratch-design path — `hedgehog-core-design` picks the stack per
+project instead. The brownfield adoption path (`hedgehog-adopt`) works with
+existing stacks as-is.
 
 When a core's own workspace template needs a new piece of repeatable
 boilerplate — a new module shape, a new generated file type — prefer

--- a/README.md
+++ b/README.md
@@ -202,9 +202,7 @@ Where possible, Hedgehog uses a battle-tested blueprint in [`hedgehog-core-autho
 
 ### Existing codebases
 
-Hedgehog also adopts onto a repo it didn't build. It reads the repo read-only and proposes a layer chain that verifies with the repo's own test/lint/build commands — never invented, never a push to migrate the stack.
-
-From there, every new change goes through the same scoped, verified, committed loop as any other core. Coverage only ever covers what's changed since adoption; a large ask gets a short clarifying pass before becoming an intent.
+Hedgehog also adopts onto a repo it didn't build. It reads the repo and proposes a layer chain that verifies with the repo's own test/lint/build commands.
 
 ## Why Hedgehog Works
 

--- a/README.md
+++ b/README.md
@@ -202,9 +202,9 @@ Where possible, Hedgehog uses a battle-tested blueprint in [`hedgehog-core-autho
 
 ### Existing codebases
 
-Hedgehog also adopts onto existing repos.
+Hedgehog also adopts onto a repo it didn't build. It reads the repo read-only and proposes a layer chain that verifies with the repo's own test/lint/build commands — never invented, never a push to migrate the stack.
 
-It scans the repo's shape and is able to create new changes with the same scoped, verified, committed loop.
+From there, every new change goes through the same scoped, verified, committed loop as any other core. Coverage only ever covers what's changed since adoption; a large ask gets a short clarifying pass before becoming an intent.
 
 ## Why Hedgehog Works
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,11 +39,10 @@ consuming project installs. The interesting boundaries:
   is a supply-chain issue.
 - **The core registry and fetcher** (`src/registry/`) — each core
   (`full-stack-app`, `pwa-app`, `landing-page`, `deepseek-harness`,
-  `authored`) ships as its own npm package that `init` resolves and fetches;
-  a bug here that lets
-  a core install from an unintended source, or that skips validating
-  what it fetched, is the same class of supply-chain issue as the
-  payload above.
+  and `authored`) ships as its own npm package that `init` resolves and
+  fetches; a bug here that lets a core install from an unintended source,
+  or that skips validating what it fetched, is the same class of
+  supply-chain issue as the payload above.
 - **Prompt injection reaching an agent** through content it reads — a
   file in the working tree, a fetched page, an issue body. Reports here
   are welcome and are treated as real, not theoretical.

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -80,6 +80,7 @@ import { rebuildDb } from '../src/db/rebuild.mjs';
 import { loadOverrides, addOverride, orphanedOverrides, OVERRIDES_DIR } from '../src/db/overrides.mjs';
 import { HOSTS, HOST_FLAGS, DEFAULT_HOST, availableHosts } from '../src/hosts/index.mjs';
 import { recordHosts, installedHosts } from '../src/hosts/installed.mjs';
+import { wrapSection } from '../src/hosts/claude-md-merge.mjs';
 import {
   recordVersion,
   checkForUpdate,
@@ -88,7 +89,7 @@ import {
 } from '../src/hosts/version.mjs';
 import { loadRegistry, resolveCore } from '../src/registry/index.mjs';
 import { fetchCore, cachedCore, cachedVersions, cachedEngine } from '../src/registry/fetch.mjs';
-import { recordCore, installedCore } from '../src/registry/installed.mjs';
+import { recordCore, installedCore, ADOPTED_CORE_NAME } from '../src/registry/installed.mjs';
 
 const AUTHORED_CORE_PATH = '.hedgehog/core.yaml';
 const CODE_INTELLIGENCE_CONFIG_PATH = '.hedgehog/code-intelligence.json';
@@ -472,7 +473,13 @@ async function writePlannedFile(f) {
         join(f.merge.includeRoot ?? PKG_ROOT, f.merge.include),
         'utf8',
       );
-      out = out.replaceAll('{{CORE_SECTION}}', section.trimEnd());
+      // Wrapped in the same markers appendCoreSection uses on a
+      // brownfield CLAUDE.md with no {{CORE_SECTION}} placeholder to
+      // substitute into — see src/hosts/claude-md-merge.mjs. Keeping
+      // both paths' output mutually recognizable is what lets
+      // hasCoreSection/appendCoreSection treat a template-filled file
+      // and an appended one the same way on a later re-run.
+      out = out.replaceAll('{{CORE_SECTION}}', wrapSection(section));
     }
     const dispatch = await readFile(join(PKG_ROOT, f.merge.dispatch), 'utf8');
     await writeFile(f.dest, out.replaceAll('{{HOST_DISPATCH}}', dispatch.trimEnd()));
@@ -544,6 +551,9 @@ ${bold('Usage')}
   npx @skyf0xx/hedgehog init --pwa-app            scaffold the pwa-app core now
   npx @skyf0xx/hedgehog init --landing-page       scaffold the landing-page core now
   npx @skyf0xx/hedgehog cores list                every core this release can install
+  npx @skyf0xx/hedgehog core record-adopted       land the authored core's agents/skills and record
+                                                   this project as adopted (hedgehog-adopt calls this
+                                                   after writing .hedgehog/core.yaml; not for other cores)
   npx @skyf0xx/hedgehog init --cursor             install for Cursor (default: Claude Code)
   npx @skyf0xx/hedgehog init --host=claude,gemini install for several coding agents at once
   npx @skyf0xx/hedgehog init --all-hosts          install for every supported coding agent
@@ -1171,6 +1181,84 @@ async function resolveInstalledCore() {
     );
     return UNRESOLVED;
   }
+}
+
+// `hedgehog core record-adopted` — the record path for `hedgehog-adopt`
+// (shipped in @skyf0xx/hedgehog-core-authored), which brings the
+// discipline to an existing repo by writing `.hedgehog/core.yaml` and
+// `.hedgehog/adoption.md` directly. That path has no `init` step and so
+// never fetches the `authored` package or calls `recordCore` — a no-flag
+// `init` (what the offer skill actually runs before adoption) installs
+// only the shared engine payload, never a core's own agents/skills, and
+// `bootstrap` (the only other place a core package gets fetched) is
+// explicitly skipped for adoption. Left alone, `hedgehog-authored-loop`
+// and `layer-eng` — the skill and agent adoption hands off to — would
+// never land on disk, and even if they did by some other means, `update`
+// would have nothing telling it they're there: `resolveInstalledCore`
+// falls through to `detectUnrecordedCore`, which only looks for a root
+// `core.yaml` (the shipped-core workspace marker) and finds nothing for
+// an adopted repo's `.hedgehog/core.yaml`, so it would read as "no core
+// yet" and update would silently rewrite `.claude/agents`/`.claude/skills`
+// down to just the shared payload, deleting the authored package's files
+// with nothing put back.
+//
+// This command is both fixes at once: it fetches the `authored` package
+// and lands its agents/skills for every host this project already has
+// installed (never its workspace, template, or vendor_skills — adoption
+// already wrote its own CLAUDE.md section and root workspace is the one
+// thing adoption must never touch), then records the core with
+// `adopted: true` so `update` refreshes it correctly from here on.
+// Idempotent and safe to re-run — e.g. from a later `hedgehog-adopt` pass
+// adding new change-work — since it always overwrites from the current
+// package rather than merging.
+async function recordAdoptedCommand() {
+  const entry = await resolveCore(ADOPTED_CORE_NAME);
+  if (!entry) {
+    console.error(
+      `${red('authored core not in this release.')} This Hedgehog release's registry has no\n` +
+        `entry named "authored" — nothing to install. Update Hedgehog and retry.\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  let core;
+  try {
+    core = await fetchCore(entry);
+  } catch (err) {
+    console.error(`\n${red(bold('Core unavailable.'))} ${err.message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const targets = await installedHosts(DEST_ROOT);
+  let written = 0;
+  for (const host of targets) {
+    const h = HOSTS[host];
+    for (const payloadEntry of corePayload(core, h, { hostOnly: true })) {
+      for (const f of await plannedFiles(payloadEntry)) {
+        await writePlannedFile(f);
+        written++;
+        console.log(`  ${green('install')}  ${relative(DEST_ROOT, f.dest)}`);
+      }
+    }
+  }
+
+  await recordCore(DEST_ROOT, { name: core.manifest.name, version: core.version, adopted: true });
+
+  console.log(
+    `\n${green(bold('Adopted core recorded.'))} ${dim(
+      `${written} file(s) written for ${targets.map((h) => HOSTS[h].label).join(', ')}`,
+    )}\n`,
+  );
+  console.log(
+    dim(
+      'hedgehog-authored-loop and layer-eng are now on disk and this project is\n' +
+        'recorded as adopted — `hedgehog update` will keep them current alongside\n' +
+        "the shared engine payload, and will never treat this project's core as a\n" +
+        'name it gets to change.\n',
+    ),
+  );
 }
 
 async function dbRebuildCommand() {
@@ -3569,6 +3657,21 @@ function engineNote(engine) {
   return `${engine} ${dim(`— CLI is ${PKG_VERSION}`)}`;
 }
 
+// `hedgehog core record-adopted` — see recordAdoptedCommand for why this
+// exists. `cores` (plural) lists the registry; `core` (singular) acts on
+// this project's own core, so the two don't collide despite the name.
+async function coreCommand(args) {
+  const sub = args[0];
+  if (sub !== 'record-adopted') {
+    console.error(
+      `${red('Unknown core subcommand:')} ${sub ?? '(none)'}\n\nUsage: hedgehog core record-adopted\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  await recordAdoptedCommand();
+}
+
 // Wraps prose to `width`, indenting every line after the first so it sits
 // under the column its label opened.
 function wrapProse(text, width, indent) {
@@ -3672,6 +3775,11 @@ async function main() {
 
   if (cmd === 'cores') {
     await coresCommand(args.slice(1));
+    return;
+  }
+
+  if (cmd === 'core') {
+    await coreCommand(args.slice(1));
     return;
   }
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "5.1.13",
+  "version": "5.1.14",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -178,10 +178,12 @@ graph, and phase gates, in place of ad-hoc scaffolding.
 
 What the discipline consists of differs by core, and a core is not just
 scaffolding — `landing-page` sequences copy and conversion, `full-stack-app`
-and `pwa-app` sequence modules split by where the data lives, and
-`deepseek-harness` fits a DSH plugin/tool/hook build. The `hedgehog` skill
-carries the full per-core selection criteria; judge a request against the
-core that actually fits it, not against a single core's shape.
+and `pwa-app` sequence modules split by where the data lives,
+`deepseek-harness` fits a DSH plugin/tool/hook build, and `authored`
+(brownfield adoption) brings the discipline to an existing codebase without
+bootstrapping a workspace. The `hedgehog` skill carries the full per-core
+selection criteria; judge a request against the core that actually fits it,
+not against a single core's shape.
 
 This project does not have it installed (no `.hedgehog/` directory).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/skills/hedgehog/SKILL.md
+++ b/skills/hedgehog/SKILL.md
@@ -40,10 +40,14 @@ Run the matching command:
   framework, or otherwise extending an existing DSH installation via its
   plugin/bundle system. `DSH`, `Cordis`, `defineTool`, `ctx.tools.register`,
   or a `cordis.patch.yml` manifest are strong signals.
-- Anything else — CLI, library, browser extension, data pipeline, an
-  existing codebase, or not yet clear from the conversation:
-  `npx @skyf0xx/hedgehog init` with no core flag. Planning intake decides
-  from there, so prefer this over guessing between the shipped cores.
+- Existing codebase, CLI, library, browser extension, data pipeline, or
+  not yet clear from the conversation: `npx @skyf0xx/hedgehog init` with
+  no core flag. `planner`'s Phase 0 decides from there — including routing
+  a repo that already has real source files to `hedgehog-adopt` (shipped
+  in `@skyf0xx/hedgehog-core-authored`, a separate package), which brings
+  Hedgehog's discipline to the existing codebase without bootstrapping a
+  workspace. Prefer this coreless install over guessing between the
+  shipped cores.
 
 Add a host flag when the user is on Cursor or Gemini CLI rather than
 Claude Code: `--cursor`, `--gemini`, `--host=claude,cursor`, or

--- a/src/db/plan.mjs
+++ b/src/db/plan.mjs
@@ -5,10 +5,11 @@
 //
 // full-stack-app and pwa-app: one task per layer per intent (an intent is
 // a domain module — see the core definition's `{module}` placeholder).
-// landing-page: one task per phase, no module axis. All three are the
-// same operation — walk a core definition's layer chain once per intent
-// — because a linear chain is the degenerate case of the layer graph
-// (spec: MVP scope item 5).
+// landing-page, deepseek-harness, and authored (whether designed from
+// scratch or adopted onto an existing repo): one task per phase/layer, no
+// module axis. All are the same operation — walk a core definition's layer
+// chain once per intent — because a linear chain is the degenerate case of
+// the layer graph (spec: MVP scope item 5).
 //
 // Layer cardinality: a layer marked `once: true` in the core definition
 // opts out of that per-intent multiplication and compiles a single task

--- a/src/hosts/claude-md-merge.mjs
+++ b/src/hosts/claude-md-merge.mjs
@@ -1,0 +1,69 @@
+// Merges a core's CLAUDE.md section into a project's root instructions
+// file, for the one path where that file is not a Hedgehog shell: a
+// repo adopted onto existing, hand-written content that has no
+// {{CORE_SECTION}} placeholder at all.
+//
+// `writePlannedFile` in bin/cli.mjs (the `merge` entry kind) fills
+// {{CORE_SECTION}} by substring replacement, which requires the shell's
+// placeholder to already be present — true for every project `init`
+// ever wrote, since it always starts from src/templates/CLAUDE.md. An
+// adopted repo's CLAUDE.md predates Hedgehog entirely and carries no
+// such marker, so that replacement has nothing to replace. This module
+// is the one place that gap is closed: appending a delimited section
+// instead of substituting into one.
+//
+// Referenced by name (not substance) from hedgehog-adopt's own SKILL.md
+// in the @skyf0xx/hedgehog-core-authored package — that skill invokes
+// `appendCoreSection` the same way it already invokes `loadCore` from
+// src/db/core.mjs, via `node -e "import('<path-to-hedgehog-install>/
+// src/hosts/claude-md-merge.mjs')..."`.
+
+const MARKER_START = '<!-- hedgehog:core-section start -->';
+const MARKER_END = '<!-- hedgehog:core-section end -->';
+
+// True when `content` already carries a Hedgehog-managed section — from
+// either mechanism: the shell's own {{CORE_SECTION}} placeholder (still
+// unfilled, or already filled by writePlannedFile's substring
+// replacement — filled content stays wrapped in the same markers, so
+// this check still finds it) or this module's own appended, delimited
+// block.
+export function hasCoreSection(content) {
+  return content.includes('{{CORE_SECTION}}') || content.includes(MARKER_START);
+}
+
+// Wraps `section` (a core's CLAUDE.core.*.md content, verbatim) in the
+// stable markers that make both the substring-replace path
+// (writePlannedFile, bin/cli.mjs) and this append path idempotent and
+// mutually recognizable. Exported so writePlannedFile's {{CORE_SECTION}}
+// substitution wraps its own output the same way, rather than each path
+// hand-rolling the marker text.
+export function wrapSection(section) {
+  return `${MARKER_START}\n\n${section.trimEnd()}\n\n${MARKER_END}`;
+}
+
+// Appends `section` to `existingContent` as a clearly delimited block,
+// never touching a byte of what's already there. Idempotent: if a
+// marked section is already present, its content is replaced in place
+// (so a later `hedgehog-adopt` re-run, or a core switch, updates the
+// section without duplicating it) rather than appending a second copy.
+//
+// This is the merge path for a CLAUDE.md hedgehog-adopt's Step 5 finds
+// with no {{CORE_SECTION}} placeholder — the file predates Hedgehog and
+// was never written from src/templates/CLAUDE.md. Every file that shell
+// ever produced already has the placeholder, so that case always goes
+// through writePlannedFile's ordinary substitution instead; this
+// function is never called on that path.
+export function appendCoreSection(existingContent, section) {
+  const block = wrapSection(section);
+  const markerRe = new RegExp(
+    `${escapeRe(MARKER_START)}[\\s\\S]*?${escapeRe(MARKER_END)}`,
+  );
+  if (markerRe.test(existingContent)) {
+    return existingContent.replace(markerRe, block);
+  }
+  return `${existingContent.trimEnd()}\n\n${block}\n`;
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }

--- a/src/registry/index.mjs
+++ b/src/registry/index.mjs
@@ -1,14 +1,16 @@
 // Core package registry. One entry per Hedgehog core — full-stack-app,
-// pwa-app, landing-page, authored — naming the npm package that ships its
-// agents, skills, and (for the three shipped cores) scaffold, plus the CLI
-// flag `hedgehog init` accepts for it and the prose `planner` reads aloud
-// in Phase 0 to choose one. A fixed table, one entry per core, discovered
-// by name or flag rather than convention.
+// pwa-app, landing-page, deepseek-harness, and authored — naming the npm
+// package that ships its agents, skills, and (for the first four) scaffold,
+// plus the CLI flag `hedgehog init` accepts for it and the prose `planner`
+// reads aloud in Phase 0 to choose one. A fixed table, one entry per core,
+// discovered by name or flag rather than convention.
 //
 // `authored` carries no flag — it is never selected off a fixed list at
-// install time. hedgehog-core-design chooses it during planning, from the
-// drivers hedgehog-planning-intake's Phase 0 elicits, not from a value a
-// user passes to `init`.
+// install time. hedgehog-core-design chooses it during planning (from-scratch
+// design path), or hedgehog-adopt brings it to an existing repo (brownfield
+// adoption path), from the drivers hedgehog-planning-intake's Phase 0 elicits
+// or the repo characteristics adoption discovers, not from a value a user
+// passes to `init`.
 
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';

--- a/src/registry/installed.mjs
+++ b/src/registry/installed.mjs
@@ -6,34 +6,62 @@
 // install time has nothing recorded until its bootstrap-core skill lands
 // the core — `installedCore` returns null until then, and `update` limits
 // itself to the shared payload.
+//
+// `authored` has a second entry point with no `init` step at all:
+// `hedgehog-adopt` brings the discipline to a repo that already exists by
+// writing `.hedgehog/core.yaml` itself, directly, and never calls
+// `recordCore` (see that skill, shipped in
+// @skyf0xx/hedgehog-core-authored — adoption has no npm package of its
+// own to fetch, just a core.yaml and adoption.md derived from the
+// existing repo). `hedgehog core record-adopted` (bin/cli.mjs) is the
+// record path for that case instead: it lands the authored package's
+// agents/skills — otherwise never installed, since adoption's `init` runs
+// with no `--core` flag and `bootstrap` is skipped entirely for adoption
+// — and calls `recordCore` with `adopted: true`. That flag is the one
+// thing distinguishing an adopted record from a normal one: `update`'s
+// resolveInstalledCore refreshes an adopted project's payload the same as
+// any other (same package, same agents/skills, kept current) but must
+// never treat `record.name` changing upstream, or the record going
+// missing, as license to fetch and install a *different* core the way it
+// would for a project that chose one at `init` — adoption's core is a
+// fixed fact of the repo (its `.hedgehog/core.yaml`), not a choice
+// `update` gets to revisit.
 
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
+
+export const ADOPTED_CORE_NAME = 'authored';
 
 const CORE_PATH = '.hedgehog/core.json';
 
 /**
  * Record the core a project installed and the exact version resolved for
  * it. Written after the core's files land, so the record describes what
- * is on disk.
+ * is on disk. `adopted: true` marks a record written by `hedgehog core
+ * record-adopted` rather than by `init` — see the module comment above.
  */
-export async function recordCore(root, { name, version }) {
+export async function recordCore(root, { name, version, adopted = false }) {
   const path = join(root, CORE_PATH);
   await mkdir(dirname(path), { recursive: true });
   await writeFile(
     path,
-    `${JSON.stringify({ core: name, version, installedAt: new Date().toISOString() }, null, 2)}\n`,
+    `${JSON.stringify(
+      { core: name, version, installedAt: new Date().toISOString(), ...(adopted ? { adopted: true } : {}) },
+      null,
+      2,
+    )}\n`,
   );
 }
 
 /**
- * The core `update` should refresh — `{ name, version }` — or null when
- * this project has no core installed yet.
+ * The core `update` should refresh — `{ name, version, adopted }` — or
+ * null when this project has no core installed yet. `adopted` is always a
+ * boolean, `false` for every record `init` writes.
  */
 export async function installedCore(root) {
   try {
-    const { core, version } = JSON.parse(await readFile(join(root, CORE_PATH), 'utf8'));
-    return core ? { name: core, version } : null;
+    const { core, version, adopted } = JSON.parse(await readFile(join(root, CORE_PATH), 'utf8'));
+    return core ? { name: core, version, adopted: adopted === true } : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- `hedgehog-adopt` (shipped in `@skyf0xx/hedgehog-core-authored`) needed two engine-side pieces this repo now provides:
  - `src/hosts/claude-md-merge.mjs` — idempotently merges a core's CLAUDE.md section into a repo whose root `CLAUDE.md` predates Hedgehog and has no `{{CORE_SECTION}}` placeholder (appends a delimited block instead of assuming a placeholder exists).
  - `hedgehog core record-adopted` (new CLI subcommand) plus an `adopted` flag in `src/registry/installed.mjs` — fixes a real bug where `hedgehog update` on an adopted repo would treat it as coreless and silently delete `layer-eng.md` and every `hedgehog-adopt`-related skill, with nothing put back.
- Updated hand-maintained enumeration docs (`CLAUDE.md`, `ARCHITECTURE.md`, `SECURITY.md`, `CONTRIBUTING.md`, `skills/hedgehog/SKILL.md`, `hooks/session-start`, `src/db/plan.mjs`, `src/registry/index.mjs`) so they mention that `authored` covers both from-scratch design and brownfield adoption.
- Rewrote README's "Existing codebases" section, which predated the real implementation, to describe what adoption actually does.
- `planner.md`/`tweaker.md` needed no changes — verified accurate against the real shipped `hedgehog-adopt`/`hedgehog-adopt-elicit` design already.
- No entry added to `src/registry/cores.json` — adoption is a second path through the existing `authored` entry, not a new core.
- Bumped `package.json` 6.0.2 → 6.0.3 (npm payload: `src/`, `bin/`) and the plugin family 5.1.13 → 5.1.14 (`skills/hedgehog/SKILL.md`, `hooks/session-start`), via `npm run release` / `npm run release:plugin`.

Companion fix in `hedgehog-core-authored` (the package that ships `hedgehog-adopt` itself, which needs to call the two pieces added here): skyf0xx/hedgehog-core-authored#6

## Test plan
- [x] `npm run check` passes (`ok — 4 agents, 5 skills, 5 cores, tarball, CLI`)
- [ ] Manually adopt onto a scratch repo with a hand-written `CLAUDE.md` and confirm the merged section appends correctly and idempotently
- [ ] Manually run `hedgehog core record-adopted` then `hedgehog update` and confirm the authored core's agents/skills survive