### PR TITLE
feat(reviewer): state the exclusivity trigger mechanically

### DIFF
--- a/AUTHORING-CORES.md
+++ b/AUTHORING-CORES.md
@@ -174,6 +174,12 @@ satisfies the package contract above.
 - [ ] Layer sequence matches the build order the core's own agents and
       skills actually follow.
 - [ ] Each layer's `verify` command is real and runnable, not a stub.
+- [ ] `verify_radius` (when set wider than `scope`) and `exclusive: true`
+      are declared on the layers that are actually join or integration
+      points — this is also where the real test bar and the `reviewer`
+      pass land (`hedgehog-authored-loop`'s "Test depth follows verify
+      radius"), so the decision made here is the same one that sets test
+      and review cadence, not a separate call to make later.
 - [ ] Every `verify` command has been checked for a system binary beyond
       what the workspace's package manager installs (Docker, Terraform,
       a database CLI, a compiler toolchain), and any such binary is

--- a/src/agents/reviewer.md
+++ b/src/agents/reviewer.md
@@ -18,7 +18,12 @@ commit — the gate already covers that.
 - **A transition check the core's loop skill defines** — the point where
   one phase or layer closes and the next opens. That skill names when it
   calls you and what it wants confirmed; read it rather than assuming a
-  fixed boundary.
+  fixed boundary. Mechanically, that point is where a layer's
+  `verify_radius` is wider than its own `scope`, or the layer is
+  `exclusive: true` (`core.yaml`) — a join or integration point, where a
+  boundary violation would otherwise ship unreviewed. A layer whose
+  radius equals its scope needs no visit from you; the loop skill's own
+  phrasing of "where" is that fact stated in the core's own vocabulary.
 - **Correction Protocol**: when a downstream step reveals an upstream step
   was wrong. Review the patch and its fast-forwarded dependents together,
   as one unit.


### PR DESCRIPTION
Part of skyf0xx/hedgehog#313. Addresses skyf0xx/hedgehog#319.

Companion PRs carrying the rest of #319 (docs/skill-content only, no engine change, as the issue scopes it): the owning statement lives in `hedgehog-core-authored` — https://github.com/skyf0xx/hedgehog-core-authored/pull/10 — with `hedgehog-core-full-stack-app`, `hedgehog-core-landing-page`, `hedgehog-core-deepseek-harness`, and `hedgehog-core-adopted` referencing it by name from their own loop skills/build agents.

- `src/agents/reviewer.md`'s "When you run" named its trigger only in prose (`reviewer.md:18-21` before this PR) — a phase/layer transition each loop skill defines separately, with no shared referent. Added the mechanical fact underneath: `verify_radius` wider than `scope`, or `exclusive: true`, is a join/integration point, and that's where review belongs.
- `AUTHORING-CORES.md`'s `core.yaml` audit checklist (`AUTHORING-CORES.md:172-186` before this PR) names the same consequence at the point a new core author actually sets `verify_radius`/`exclusive` — that decision also sets test/review cadence.
- Version bumped `6.1.1` → `6.1.2` via `npm run release` (`bump-package-version.mjs` failed locally with `spawnSync npm ENOENT` — the same Windows-only `execFileSync` quirk noted on #325 — worked around by running `npm version patch --no-git-tag-version` directly and hand-updating `src/hosts/gemini/gemini-extension.json` to match, exactly what the script does). This PR carries the bump for both this branch and #325 (`feat/core-pattern-field`, open) — they were on the same base commit and I only bumped one to avoid a version-line merge conflict for whichever lands second.

## Test plan

- Read both edited files in full after editing to confirm the new text reads correctly in place and doesn't contradict anything else in either file.
- Confirmed `package.json` and `src/hosts/gemini/gemini-extension.json` agree on `6.1.2` (what `scripts/check.mjs` gates on).
- No engine code touched — no repro/test suite run needed for this PR specifically; `npm run check`'s structural checks were exercised for #325 in this same session and aren't affected by this PR's files.
