### PR TITLE
fix: close the two brownfield adoption seams (#302, #303)

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -424,6 +424,17 @@ async function writePlannedFile(f) {
       const existing = await readFile(f.dest, 'utf8');
       if (!existing.includes('{{PROJECT_NAME}}') && existing.includes('{{CORE_SECTION}}')) {
         out = existing;
+      } else if (!existing.includes('{{PROJECT_NAME}}') && !f.merge.include) {
+        // Brownfield: hand-written content that predates Hedgehog, with
+        // no shell markers at all, on the coreless deferred path (no
+        // `include` — there's no core section yet to fill in). Nothing
+        // to merge in here; the file is untouched until `hedgehog-adopt`
+        // later appends its own core section via appendCoreSection
+        // (src/hosts/claude-md-merge.mjs). Overwriting it with the
+        // greenfield shell, or even just filling {{HOST_DISPATCH}} into
+        // it, would assert a fresh-install shape onto a repo that isn't
+        // new.
+        return;
       }
     }
     if (out === null) out = await readFile(join(PKG_ROOT, f.merge.shell), 'utf8');
@@ -688,11 +699,26 @@ async function init({ force, core, host = DEFAULT_HOST, hostOnly = false, global
   // the project, so rewriting it loses nothing and never counts as a
   // conflict — that's what lets a second host be added to a project the
   // first one already set up.
+  //
+  // A deferred (coreless) install's root-instructions merge is exempted
+  // too, but only when the existing file is a brownfield one: hand-written
+  // content with no {{PROJECT_NAME}} shell marker. That file was never a
+  // Hedgehog shell to overwrite — writePlannedFile leaves it untouched,
+  // for hedgehog-adopt's own merge step to append its delimited core
+  // section into later (src/hosts/claude-md-merge.mjs), once a core is
+  // actually known. A file still carrying {{PROJECT_NAME}} (a previous
+  // deferred init's untouched shell) is not brownfield content and keeps
+  // hitting the ordinary conflict/--force path below.
   const conflicts = [];
   for (const { entry, files } of groups) {
     if (entry.type === 'generated') continue;
     for (const f of files) {
-      if (await exists(f.dest)) conflicts.push(f.dest);
+      if (!(await exists(f.dest))) continue;
+      if (core === null && f.merge) {
+        const existing = await readFile(f.dest, 'utf8');
+        if (!existing.includes('{{PROJECT_NAME}}')) continue;
+      }
+      conflicts.push(f.dest);
     }
   }
 
@@ -719,7 +745,15 @@ async function init({ force, core, host = DEFAULT_HOST, hostOnly = false, global
   for (const { files } of groups) {
     for (const f of files) {
       const already = await exists(f.dest);
+      // Brownfield CLAUDE.md on the coreless path: writePlannedFile
+      // leaves it untouched (see its own comment) rather than overwriting
+      // it, so this write must not be logged or counted as one.
+      const before = already && f.merge ? await readFile(f.dest, 'utf8') : null;
       await writePlannedFile(f);
+      if (before !== null && (await readFile(f.dest, 'utf8')) === before) {
+        console.log(`  ${dim('keep')}  ${relative(DEST_ROOT, f.dest)}`);
+        continue;
+      }
       if (already) overwritten++;
       else written++;
       const label = already ? yellow('overwrite') : green('create');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/src/agents/planner.md
+++ b/src/agents/planner.md
@@ -202,9 +202,11 @@ none of them is a description matching a `when` paragraph:
   enforcement on my changes here"). This is a distinct question from
   everything above: it's not about which core fits new work, because no
   new workspace gets built at all. This project gets the **adopted
-  core**. Route straight to `hedgehog-adopt` — bootstrap and every other
-  Phase 0 outcome are skipped entirely, since there is no workspace to
-  scaffold and no shipped stack to adopt toward. `hedgehog-adopt` runs
+  core**. Run `hedgehog core record-adopted` first — a no-flag `init`
+  never fetched the `adopted` package, so `hedgehog-adopt` is not yet on
+  disk to route to — then route to `hedgehog-adopt`. Bootstrap and every
+  other Phase 0 outcome are skipped entirely, since there is no workspace
+  to scaffold and no shipped stack to adopt toward. `hedgehog-adopt` runs
   its own read-only intake and writes its own `.hedgehog/core.yaml`;
   don't run `hedgehog-planning-intake`'s BMAD shelf first — the drivers
   that skill elicits (persistence, stack, deployment target) are already
@@ -389,18 +391,23 @@ as full-stack-app's Auth/Queue/Mobile trio.
      run.** Continue at step 3.
    - **No intents in the graph, and the request is adoption onto an
      existing repo → brownfield first run.** Skip Phase 0's core
-     selection and every step below through step 9 — go straight to
-     `hedgehog-adopt`. It runs its own intake and Confirm & Lock, writes
-     `.hedgehog/core.yaml` and `.hedgehog/adoption.md`, and adds the
-     first intent(s) itself. Return the summary (step 10) once it's done.
+     selection and every step below through step 9. Run `hedgehog core
+     record-adopted` first — a no-flag `init` never fetched the
+     `adopted` package, so `hedgehog-adopt` is not yet on disk — then go
+     straight to `hedgehog-adopt`. It runs its own intake and Confirm &
+     Lock, writes `.hedgehog/core.yaml` and `.hedgehog/adoption.md`, and
+     adds the first intent(s) itself. Return the summary (step 10) once
+     it's done.
    - **One or more intents, on `.hedgehog/core.yaml` written by
      `hedgehog-adopt` → adoption re-entry.** New change-work on a repo
-     already under adoption. Skip steps 3 through 9 — route straight to
-     `hedgehog-adopt` again instead, same as brownfield first run above.
-     It owns everything the other path's steps 5, 7, 8, and 9 would
-     otherwise do: it sizes the request (a large or ambiguous one gets its
-     own short clarifying pass, a clear small one doesn't), adds the
-     intent(s), runs `hedgehog plan`, and commits its own work as `chore
+     already under adoption. Skip steps 3 through 9. Run `hedgehog core
+     record-adopted` first — safe and idempotent to re-run, and the only
+     guarantee that `hedgehog-adopt` is on disk in this session — then
+     route straight to `hedgehog-adopt` again, same as brownfield first
+     run above. It owns everything the other path's steps 5, 7, 8, and 9
+     would otherwise do: it sizes the request (a large or ambiguous one
+     gets its own short clarifying pass, a clear small one doesn't), adds
+     the intent(s), runs `hedgehog plan`, and commits its own work as `chore
      (planning): adopt change`. Don't run `hedgehog-planning-intake`'s
      Re-entry pass here — there is no BMAD archive to read as context on
      this path, since adoption never runs one. Return the summary (step

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Summary

- `hedgehog-adopt` is now fetched before `planner` routes to it. A no-flag `init` never fetches a core package, and `bootstrap` is skipped entirely on the brownfield path, so `hedgehog-adopt` (shipped in `@skyf0xx/hedgehog-core-adopted` after today's authored/adopted split) was never on disk at the moment `planner` tried to route there. `planner.md` now runs `hedgehog core record-adopted` first, on both the brownfield-first-run and adoption-re-entry branches.
- `init` on an existing repo no longer destroys a hand-written `CLAUDE.md`. It previously hard-failed with "Refusing to overwrite existing files", and `--force` replaced the file with the unfilled greenfield shell — both destroy content that `hedgehog-adopt`'s own merge step (`appendCoreSection`) is meant to append into later. A coreless `init` now recognizes a `CLAUDE.md` with no `{{PROJECT_NAME}}` shell marker as brownfield content and leaves it byte-for-byte untouched, logged as `keep`.
- Version bump: `6.1.0` → `6.1.1` (`bin/`, `src/agents/` changed).

Verified both bugs were still present after today's `refactor: split authored core into authored (greenfield) and adopted (brownfield)` — that commit renamed the target package (`authored` → `adopted`) and fixed a separate template-staging bug, but didn't touch either seam.

Fixes #302. Fixes #303. Addresses the first two items of #304's definition of done (onboarding path); #304's item 2 (extending an already-adopted repo) and item 4 (ROADMAP.md entry) still need separate work, so leaving #304 open.

## Test plan

- [x] `npm run check` passes
- [x] `npm run repro` — all 62 reproductions pass
- [x] Manual smoke test: `init` (no flag) in a fresh repo with a hand-written `CLAUDE.md` — content preserved byte-for-byte, logged as `keep`, ordinary conflicts on `.claude/agents/*` etc. still correctly refuse without `--force`