### PR TITLE
feat: close out #304: ROADMAP entry and published-package fixture check

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -191,6 +191,23 @@ it's a single file.
 
 Anything in a skill that can be trimmed (removing excess verbosity while maintaining essentials)
 
+### Brownfield adoption hardening
+
+Bringing Hedgehog to a repo that already exists is two paths: onboarding
+(`init` on a repo with its own `CLAUDE.md` and source, routing to
+`hedgehog-adopt` without losing either) and extension (a second or third
+adoption pass on an already-adopted repo, adding change-work without
+re-running planning intake's BMAD shelf or re-scaffolding). Both are
+live and exercised — `src/hosts/claude-md-merge.mjs` and `src/agents/
+planner.md`'s adoption-re-entry branch (Workflow step 2) cover onboarding,
+`@skyf0xx/hedgehog-core-adopted`'s `hedgehog-adopt` skill covers
+extension, keeping `.hedgehog/core.yaml` and `adoption.md` locked and
+byte-identical across re-entries. This entry exists so the area keeps an
+owner: further gaps found while actually adopting a real repo (a repo
+shape Step 1 misreads, a verify-command heuristic that's too narrow, a
+rough edge in the re-entry elicitation pass) belong here rather than as
+one-off closed bugs with no place to land the next one.
+
 ## Contributing to this list
 
 Adding an item here is itself a contribution. Keep new entries scoped the

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -17,6 +17,7 @@ import { AGENT_CAPABILITY } from '../src/hosts/capabilities.mjs';
 import { loadCore, lintCore } from '../src/db/core.mjs';
 import { loadRegistry } from '../src/registry/index.mjs';
 import { parseCoreManifest } from '../src/registry/manifest.mjs';
+import { fetchCore } from '../src/registry/fetch.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, '..');
@@ -190,6 +191,45 @@ for (const core of cores) {
             `published version is ${latest}. Widen the pin (e.g. ">=X.0.0 <Y.0.0" spanning ` +
             `the current major) so a future release of that core doesn't require a new ` +
             `hedgehog release just to reach it.`,
+        );
+      }
+    }
+  }
+}
+
+// ── 2d. Every core's fixture manifest is not just internally consistent
+//    but a true subset of what the published package it stands in for
+//    actually ships. The sibling-checkout comparison above (2b) only runs
+//    when that core's repo happens to be checked out next to this one —
+//    true for a maintainer mid-release, never for CI or a contributor. This
+//    is the check that runs everywhere: it fetches the real published
+//    package at its pinned version and fails if the fixture claims an
+//    agent or skill the package doesn't actually carry, so a payload move
+//    in a core repo breaks `npm run check` here rather than a user's
+//    install (#304). Network-dependent, same skip as 2c. ─────────────────
+{
+  const skipReason = process.env.HEDGEHOG_SKIP_REGISTRY_VERSION_CHECK;
+  if (!skipReason) {
+    for (const core of cores) {
+      if (!core.package || !core.version) continue;
+      const fixturePath = join(ROOT, `repro/fixtures/cores/${core.name}.manifest.yaml`);
+      const fixtureText = await readFile(fixturePath, 'utf8');
+      const fixture = parseCoreManifest(fixtureText, `${core.name}.manifest.yaml`);
+
+      let published;
+      try {
+        published = await fetchCore(core);
+      } catch {
+        continue; // offline or registry unreachable — not this check's failure to report
+      }
+      const publishedNames = new Set([...published.manifest.agents, ...published.manifest.skills]);
+      const fixtureNames = [...fixture.agents, ...fixture.skills];
+      const missing = fixtureNames.filter((name) => !publishedNames.has(name));
+      if (missing.length > 0) {
+        fail(
+          `repro/fixtures/cores/${core.name}.manifest.yaml: claims ${missing.join(', ')}, but ` +
+            `the published ${core.package}@${published.version} carries no such agent or skill. ` +
+            `Update the fixture to match what that package actually ships.`,
         );
       }
     }


### PR DESCRIPTION
## Summary

Completes the remaining definition-of-done items on #304 (item 1 was already fixed in #311).

- **Item 2 (extending an already-adopted repo)** — verified working, no fix needed. Ran a real three-pass smoke test against a scratch brownfield repo: `hedgehog-adopt`'s "Later run" branch correctly skips BMAD and re-scaffolding, and `.hedgehog/core.yaml`/`adoption.md` stayed byte-identical (same SHA-256) across a second and third adoption pass while intents were added and planned each time.
- **Item 4 (ROADMAP entry)** — added a "Brownfield adoption hardening" entry under ROADMAP.md's Small items, naming both the onboarding and extension paths as a stated area with an owner.
- **Also worth fixing** — `scripts/check.mjs` now fetches each core's actual published npm package (via `fetchCore`) and asserts every agent/skill named in that core's `repro/fixtures/cores/*.manifest.yaml` fixture is really in the package, not just internally consistent with a sibling checkout that's rarely present. Verified the check fires by temporarily injecting a fake skill name into the adopted fixture and confirming `npm run check` failed with the right message, then restored it.

## Test plan

- [x] `npm run check` passes clean
- [x] `npm run repro` — all 62 reproductions pass
- [x] Manual smoke test: scratch brownfield repo, `hedgehog init` → `core record-adopted` → hand-written `core.yaml`/`adoption.md` → three adoption passes (`intent add` → `plan` → commit) with `.hedgehog/core.yaml` and `adoption.md` hash-verified identical after each
- [x] Confirmed the new check.mjs assertion actually fails when the fixture drifts (injected a fake skill, reverted after confirming)

Closes remaining items on #304.