### PR TITLE
fix(ci): survive a moved master in the badge refresh push

### DIFF
--- a/.github/workflows/badge-refresh.yml
+++ b/.github/workflows/badge-refresh.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           token: ${{ secrets.BADGE_REFRESH_TOKEN }}
+          ref: master
 
       - name: Compute total downloads across all packages
         id: downloads
@@ -130,12 +131,30 @@ jobs:
 
       - name: Commit if changed
         run: |
+          files="badges/npm-downloads.svg badges/kofi-top.svg badges/github-stars-cta.svg DOWNLOADS.md"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          if ! git diff --quiet -- badges/npm-downloads.svg badges/kofi-top.svg badges/github-stars-cta.svg DOWNLOADS.md; then
-            git add badges/npm-downloads.svg badges/kofi-top.svg badges/github-stars-cta.svg DOWNLOADS.md
-            git commit -m "chore: refresh badges"
-            git push
-          else
+          if git diff --quiet -- $files; then
             echo "No change in badges, skipping commit"
+            exit 0
           fi
+          git add $files
+          git commit -m "chore: refresh badges"
+          for attempt in 1 2 3 4 5; do
+            if git push origin HEAD:master; then
+              echo "Pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "Push rejected on attempt $attempt, rebasing onto origin/master"
+            git fetch origin master
+            git rebase origin/master || {
+              echo "Rebase hit a conflict; taking our regenerated files" >&2
+              # During a rebase, --theirs is the commit being replayed (ours).
+              git checkout --theirs -- $files || true
+              git add $files
+              git -c core.editor=true rebase --continue || exit 1
+            }
+            sleep $((attempt * 5))
+          done
+          echo "Could not push after 5 attempts" >&2
+          exit 1


### PR DESCRIPTION
## Problem

The scheduled `Refresh badges` run [32938392486](https://github.com/skyf0xx/hedgehog/actions/runs/32938392486) failed on push:

```
error: failed to push some refs to 'https://github.com/skyf0xx/hedgehog'
hint: Updates were rejected because the remote contains work that you do not have locally.
```

The run was created `2026-08-26T06:29:40Z` but did not start until `2026-08-27T08:40:33Z` — over 26 hours in the queue. Its `headSha` was `a314d44`, stale by then: master had since taken the 08-26 badge refresh (`3a24c51`) and PR #308 (`10a180b`). The job regenerated the badges against that old tree and pushed onto a master that had moved, with no retry to recover.

## Fix

- Pin the checkout to `master` rather than the event's recorded SHA.
- Push through a rebase-and-retry loop (5 attempts, backoff). On a content conflict the regenerated badge files win, since they are the freshly computed output; the concurrent commit's other work is kept by the rebase.

## Verification

Simulated the race in a scratch repo — stale clone, remote advanced with a commit that also touched `DOWNLOADS.md`:

```
Push rejected on attempt 1, rebasing onto origin/master
CONFLICT (content): Merge conflict in DOWNLOADS.md
Rebase hit a conflict; taking our regenerated files
Pushed on attempt 2
=== exit: 0 ===
```

The remote ended with the new badge content and the concurrent commit's unrelated change both intact. YAML validated with `js-yaml`.