### PR TITLE
feat(core): parse and conformance-check a `pattern` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/repro/pattern-hexagonal-checks-direction.mjs
+++ b/repro/pattern-hexagonal-checks-direction.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// Repro: `pattern: hexagonal` checks direction alone (no adapter marker
+// exists yet — see #314's "Not in this issue"). The head layer (the
+// domain, by convention) must have no depends_on, and every other
+// layer's depends_on chain must terminate at the head with no cycle. Not
+// required by #314's own test list, but the check is real code with real
+// failure modes, so it gets the same coverage as layered/vertical-slice.
+//
+// Run: node repro/pattern-hexagonal-checks-direction.mjs
+
+import { check, finish } from './papercuts-lib.mjs';
+import { validateCore } from '../src/db/core.mjs';
+
+console.log('repro: pattern-hexagonal-checks-direction');
+
+// domain (head, no depends_on) <- repository <- controller: every chain
+// terminates at domain. Must validate clean.
+const VALID = {
+  id: 'valid-hexagonal',
+  pattern: 'hexagonal',
+  layers: [
+    { id: 'domain', scope: ['domain/**'], verify: 'true', commit: 'feat: domain' },
+    {
+      id: 'repository',
+      depends_on: 'domain',
+      scope: ['repository/**'],
+      verify: 'true',
+      commit: 'feat: repository',
+    },
+    {
+      id: 'controller',
+      depends_on: 'domain',
+      scope: ['controller/**'],
+      verify: 'true',
+      commit: 'feat: controller',
+    },
+  ],
+};
+try {
+  validateCore(VALID);
+  check('two adapters both pointing at the domain validates clean', true, {});
+} catch (err) {
+  check('two adapters both pointing at the domain validates clean', false, {
+    expected: 'no error',
+    actual: err.message,
+  });
+}
+
+// The head itself has a depends_on — it can't be the sink if it also
+// depends on something.
+const HEAD_HAS_DEPENDENCY = {
+  id: 'head-has-dependency',
+  pattern: 'hexagonal',
+  layers: [
+    {
+      id: 'domain',
+      depends_on: 'infra',
+      scope: ['domain/**'],
+      verify: 'true',
+      commit: 'feat: domain',
+    },
+    { id: 'infra', scope: ['infra/**'], verify: 'true', commit: 'feat: infra' },
+  ],
+};
+try {
+  validateCore(HEAD_HAS_DEPENDENCY);
+  check('a head layer with a depends_on throws', false, {
+    expected: 'throws',
+    actual: 'validated without error',
+  });
+} catch (err) {
+  check('a head layer with a depends_on throws', true, {});
+}
+
+// A non-head layer with no depends_on is a second, ambiguous root.
+const SECOND_ROOT = {
+  id: 'second-root',
+  pattern: 'hexagonal',
+  layers: [
+    { id: 'domain', scope: ['domain/**'], verify: 'true', commit: 'feat: domain' },
+    { id: 'orphan', scope: ['orphan/**'], verify: 'true', commit: 'feat: orphan' },
+  ],
+};
+try {
+  validateCore(SECOND_ROOT);
+  check('a non-head layer with no depends_on throws', false, {
+    expected: 'throws',
+    actual: 'validated without error',
+  });
+} catch (err) {
+  check('a non-head layer with no depends_on throws', true, {});
+}
+
+// A cycle that never reaches the head.
+const CYCLE = {
+  id: 'cycle',
+  pattern: 'hexagonal',
+  layers: [
+    { id: 'domain', scope: ['domain/**'], verify: 'true', commit: 'feat: domain' },
+    { id: 'x', depends_on: 'y', scope: ['x/**'], verify: 'true', commit: 'feat: x' },
+    { id: 'y', depends_on: 'x', scope: ['y/**'], verify: 'true', commit: 'feat: y' },
+  ],
+};
+try {
+  validateCore(CYCLE);
+  check('a cycle that never reaches the head throws', false, {
+    expected: 'throws',
+    actual: 'validated without error',
+  });
+} catch (err) {
+  check('a cycle that never reaches the head throws', true, {});
+}
+
+finish('pattern-hexagonal-checks-direction');

--- a/repro/pattern-layered-rejects-branching-chain.mjs
+++ b/repro/pattern-layered-rejects-branching-chain.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+// Repro: `pattern: layered` claims a strict linear chain — one dependent
+// per layer. Two layers sharing a depends_on parent is branching, not a
+// chain, and validateCore must reject it.
+//
+// Run: node repro/pattern-layered-rejects-branching-chain.mjs
+
+import { check, finish } from './papercuts-lib.mjs';
+import { validateCore } from '../src/db/core.mjs';
+
+console.log('repro: pattern-layered-rejects-branching-chain');
+
+// `b` and `c` both depend_on `a` — a fork, not a linear chain.
+const BRANCHING = {
+  id: 'branching',
+  pattern: 'layered',
+  layers: [
+    { id: 'a', scope: ['a/**'], verify: 'true', commit: 'feat: a' },
+    { id: 'b', depends_on: 'a', scope: ['b/**'], verify: 'true', commit: 'feat: b' },
+    { id: 'c', depends_on: 'a', scope: ['c/**'], verify: 'true', commit: 'feat: c' },
+  ],
+};
+
+try {
+  validateCore(BRANCHING);
+  check('a branching chain under layered throws', false, {
+    expected: 'throws',
+    actual: 'validated without error',
+  });
+} catch (err) {
+  check('a branching chain under layered throws', true, {});
+  check('message names the shared parent layer "a"', err.message.includes('"a"'), {
+    expected: 'message mentioning layer "a"',
+    actual: err.message,
+  });
+}
+
+// A genuine linear chain under layered must validate clean — the check
+// above must be a real check, not always-throw.
+const LINEAR = {
+  id: 'linear',
+  pattern: 'layered',
+  layers: [
+    { id: 'schema', scope: ['schema/**'], verify: 'true', commit: 'feat: schema' },
+    {
+      id: 'repository',
+      depends_on: 'schema',
+      scope: ['repository/**'],
+      verify: 'true',
+      commit: 'feat: repository',
+    },
+    {
+      id: 'service',
+      depends_on: 'repository',
+      scope: ['service/**'],
+      verify: 'true',
+      commit: 'feat: service',
+    },
+  ],
+};
+
+try {
+  validateCore(LINEAR);
+  check('a genuine linear chain under layered validates clean', true, {});
+} catch (err) {
+  check('a genuine linear chain under layered validates clean', false, {
+    expected: 'no error',
+    actual: err.message,
+  });
+}
+
+// A layer disconnected from the head (a 2-cycle between two non-head
+// layers) has no shared parent and every non-head layer has exactly one
+// depends_on — the two checks above don't catch it. Reachability must.
+const DISCONNECTED = {
+  id: 'disconnected',
+  pattern: 'layered',
+  layers: [
+    { id: 'head', scope: ['head/**'], verify: 'true', commit: 'feat: head' },
+    { id: 'x', depends_on: 'y', scope: ['x/**'], verify: 'true', commit: 'feat: x' },
+    { id: 'y', depends_on: 'x', scope: ['y/**'], verify: 'true', commit: 'feat: y' },
+  ],
+};
+
+try {
+  validateCore(DISCONNECTED);
+  check('a chain disconnected from the head throws', false, {
+    expected: 'throws',
+    actual: 'validated without error',
+  });
+} catch (err) {
+  check('a chain disconnected from the head throws', true, {});
+}
+
+finish('pattern-layered-rejects-branching-chain');

--- a/repro/pattern-none-never-throws.mjs
+++ b/repro/pattern-none-never-throws.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Repro: `pattern: none` is explicitly "no enforced direction" — the
+// adopted-repo default (hedgehog-adopt records exactly this for a repo
+// whose owner never asked for an architecture review). It must never
+// produce a finding, no matter how messy the layer graph actually is.
+//
+// Run: node repro/pattern-none-never-throws.mjs
+
+import { check, finish } from './papercuts-lib.mjs';
+import { validateCore } from '../src/db/core.mjs';
+
+console.log('repro: pattern-none-never-throws');
+
+// Deliberately messy: branching (b and c both depend_on a) *and* a
+// 2-cycle disconnected from the head (x/y) — exactly the two shapes
+// pattern: layered rejects. none must wave both through.
+const MESSY = {
+  id: 'messy',
+  pattern: 'none',
+  layers: [
+    { id: 'a', scope: ['a/**'], verify: 'true', commit: 'feat: a' },
+    { id: 'b', depends_on: 'a', scope: ['b/**'], verify: 'true', commit: 'feat: b' },
+    { id: 'c', depends_on: 'a', scope: ['c/**'], verify: 'true', commit: 'feat: c' },
+    { id: 'x', depends_on: 'y', scope: ['x/**'], verify: 'true', commit: 'feat: x' },
+    { id: 'y', depends_on: 'x', scope: ['y/**'], verify: 'true', commit: 'feat: y' },
+  ],
+};
+
+try {
+  validateCore(MESSY);
+  check('pattern: none never throws, even on a messy graph', true, {});
+} catch (err) {
+  check('pattern: none never throws, even on a messy graph', false, {
+    expected: 'no error',
+    actual: err.message,
+  });
+}
+
+finish('pattern-none-never-throws');

--- a/repro/pattern-rejects-unknown-value.mjs
+++ b/repro/pattern-rejects-unknown-value.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// Repro: an unrecognized `pattern` value must throw at parse time, naming
+// the valid set — never silently degrade to "unset", which would turn
+// conformance checking off with no signal anything is wrong.
+//
+// Run: node repro/pattern-rejects-unknown-value.mjs
+
+import { check, finish } from './papercuts-lib.mjs';
+import { parseCoreYaml } from '../src/db/core.mjs';
+
+console.log('repro: pattern-rejects-unknown-value');
+
+const CORE = `id: demo
+pattern: hexagnoal
+layers:
+  - id: only
+    scope: ["src/**"]
+    verify: "true"
+    commit: "feat: only"
+`;
+
+try {
+  parseCoreYaml(CORE);
+  check('a typo\'d pattern value throws', false, {
+    expected: 'throws',
+    actual: 'parsed without error',
+  });
+} catch (err) {
+  check('a typo\'d pattern value throws', true, {});
+  check('message names the typo\'d value', err.message.includes('hexagnoal'), {
+    expected: 'message containing "hexagnoal"',
+    actual: err.message,
+  });
+  for (const valid of ['hexagonal', 'layered', 'vertical-slice', 'none']) {
+    check(`message names valid value "${valid}"`, err.message.includes(valid), {
+      expected: `message containing "${valid}"`,
+      actual: err.message,
+    });
+  }
+}
+
+finish('pattern-rejects-unknown-value');

--- a/repro/pattern-unset-still-valid.mjs
+++ b/repro/pattern-unset-still-valid.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Repro / regression guard: `pattern` is new and optional, so a core.yaml
+// that omits it must keep parsing and validating exactly as before.
+//
+// The failure this guards against is the obvious way to implement the
+// field — treating "unset" as itself something to check — which would
+// reject every core.yaml written before this field existed, including
+// every shipped core. It also pins the shape the rest of the feature
+// relies on: an omitted `pattern` parses to `null` (never undefined), and
+// `validateCore` runs zero conformance checks against it.
+//
+// Run: node repro/pattern-unset-still-valid.mjs
+
+import { join } from 'node:path';
+import { check, finish, REPO_ROOT } from './papercuts-lib.mjs';
+import { loadCore, parseCoreYaml, validateCore } from '../src/db/core.mjs';
+
+console.log('repro: pattern-unset-still-valid');
+
+// ── parseCoreYaml: an omitted pattern parses to null ───────────────────
+const CORE_NO_PATTERN = `id: demo
+layers:
+  - id: only
+    scope: ["src/**"]
+    verify: "true"
+    commit: "feat: only"
+`;
+const parsed = parseCoreYaml(CORE_NO_PATTERN);
+check('parseCoreYaml: pattern defaults to null', parsed.pattern === null, {
+  expected: 'null',
+  actual: String(parsed.pattern),
+});
+
+// ── validateCore: an unset pattern never throws, on any shape ──────────
+// Deliberately messy — branching, no linear chain — to prove the absence
+// of a pattern skips conformance checking entirely rather than falling
+// back to some default check.
+const MESSY = {
+  id: 'messy',
+  layers: [
+    { id: 'a', scope: ['a/**'], verify: 'true', commit: 'feat: a' },
+    { id: 'b', depends_on: 'a', scope: ['b/**'], verify: 'true', commit: 'feat: b' },
+    { id: 'c', depends_on: 'a', scope: ['c/**'], verify: 'true', commit: 'feat: c' },
+  ],
+};
+try {
+  validateCore(MESSY);
+  check('validateCore: unset pattern never throws, even on a branching graph', true, {});
+} catch (err) {
+  check('validateCore: unset pattern never throws, even on a branching graph', false, {
+    expected: 'no error',
+    actual: err.message,
+  });
+}
+
+// ── every shipped core still loads and validates unchanged ─────────────
+for (const name of ['full-stack-app', 'landing-page', 'pwa-app']) {
+  const path = join(REPO_ROOT, 'repro/fixtures/cores', `${name}.core.yaml`);
+  try {
+    const core = await loadCore(path);
+    check(`${name}: loads and validates with pattern === null`, core.pattern === null, {
+      expected: 'null',
+      actual: String(core.pattern),
+    });
+  } catch (err) {
+    check(`${name}: loads and validates with pattern === null`, false, {
+      expected: 'loads cleanly',
+      actual: err.message,
+    });
+  }
+}
+
+finish('pattern-unset-still-valid');

--- a/repro/pattern-vertical-slice-requires-module-axis.mjs
+++ b/repro/pattern-vertical-slice-requires-module-axis.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// Repro: `pattern: vertical-slice` claims a chain instantiated per module
+// — a core declaring it with no `{module}` anywhere in scope is a
+// mislabel, and validateCore must reject it, naming why.
+//
+// Run: node repro/pattern-vertical-slice-requires-module-axis.mjs
+
+import { check, finish } from './papercuts-lib.mjs';
+import { validateCore } from '../src/db/core.mjs';
+
+console.log('repro: pattern-vertical-slice-requires-module-axis');
+
+// No layer's scope contains {module} — not module-axis at all.
+const NOT_MODULE_AXIS = {
+  id: 'not-module-axis',
+  pattern: 'vertical-slice',
+  layers: [
+    { id: 'domain', scope: ['src/domain/**'], verify: 'true', commit: 'feat: domain' },
+    {
+      id: 'io',
+      depends_on: 'domain',
+      scope: ['src/io/**'],
+      verify: 'true',
+      commit: 'feat: io',
+    },
+  ],
+};
+
+try {
+  validateCore(NOT_MODULE_AXIS);
+  check('vertical-slice with no {module} throws', false, {
+    expected: 'throws',
+    actual: 'validated without error',
+  });
+} catch (err) {
+  check('vertical-slice with no {module} throws', true, {});
+  check('message names the offending layer or the pattern', err.message.includes('vertical-slice'), {
+    expected: 'message mentioning vertical-slice',
+    actual: err.message,
+  });
+  check('message names {module}', err.message.includes('{module}'), {
+    expected: 'message mentioning {module}',
+    actual: err.message,
+  });
+}
+
+// A genuinely module-axis core with pattern: vertical-slice must validate
+// clean — the check above must be a real check, not always-throw.
+const MODULE_AXIS = {
+  id: 'module-axis',
+  pattern: 'vertical-slice',
+  layers: [
+    {
+      id: 'schema',
+      scope: ['libs/{module}/schema/**'],
+      verify: 'true',
+      commit: 'feat({module}): schema',
+    },
+    {
+      id: 'service',
+      depends_on: 'schema',
+      scope: ['libs/{module}/service/**'],
+      verify: 'true',
+      commit: 'feat({module}): service',
+    },
+  ],
+};
+
+try {
+  validateCore(MODULE_AXIS);
+  check('vertical-slice with a real module axis validates clean', true, {});
+} catch (err) {
+  check('vertical-slice with a real module axis validates clean', false, {
+    expected: 'no error',
+    actual: err.message,
+  });
+}
+
+finish('pattern-vertical-slice-requires-module-axis');

--- a/src/db/core.mjs
+++ b/src/db/core.mjs
@@ -180,9 +180,16 @@ function indentOf(line) {
   return line.length - line.trimStart().length;
 }
 
+// The only values `pattern` may declare — named in every rejection
+// message below, so a typo surfaces the valid set instead of silently
+// degrading to "unset" (which would turn conformance checking off with
+// no signal that anything is wrong).
+const VALID_PATTERNS = ['hexagonal', 'layered', 'vertical-slice', 'none'];
+
 // Parses the narrow subset of YAML a core definition needs:
 //   id: <scalar>
 //   pluralizes: <bool>            # optional, default true
+//   pattern: <scalar>             # optional, one of hexagonal|layered|vertical-slice|none
 //   layers:
 //     - id: <scalar>
 //       depends_on: <scalar>          # optional
@@ -202,7 +209,7 @@ export function parseCoreYaml(text) {
     lines.push({ indent: indentOf(noComment), text: noComment.trim() });
   }
 
-  const core = { id: undefined, pluralizes: true, layers: [] };
+  const core = { id: undefined, pluralizes: true, pattern: null, layers: [] };
   let i = 0;
 
   while (i < lines.length && lines[i].indent === 0) {
@@ -224,6 +231,21 @@ export function parseCoreYaml(text) {
     // advisory stops firing on it for good, rather than every user of
     // that core re-discovering the same false positive.
     if (key === 'pluralizes') core.pluralizes = parseScalar(value) === 'true';
+    // An architecture claim, checked by validateCore below — see that
+    // function's pattern-conformance block for what each value asserts.
+    // Rejected here, at parse time, rather than left to validateCore:
+    // an unrecognized value must never silently resolve to "unset" (the
+    // one value that turns conformance checking off), so a typo has to
+    // surface as a parse error, not a quietly-skipped check.
+    if (key === 'pattern') {
+      const declared = parseScalar(value);
+      if (!VALID_PATTERNS.includes(declared)) {
+        throw new Error(
+          `unknown pattern "${declared}" — must be one of: ${VALID_PATTERNS.join(', ')}`,
+        );
+      }
+      core.pattern = declared;
+    }
     i++;
   }
 
@@ -498,6 +520,132 @@ export function isModuleAxis(core) {
   return core.layers.some((layer) => layer.scope.join('').includes('{module}'));
 }
 
+// `layered`'s and `hexagonal`'s checks both anchor on "the head layer" —
+// the first-declared layer, by the same convention `core.layers[0]`
+// already carries informally everywhere else in this file (e.g. the
+// once-layer checks below walk `core.layers` in declaration order too).
+function headLayer(core) {
+  return core.layers[0];
+}
+
+// `pattern: layered` — a strict linear chain: every layer but the head
+// depends on exactly one other, no two layers share a depends_on parent
+// (that would be branching, not a chain), and every layer is reachable
+// from the head by walking depends_on forward. Throws naming the first
+// layer that breaks the shape, in the order the checks below run.
+function checkLayeredPattern(core) {
+  const head = headLayer(core);
+  const rest = core.layers.filter((layer) => layer.id !== head.id);
+
+  for (const layer of rest) {
+    if (!layer.depends_on) {
+      throw new Error(
+        `core "${core.id}" declares pattern: layered, but layer "${layer.id}" has no depends_on — every layer but the head ("${head.id}") must depend on exactly one other layer`,
+      );
+    }
+  }
+
+  const dependents = new Map(); // parent layer id -> the one layer that depends on it
+  for (const layer of rest) {
+    const prior = dependents.get(layer.depends_on);
+    if (prior) {
+      throw new Error(
+        `core "${core.id}" declares pattern: layered, but both "${prior}" and "${layer.id}" depend on "${layer.depends_on}" — a layered chain is linear, one dependent per layer`,
+      );
+    }
+    dependents.set(layer.depends_on, layer.id);
+  }
+
+  // Walk forward from the head (parent -> its one dependent) and confirm
+  // every layer gets visited. This also catches a chain disconnected from
+  // the head entirely — e.g. two layers depending on each other with
+  // neither reachable from the head — which the checks above don't rule
+  // out on their own: each layer still has exactly one depends_on and no
+  // parent is shared, they just never connect back to "${head.id}".
+  const visited = new Set([head.id]);
+  let current = head;
+  while (dependents.has(current.id)) {
+    current = core.layers.find((layer) => layer.id === dependents.get(current.id));
+    visited.add(current.id);
+  }
+  for (const layer of core.layers) {
+    if (!visited.has(layer.id)) {
+      throw new Error(
+        `core "${core.id}" declares pattern: layered, but layer "${layer.id}" is not reachable from the head layer "${head.id}" by following depends_on`,
+      );
+    }
+  }
+}
+
+// `pattern: hexagonal` — Hedgehog has no adapter marker today, so this
+// checks direction alone rather than an actual domain/adapter boundary:
+// the head layer (the domain, by convention) must have no depends_on, and
+// every other layer's depends_on chain must terminate at the head with no
+// cycle — i.e. dependencies all point one way, inward, and the head is the
+// sink every chain ends at. Weaker than the real hexagonal rule (nothing
+// stops an adapter depending on another adapter instead of the domain
+// directly), and deliberately so — see #314's "Not in this issue" for why
+// a real adapter-boundary marker is a separate design decision.
+function checkHexagonalPattern(core) {
+  const head = headLayer(core);
+  if (head.depends_on) {
+    throw new Error(
+      `core "${core.id}" declares pattern: hexagonal, but its head layer "${head.id}" has a depends_on — the domain layer must be the sink every dependency chain points to, not itself a dependent`,
+    );
+  }
+
+  const byId = new Map(core.layers.map((layer) => [layer.id, layer]));
+  for (const layer of core.layers) {
+    if (layer.id === head.id) continue;
+    if (!layer.depends_on) {
+      throw new Error(
+        `core "${core.id}" declares pattern: hexagonal, but layer "${layer.id}" has no depends_on — only the domain layer ("${head.id}") may have none`,
+      );
+    }
+    const seen = new Set([layer.id]);
+    let current = layer;
+    while (current.depends_on) {
+      const next = byId.get(current.depends_on);
+      if (seen.has(next.id)) {
+        throw new Error(
+          `core "${core.id}" declares pattern: hexagonal, but layer "${layer.id}"'s depends_on chain cycles back through "${next.id}" instead of terminating at the domain layer "${head.id}"`,
+        );
+      }
+      seen.add(next.id);
+      current = next;
+    }
+    if (current.id !== head.id) {
+      throw new Error(
+        `core "${core.id}" declares pattern: hexagonal, but layer "${layer.id}"'s depends_on chain terminates at "${current.id}", not the domain layer "${head.id}" — every layer must point inward toward the domain`,
+      );
+    }
+  }
+}
+
+// Dispatches on `core.pattern` to the check above matching what was
+// declared. `null` (never set) and `'none'` (set, explicitly no enforced
+// direction — the adopted-repo default) both skip checking entirely: an
+// absent pattern must validate exactly as it did before this field
+// existed, and `none` recording "no direction" is a fact, not a finding.
+function checkPatternConformance(core) {
+  if (!core.pattern || core.pattern === 'none') return;
+  if (core.pattern === 'vertical-slice') {
+    if (!isModuleAxis(core)) {
+      throw new Error(
+        `core "${core.id}" declares pattern: vertical-slice, but no layer's scope contains {module} — vertical-slice is a chain instantiated per module, so at least one layer must vary by module`,
+      );
+    }
+    return;
+  }
+  if (core.pattern === 'layered') {
+    checkLayeredPattern(core);
+    return;
+  }
+  if (core.pattern === 'hexagonal') {
+    checkHexagonalPattern(core);
+  }
+}
+
 // Enforces the interview's rule (spec: "Authored cores") — a layer without
 // scope or without a verify command is rejected. Applied uniformly to
 // shipped and authored cores alike; the loader has no shipped-core-only
@@ -574,6 +722,13 @@ export function validateCore(core) {
       );
     }
   }
+
+  // An architecture claim, checked mechanically — an unchecked `pattern`
+  // is a comment, and a comment that can silently disagree with the graph
+  // is worse than no field at all. Depends on depends_on already being
+  // resolved to real layer ids (the loop just above), which every check
+  // below relies on.
+  checkPatternConformance(core);
 
   // A `once: true` layer compiles a single task for the whole build, so
   // there is no module to substitute into its templates. Left unchecked,

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
Part of #313. Closes #314.

- Adds an optional top-level `pattern` key to `core.yaml` (`hexagonal | layered | vertical-slice | none`), parsed in `parseCoreYaml` (`src/db/core.mjs`). An unrecognized value throws at parse time naming the valid set; absent stays `null` and unchecked, same stance `requires`/`pluralizes` already take.
- Adds a conformance check in `validateCore` for the three checkable values. `none` is an explicit no-op. `layered` requires a strict linear chain (every layer but the head has exactly one `depends_on`, no shared parent, every layer reachable from the head). `vertical-slice` requires `isModuleAxis(core)`. `hexagonal` checks direction alone — the head has no `depends_on`, every other layer's chain terminates at the head with no cycle — deliberately weaker than a real adapter-boundary check, per the issue's "Not in this issue" note.
- No change needed to `hedgehog status`: `validateCore` throwing on load is already caught and reported by `coreWarningLines` (`bin/cli.mjs`).

<details>
<summary>Why hexagonal is checked on direction alone</summary>

Hedgehog has no adapter marker today, so there's no way to distinguish "an adapter depending on another adapter" from "an adapter depending on the domain." The issue explicitly scopes a real marker field out of #314 as a separate design decision, so this only enforces that every layer's dependency chain points inward and terminates at the domain layer, with no cycle — real signal, not the full rule.

</details>

## Test plan

- 6 repro scripts under `repro/`, run individually and via `node --experimental-sqlite repro/run-all.mjs`: `pattern-unset-still-valid.mjs`, `pattern-rejects-unknown-value.mjs`, `pattern-vertical-slice-requires-module-axis.mjs`, `pattern-layered-rejects-branching-chain.mjs`, `pattern-none-never-throws.mjs` (the five #314 asks for), plus `pattern-hexagonal-checks-direction.mjs` (not required by the issue, added because the check is real code with real failure modes). All 6 pass.
- `repro/parse-real-cores.mjs`: confirmed via `git stash`/diff that the only change in its output is the new `"pattern": null` field on every shipped core — no other drift.
- Full repro suite (68 scripts, including the 6 new ones): ran on this branch and, separately, on unmodified `master` in the same environment. Same 10 pre-existing failures on both — all Windows-only environment gaps unrelated to this change (no `/bin/sh`, no unprivileged symlinks, Node's ESM loader rejecting a bare Windows drive-letter path, temp-dir cleanup permission errors). Zero regressions; every new pass is additive.
- `npm run check`: two of its checks fail locally on Windows, both confirmed pre-existing on unmodified `master` too, unrelated to this PR: (1) a `repro/fixtures/cores/*.manifest.yaml` fixture gets checked out with CRLF line endings on this machine, which its hand-rolled line parser doesn't strip, so every key look like it's missing (worked around locally with a `core.autocrlf=false` clone — real checkout content is LF, this is purely local `git config`, not the repo); (2) `npm pack --dry-run` fails with `spawnSync ENOENT` because Node's `execFileSync('npm', ...)` doesn't resolve `npm.cmd` on Windows. Ran `npm pack --dry-run --json` directly and confirmed `src/db/core.mjs` (the only file this PR touches) is included in the tarball. Every other check in `scripts/check.mjs` passed (it accumulates failures rather than stopping at the first one — only these two were reported). Linux CI should be green.
