### PR TITLE
docs: require a loop-skill dispatch fallback pointer in the core contract

### DIFF
--- a/AUTHORING-CORES.md
+++ b/AUTHORING-CORES.md
@@ -71,6 +71,32 @@ At the package root:
   [`src/db/requires.mjs`](src/db/requires.mjs)'s header comment for the
   resolution semantics.
 
+## The loop skill's dispatch step needs a fallback pointer
+
+A core's own loop skill (`hedgehog-loop`, `hedgehog-dsh-loop`,
+`hedgehog-landing-loop`, `hedgehog-authored-loop`, or the equivalent in a
+new core) has exactly one step that dispatches a claimed packet to a
+named subagent (`backend-eng`, `pwa-eng`, `harness-eng`, `landing-builder`,
+`layer-eng`, or whatever this core's own build agent is called). That
+subagent is installed by this same `init`/`update` call, in the same
+session — and Claude Code (per `src/hosts/claude/DISPATCH.md`) registers
+agents once, at session start, so a name-based dispatch immediately after
+install reports the agent as not found even though its file exists on
+disk. This is the default first-build experience, not an edge case: `init`
+→ `planner` → `bootstrap` → the loop all naturally happen in one
+continuous session.
+
+Root CLAUDE.md already carries the explanation and the workaround (read
+the agent's file directly rather than waiting for a session restart) via
+`{{HOST_DISPATCH}}`. A core's loop skill doesn't need to restate that
+explanation — it needs one sentence at its own dispatch step pointing
+back to it, so an agent deep in loop execution doesn't have to
+rediscover the fallback on its own or treat the failure as fatal. Model
+the wording on the existing cores' loop skills: *"If a dispatch by name
+reports the agent as not found — expected right after `init`/`update`
+installed it this same session — see root CLAUDE.md's 'Delegating on
+this host' note rather than treating it as fatal."*
+
 ## Registering the core
 
 Adding the package to the CLI's `init` menu is one entry in
@@ -117,10 +143,12 @@ way it is.
 2. If it ships a workspace, build its generators before hand-authoring
    any repeatable scaffolding, and add the dependency-update workflow
    described above.
-3. Add the entry to `src/registry/cores.json`, including `selects_when`.
-4. Sweep the places that enumerate cores by hand rather than reading the
+3. In the loop skill's per-packet dispatch step, add the fallback pointer
+   to root CLAUDE.md's "Delegating on this host" note described above.
+4. Add the entry to `src/registry/cores.json`, including `selects_when`.
+5. Sweep the places that enumerate cores by hand rather than reading the
    registry — `CLAUDE.md` names the full list to update in the same PR.
-5. Run `npm run check` — it asserts a manifest's `selects_when` isn't
+6. Run `npm run check` — it asserts a manifest's `selects_when` isn't
    silently duplicating the registry's, among other structural checks.
 
 ## Auditing an existing core
@@ -158,6 +186,13 @@ satisfies the package contract above.
       `docker-compose`).
 - [ ] No `requires:` entries for ordinary JS/TS toolchain binaries
       (vitest, tsc, eslint, nx, …) — those don't belong there.
+
+### Loop skill
+
+- [ ] The per-packet dispatch step points back to root CLAUDE.md's
+      "Delegating on this host" note for the not-found-on-first-session
+      case, per "The loop skill's dispatch step needs a fallback pointer"
+      above.
 
 ### `src/registry/cores.json` entry
 


### PR DESCRIPTION
## Summary
- Adds the loop-skill dispatch fallback requirement to `AUTHORING-CORES.md`'s package contract, authoring checklist, and audit checklist, so a new core builds it in from the start instead of rediscovering the gap the way #293 did.
- Companion PRs land the actual one-line fix in each existing core's loop skill (all reference #293):
  - full-stack-app: skyf0xx/hedgehog-core-full-stack-app#21
  - pwa-app: skyf0xx/hedgehog-core-pwa-app#15
  - landing-page: skyf0xx/hedgehog-core-landing-page#15
  - deepseek-harness: skyf0xx/hedgehog-core-deepseek-harness#5
  - authored: skyf0xx/hedgehog-core-authored#8

## Why
`hedgehog-loop` (and its per-core equivalents) dispatch each claimed packet to a named subagent installed by that same `init`/`update` call in the same session. Claude Code registers agents once at session start, so the dispatch can report "not found" even though the agent file exists on disk. Root CLAUDE.md already explains the fallback via `DISPATCH.md`, but nothing in a loop skill pointed back to it at the moment of failure — so an agent deep in loop execution had no way to discover the workaround without already having read `init`'s earlier output.

Closes #293.

## Test plan
- [x] Docs-only change; no build/test impact. Confirm wording reads correctly in context.