### PR TITLE
fix(db): migrate stale schema on every writable open, not only init

### DIFF
--- a/src/db/init.mjs
+++ b/src/db/init.mjs
@@ -24,12 +24,24 @@ export const dbAbsPath = (root = process.cwd()) => resolve(root, DB_PATH);
 // a call site that forgot them. journal_mode is skipped for read-only
 // handles — it requires write access and a readOnly connection has no
 // business changing the file's journal mode anyway.
+//
+// applySchema also runs here, not only from `dbInit`: a graph created by
+// an older CLI version is missing whatever tables/columns shipped since,
+// and every command besides `init`/`update` opens the graph straight
+// from here rather than going through dbInit first. Without this, those
+// commands only see the fix after someone thinks to rerun `init` on an
+// already-initialized project — which nothing prompts them to do — and
+// until then every query naming a newer column fails with "no such
+// column". Skipped for read-only handles for the same reason
+// journal_mode is: it requires write access, and a readOnly caller is
+// only ever reached after a writable open earlier in the same command.
 export function openDb({ readOnly = false } = {}) {
   const db = new DatabaseSync(dbAbsPath(), { readOnly });
   db.exec('PRAGMA foreign_keys = ON');
   db.exec('PRAGMA busy_timeout = 10000');
   if (!readOnly) db.exec('PRAGMA journal_mode = WAL');
   db.exec('PRAGMA synchronous = NORMAL');
+  if (!readOnly) applySchema(db);
   return db;
 }
 

--- a/src/db/schema.mjs
+++ b/src/db/schema.mjs
@@ -121,7 +121,25 @@ CREATE TABLE IF NOT EXISTS friction (
 // IF NOT EXISTS` above is a no-op against a DB created by an earlier
 // version, so a new column has to be ALTERed in explicitly or every
 // statement naming it fails on that DB. Each entry is `[name, ddl]`.
-const TASK_COLUMN_MIGRATIONS = [['claim_snapshot', 'claim_snapshot TEXT']];
+//
+// The lease columns (lease_owner, lease_expires_at, leased_at) and their
+// siblings (exclusive, verify_radius, blocked_reason) shipped together in
+// the same commit that introduced them to SCHEMA_SQL above, but were
+// never added here — so a graph created before that commit still lacks
+// them today, with every query naming lease_owner failing "no such
+// column" instead of self-healing the way claim_snapshot already does.
+const TASK_COLUMN_MIGRATIONS = [
+  ['exclusive', 'exclusive INTEGER NOT NULL DEFAULT 0'],
+  ['verify_radius', 'verify_radius TEXT'],
+  [
+    'blocked_reason',
+    "blocked_reason TEXT CHECK (blocked_reason IS NULL OR blocked_reason IN ('scope_violation','verification_failed','lease_expired'))",
+  ],
+  ['lease_owner', 'lease_owner TEXT'],
+  ['lease_expires_at', 'lease_expires_at TEXT'],
+  ['leased_at', 'leased_at TEXT'],
+  ['claim_snapshot', 'claim_snapshot TEXT'],
+];
 
 // Brings an already-created `tasks` table up to the current column set.
 // Idempotent and cheap (one PRAGMA), so callers that must not fail on a


### PR DESCRIPTION
## Summary

- `applySchema`/`ensureTaskColumns` (the self-healing migration path) previously only ran from `hedgehog db init`/`update`. Every other command (`status`, `next`, `claim`, ...) opens the graph straight through `openDb()` in `src/db/init.mjs`, which never called it - so a graph created by an older CLI version crashed with "no such column" on any command naming a column added since, until someone thought to rerun `init` against an already-initialized project. `openDb()` now calls `applySchema` for writable connections (skipped for read-only, which needs write access it doesn't have and is only ever reached after a writable open earlier in the same command).
- `TASK_COLUMN_MIGRATIONS` only ever listed `claim_snapshot`. The lease columns (`lease_owner`, `lease_expires_at`, `leased_at`) and their siblings (`exclusive`, `verify_radius`, `blocked_reason`) shipped straight into `SCHEMA_SQL`'s `CREATE TABLE` in the commit that introduced them, with no corresponding migration entry - so a graph created before that commit was still missing them with no path to get them short of a full re-init. All six now have their own entry alongside `claim_snapshot`.

Fixes #298.

## Test plan

- [x] Ran `node bin/cli.mjs init` in a scratch dir and confirmed `.claude/agents/`, `.claude/skills/`, and `.hedgehog/hedgehog.db` land correctly.
- [x] Reconstructed a graph on the pre-lease-commit schema (missing `exclusive`/`verify_radius`/`blocked_reason`/`lease_owner`/`lease_expires_at`/`leased_at`) and confirmed `hedgehog status` reproduces the exact `no such column: t.lease_owner` crash beforehand, and reports the graph correctly after this fix, with no manual `init` re-run needed.
- [x] `node --experimental-sqlite repro/run-all.mjs` (60 repros): same 10 pre-existing failures as a clean checkout with no changes (unrelated - e.g. a `/bin/sh` ENOENT on Windows), ran twice to rule out flakiness.