### PR TITLE
chore(release): 6.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/repro/_lib.mjs
+++ b/repro/_lib.mjs
@@ -89,6 +89,7 @@ export function cli(cwd, args) {
       cwd,
       encoding: 'utf8',
       stdio: 'pipe',
+      env: { ...process.env, HEDGEHOG_NO_UPDATE_CHECK: '1' },
     });
     return { status: 0, stdout, stderr: '' };
   } catch (err) {

--- a/repro/commit-failure-recovery.mjs
+++ b/repro/commit-failure-recovery.mjs
@@ -73,7 +73,7 @@ function hedgehog(cwd, args) {
       cwd,
       encoding: 'utf8',
       stdio: 'pipe',
-      env: { ...process.env, NO_COLOR: '1' },
+      env: { ...process.env, NO_COLOR: '1', HEDGEHOG_NO_UPDATE_CHECK: '1' },
     });
     return { code: 0, out: stripWarnings(out) };
   } catch (err) {

--- a/repro/drift-lib.mjs
+++ b/repro/drift-lib.mjs
@@ -88,6 +88,7 @@ export function makeProject(coreYaml = CORE_YAML_BEFORE) {
     ...process.env,
     PATH: `${binDir}:${process.env.PATH}`,
     NO_COLOR: '1',
+    HEDGEHOG_NO_UPDATE_CHECK: '1',
   };
 
   const project = {

--- a/repro/fixtures/cores/authored.manifest.yaml
+++ b/repro/fixtures/cores/authored.manifest.yaml
@@ -1,7 +1,7 @@
 name: authored
 flag: null
 language: typescript
-engine: "^5.0.0"
+engine: "^6.0.0"
 template: CLAUDE.core.md
 template_adopted: CLAUDE.core.adopted.md
 agents: [layer-eng]

--- a/repro/fixtures/cores/deepseek-harness.manifest.yaml
+++ b/repro/fixtures/cores/deepseek-harness.manifest.yaml
@@ -1,7 +1,7 @@
 name: deepseek-harness
 flag: --deepseek-harness
 language: typescript
-engine: "^5.0.0"
+engine: "^6.0.0"
 workspace: workspace/
 template: CLAUDE.core.md
 agents: [harness-eng]

--- a/repro/fixtures/cores/full-stack-app.manifest.yaml
+++ b/repro/fixtures/cores/full-stack-app.manifest.yaml
@@ -1,7 +1,7 @@
 name: full-stack-app
 flag: --ts-full-stack-app
 language: typescript
-engine: "^5.0.0"
+engine: "^6.0.0"
 workspace: workspace/
 template: CLAUDE.core.md
 agents: [backend-eng, ux-planner, front-end-eng]

--- a/repro/fixtures/cores/landing-page.manifest.yaml
+++ b/repro/fixtures/cores/landing-page.manifest.yaml
@@ -1,7 +1,7 @@
 name: landing-page
 flag: --landing-page
 language: typescript
-engine: "^5.0.0"
+engine: "^6.0.0"
 workspace: workspace/
 template: CLAUDE.core.md
 agents: [landing-builder, landing-copywriter, landing-executor,

--- a/repro/fixtures/cores/pwa-app.manifest.yaml
+++ b/repro/fixtures/cores/pwa-app.manifest.yaml
@@ -1,7 +1,7 @@
 name: pwa-app
 flag: --pwa-app
 language: typescript
-engine: "^5.0.0"
+engine: "^6.0.0"
 workspace: workspace/
 template: CLAUDE.core.md
 agents: [pwa-eng]

--- a/repro/lib.mjs
+++ b/repro/lib.mjs
@@ -173,7 +173,7 @@ export function hedgehog(cwd, args) {
     stdio: 'pipe',
     // ExperimentalWarning: SQLite noise on stderr would otherwise land in
     // every captured output string.
-    env: { ...process.env, NODE_NO_WARNINGS: '1', NO_COLOR: '1' },
+    env: { ...process.env, NODE_NO_WARNINGS: '1', NO_COLOR: '1', HEDGEHOG_NO_UPDATE_CHECK: '1' },
     // execFileSync throws on non-zero; catching below keeps the code.
   });
   return { code: 0, out: result };

--- a/repro/no-op-layer-commit.mjs
+++ b/repro/no-op-layer-commit.mjs
@@ -66,7 +66,7 @@ function hedgehog(cwd, args) {
     cwd,
     encoding: 'utf8',
     stdio: 'pipe',
-    env: { ...process.env, NO_COLOR: '1' },
+    env: { ...process.env, NO_COLOR: '1', HEDGEHOG_NO_UPDATE_CHECK: '1' },
   });
 }
 

--- a/repro/packet-lib.mjs
+++ b/repro/packet-lib.mjs
@@ -46,7 +46,7 @@ export function makeFixture({ goal = GOAL, outcome = OUTCOME } = {}) {
       cwd: dir,
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...process.env, NODE_NO_WARNINGS: '1' },
+      env: { ...process.env, NODE_NO_WARNINGS: '1', HEDGEHOG_NO_UPDATE_CHECK: '1' },
       ...opts,
     });
 

--- a/repro/papercuts-lib.mjs
+++ b/repro/papercuts-lib.mjs
@@ -86,7 +86,7 @@ export function hedgehog(cwd, args, env = {}) {
   const res = spawnSync(process.execPath, [CLI, ...args], {
     cwd,
     encoding: 'utf8',
-    env: { ...process.env, ...env, NO_COLOR: '1' },
+    env: { ...process.env, ...env, NO_COLOR: '1', HEDGEHOG_NO_UPDATE_CHECK: '1' },
   });
   return {
     status: res.status,

--- a/repro/run-all.mjs
+++ b/repro/run-all.mjs
@@ -29,11 +29,21 @@ const scripts = readdirSync(HERE)
   .filter((f) => f.endsWith('.mjs') && !isHelper(f))
   .sort();
 
+// Reproductions drive the real CLI, and every CLI invocation otherwise
+// runs `ensureGlobalInstall` — a live `npm install -g
+// @skyf0xx/hedgehog@latest`. That reaches the network, mutates the
+// machine's global npm root, and (worst of all here) leaves later
+// reproductions resolving `hedgehog` to the published release instead of
+// this working tree, so a suite run stops testing the code under test.
+// The guard keeps every reproduction hermetic and offline.
+const REPRO_ENV = { ...process.env, HEDGEHOG_NO_UPDATE_CHECK: '1' };
+
 const failed = [];
 for (const script of scripts) {
   console.log(`\n=== ${script} ===`);
   const result = spawnSync(process.execPath, ['--experimental-sqlite', join(HERE, script)], {
     stdio: 'inherit',
+    env: REPRO_ENV,
   });
   if (result.status !== 0) failed.push(script);
 }

--- a/repro/scope-gate-lib.mjs
+++ b/repro/scope-gate-lib.mjs
@@ -128,7 +128,7 @@ function runCli(dir, args) {
   const res = spawnSync(process.execPath, ['--experimental-sqlite', CLI, ...args], {
     cwd: dir,
     encoding: 'utf8',
-    env: { ...process.env, NO_COLOR: '1' },
+    env: { ...process.env, NO_COLOR: '1', HEDGEHOG_NO_UPDATE_CHECK: '1' },
   });
   return {
     code: res.status,

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.0.4",
+  "version": "6.0.5",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
Cuts 6.0.5 so the changes merged to `master` reach clients through `npx @skyf0xx/hedgehog init`/`update`.

## Payload since 6.0.4

- `pr-writing` skill added, and `hedgehog-contributing` rewritten to use it (`src/skills/`).
- Schema migration on every writable open, not only init (`src/db/`).
- Versioned schema migrations and a decisions ledger (#301), merged into this branch from `master`.

Nothing under `skills/`, `hooks/`, `.claude-plugin/`, `.cursor-plugin/`, or root `gemini-extension.json` changed, so the plugin version stays at 5.1.15.

## Changes here

- `npm run release` patch bump: `package.json` and `src/hosts/gemini/gemini-extension.json` to 6.0.5.
- Refreshed the five `repro/fixtures/cores/*.manifest.yaml` fixtures from each core's committed `hedgehog-core.yaml`. The only difference is `engine: "^5.0.0"` to `"^6.0.0"`, which the core repos bumped separately.
- Made the reproductions hermetic.

## Why the reproductions changed

Every CLI invocation runs `ensureGlobalInstall`, a live `npm install -g @skyf0xx/hedgehog@latest`. The reproductions drive the real CLI, so a suite run reached the network, mutated the machine's global npm root, and left later reproductions resolving `hedgehog` to the published release instead of this working tree.

That is what failed CI here: `02-unrelated-dirty-tracked-file` ran against published 6.0.4 rather than the branch, and reported a scope violation on a shared dirty file. It passed when run alone, which is the signature of the contamination rather than of the code under test.

`HEDGEHOG_NO_UPDATE_CHECK=1` is now set in the suite runner and at every helper that spawns the CLI, so a reproduction is hermetic run either way.

`npm run repro` (62 passed) and `npm run check` both pass.

No tag pushed — `publish.yml` tags `v6.0.5`, publishes, and creates the release once this merges.