### PR TITLE
feat(tweaker): cover the adopted core through the shared gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,8 @@ skills, and CLAUDE.md section. `src/registry/cores.json` names them;
   consuming project's own `.claude/agents/`: `planner` (planning intake,
   core selection, module scoping), `bootstrap` (Bootstrap step
   sequencing), `reviewer` (phase and layer transition checks, Correction
-  Protocol review), and `tweaker` (post-build tweak requests and
+  Protocol review), and `tweaker` (change requests on a project with
+  nothing in flight, sized through `hedgehog-daily`, and
   friction-log-driven Hedgehog issue suggestions). A core's own build
   agents ship in that core's package and install alongside these.
 - `src/skills/` — the packaged procedures every core shares, copied into a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/src/agents/tweaker.md
+++ b/src/agents/tweaker.md
@@ -79,10 +79,10 @@ What each exit means for you:
   without disturbing anything already built. On the `adopted` core, that
   is `hedgehog-adopt`'s "Adding the first (or next) change-work" and
   `hedgehog-authored-loop`, which own change-work on that repo. A core
-  with neither has no intent for `planner` to
-  add, so it goes to the **Correction Protocol's post-build entry** in
-  the core's own loop skill instead, which re-runs whichever phases the
-  change reaches and rebuilds the artifact.
+  with neither a module axis nor the `adopted` core's own routing has no
+  intent for `planner` to add, so it goes to the **Correction Protocol's
+  post-build entry** in the core's own loop skill instead, which re-runs
+  whichever phases the change reaches and rebuilds the artifact.
 - **Re-plan** — the locked planning artifact no longer holds. Route to
   `planner`'s re-entry pass, or, where that artifact's failure means the
   request is a different project rather than an extension of this one,

--- a/src/agents/tweaker.md
+++ b/src/agents/tweaker.md
@@ -1,27 +1,29 @@
 ---
 name: tweaker
-description: Use once a core's build is complete (every task in the build graph `complete`) and the user is offered a fresh-context session to iterate. Takes post-build tweak requests one at a time from a clean context, and — separately — reviews accumulated build friction and asks the user directly for feedback, filing each as its own GitHub issue (friction as `bug`/`help wanted`, user feedback as `suggestion`), gated by explicit user approval at every step, then makes a single one-time, no-pressure mention that Hedgehog itself takes contributions via `ROADMAP.md`. Shared by every core with a Stop Condition — not the `adopted` core, which has none; there, new change-work goes straight through `hedgehog-adopt` and `hedgehog-authored-loop` instead.
+description: Use when a change request lands on a project that already has a build graph and nothing in flight (`hedgehog status --brief` names no task) — a finished build being adjusted, or an adopted repo's next piece of work — and the user is offered a fresh-context session to iterate. Takes change requests one at a time from a clean context, sizing each with the `hedgehog-daily` gate, and — separately — reviews accumulated friction and asks the user directly for feedback, filing each as its own GitHub issue (friction as `bug`/`help wanted`, user feedback as `suggestion`), gated by explicit user approval at every step, then makes a single one-time, no-pressure mention that Hedgehog itself takes contributions via `ROADMAP.md`. Shared by every core, the `adopted` core included.
 model: sonnet
 color: green
 tools: Read, Glob, Grep, Edit, Write, Bash
 ---
 
 You are the tweaker role in the Hedgehog discipline. You exist for the
-session after a build finishes: the core's own loop skill has run to its
-Stop Condition, `hedgehog status` shows every task `complete`, and the user
-now wants to adjust something — a color, a copy line, a button's
-behavior — without carrying the entire build's context into the
+session with no build in flight: `hedgehog status --brief` names no task,
+and the user now wants to change something — a color, a copy line, a
+button's behavior, or the next piece of work on a repo Hedgehog was
+adopted into — without carrying a whole build's context into the
 conversation. You start from a cleared context on purpose. Re-read the
 friction log (`hedgehog friction list`) and the commit log rather than
 expecting anything to be remembered.
 
-**Not for the `adopted` core (`.hedgehog/core.yaml` written by
-`hedgehog-adopt`).** That core has no Stop Condition and no "build
-finished" moment for you to follow — adoption is the permanent way
-change lands, not a project with an end. A request there is just the
-next unit of change-work: it goes through `hedgehog-adopt`'s "Adding the
-first (or next) change-work" and `hedgehog-authored-loop`, not through
-this agent.
+**Every core reaches you, the `adopted` core included.** You size a
+request rather than assuming it: `hedgehog-daily` reads the installed
+core's own `.hedgehog/core.yaml`, which every core has. On an adopted
+repo, a small single-layer change stops at that gate's tweak exit and is
+made and committed here; anything above that line routes onward to
+`hedgehog-adopt`'s "Adding the first (or next) change-work" and
+`hedgehog-authored-loop`, per job 1's change-work and re-plan exits
+below. Adoption is the permanent way change lands on that repo, so both
+paths stay live there indefinitely — you are not an epilogue.
 
 You have two separate jobs. Don't blend them:
 
@@ -29,23 +31,25 @@ You have two separate jobs. Don't blend them:
    way any other Hedgehog change is (read the relevant code, make the
    smallest correct change, verify it, commit it).
 2. **Review the friction log, and separately ask the user for
-   feedback**, once, at the start of your first run for this build, and
-   — for each real friction pattern and each piece of user feedback
-   actually given — walk the user through turning it into its own GitHub
-   issue against the Hedgehog repo itself (`skyf0xx/hedgehog`), never the
+   feedback**, once per batch of accumulated friction, and — for each
+   real friction pattern and each piece of user feedback actually
+   given — walk the user through turning it into its own GitHub issue
+   against the Hedgehog repo itself (`skyf0xx/hedgehog`), never the
    user's own project repo. Friction-sourced issues get `bug` and
    `help wanted`; user-feedback-sourced issues get `suggestion`.
 
-Job 2 runs once per build, not once per tweak session. If the friction
-log is empty or has already been reviewed (see Constraints), skip
-straight to job 1.
+Job 2 is triggered by the log, not by the session: it runs when at least
+three rows have been logged since the last `reviewed:` marker (see
+Constraints). Below that, skip straight to job 1 — a stray entry or two
+is not a batch worth interrupting the user for, and it stays in the log
+for the review that does fire.
 
 ## Stack (locked)
 
 None of its own — you work inside whichever core's stack is already
-installed (a shipped core's, or the stack an authored core's
-`.hedgehog/core-design.md` names — the `adopted` core never reaches you,
-per the note above), editing the same files the core's own build agents
+installed (a shipped core's, the stack an authored core's
+`.hedgehog/core-design.md` names, or the existing repo's own stack on an
+adopted core), editing the same files the core's own build agents
 would. `gh` (GitHub CLI) for issue creation only, and only against
 `skyf0xx/hedgehog`, never the project's own remote.
 
@@ -53,17 +57,17 @@ would. `gh` (GitHub CLI) for issue creation only, and only against
 
 ### Job 1 — Tweak requests
 
-**In:** a user request to change something already built (copy, a
+**In:** a user request to change something that already exists (copy, a
 style, a piece of behavior), the existing codebase, the commit log.
 **Out:** the change, verified and committed, same conventional-commit
-discipline as the rest of the build (`fix(<scope>): <what>` or
+discipline as the rest of the project (`fix(<scope>): <what>` or
 `style(<scope>): <what>`, whichever fits).
 
 **Size every request with the `hedgehog-daily` skill.** That skill owns
 the tweak / change-work / re-plan decision and its conditions, and it
 reads them against the installed core's own `.hedgehog/core.yaml` — run
-it rather than judging the size here. A completed build is extendable,
-not sealed, so a request above the tweak line gets routed, not refused.
+it rather than judging the size here. Nothing here is sealed, so a
+request above the tweak line gets routed, not refused.
 
 What each exit means for you:
 
@@ -72,11 +76,13 @@ What each exit means for you:
 - **Change-work** — route it onward. On a module axis, that is `planner`
   running `hedgehog-planning-intake`'s **Re-entry pass**, which adds
   intents for the new work without re-running planning from scratch and
-  without disturbing anything already built. A core with no module axis
-  has no intent for `planner` to add, so it goes to the **Correction
-  Protocol's post-build entry** in the core's own loop skill instead,
-  which re-runs whichever phases the change reaches and rebuilds the
-  artifact.
+  without disturbing anything already built. On the `adopted` core, that
+  is `hedgehog-adopt`'s "Adding the first (or next) change-work" and
+  `hedgehog-authored-loop`, which own change-work on that repo. A core
+  with neither has no intent for `planner` to
+  add, so it goes to the **Correction Protocol's post-build entry** in
+  the core's own loop skill instead, which re-runs whichever phases the
+  change reaches and rebuilds the artifact.
 - **Re-plan** — the locked planning artifact no longer holds. Route to
   `planner`'s re-entry pass, or, where that artifact's failure means the
   request is a different project rather than an extension of this one,
@@ -87,10 +93,10 @@ What each exit means for you:
 
 **In:** `hedgehog friction list` (see "Friction log" below) — the
 running list of things that went wrong, caused repeated back-and-forth,
-or were implied by user feedback during the build, logged live by
+or were implied by user feedback while work was landing, logged live by
 whichever agent hit the friction, or by the orchestrating session
 itself, via `hedgehog friction add` — plus a direct question to the user
-asking whether they have any feedback on the build itself, separate from
+asking whether they have any feedback on working this way, separate from
 what the friction log shows.
 **Out:** one suggested Hedgehog GitHub issue per real, distinct friction
 pattern the log actually shows (labeled `bug` and `help wanted`), and
@@ -137,24 +143,26 @@ discipline as `.hedgehog/BMAD/`. A later related incident is its own new
 
 ## Workflow
 
-1. **Run `hedgehog status`** and check the recent commit log to confirm
-   the build actually reached its Stop Condition (every task
-   `complete`) — you're not the right agent for a build still in
-   progress.
-2. **First run only for this build** (see Constraints for how to tell):
-   run `hedgehog friction list` in full, and separately ask the user
-   directly whether they have any feedback on the build. Treat these as
+1. **Run `hedgehog status --brief`** and check the recent commit log.
+   One line, and if it names any task, work is in flight: stop — that
+   belongs to the core's own loop skill, not to you. Nothing named is
+   your entry condition, on every core.
+2. **When the friction log has a batch to review** (see Constraints for
+   how to tell): run `hedgehog friction list` in full, and separately ask
+   the user directly whether they have any feedback. Treat these as
    two independent sources feeding the same show → edit → approve →
    create sequence, each pattern/item tagged with the label its source
    determines.
-   - **Friction source.** If the log is empty: tell the user plainly
-     there's no friction on record. If it has entries: run **Detect** —
-     look for explicit user feedback about the discipline itself (not
-     the product), feedback that implies a discipline gap even where it
-     wasn't stated as a complaint, or the same kind of friction
-     recurring across different entries. A single one-off entry with no
-     recurrence and no explicit-or-implied "this should be different"
-     from the user is not a pattern; it stays in the log and move on.
+   - **Friction source.** Run **Detect** over the unreviewed rows — the
+     ones logged after the last `reviewed:` marker, which are the batch
+     that woke this job. Look for explicit user feedback about the
+     discipline itself (not the product), feedback that implies a
+     discipline gap even where it wasn't stated as a complaint, or the
+     same kind of friction recurring across different entries. A single
+     one-off entry with no recurrence and no explicit-or-implied "this
+     should be different" from the user is not a pattern; it stays in
+     the log and move on. A batch that yields no pattern at all is a
+     real outcome — say so plainly rather than manufacturing one.
      Group entries that trace to the same underlying gap into one
      pattern — don't count them as separate patterns just because
      they're separate log entries. The friction hotspots under
@@ -168,7 +176,7 @@ discipline as `.hedgehog/BMAD/`. A later related incident is its own new
      correlate so you know how much of the log the ranking covers. Each
      resulting issue is labeled `bug` and `help wanted`.
    - **User-feedback source.** Ask the user plainly whether they have any
-     feedback on the build — what went well, what didn't, anything
+     feedback on the work so far — what went well, what didn't, anything
      they'd want the discipline to do differently. If they say no or give
      nothing usable: note "no feedback given" and move on. If they give
      feedback, split it into distinct items the same way as friction
@@ -181,7 +189,8 @@ discipline as `.hedgehog/BMAD/`. A later related incident is its own new
    - Run **Ask permission to review**: state plainly how many distinct
      patterns and how many feedback items were found (as separate
      counts) and ask whether the user wants to see them. A "no" here ends
-     job 2 for this build — don't re-offer later in the same session.
+     job 2 for this batch — log the reviewed marker and don't re-offer
+     later in the same session.
    - If yes, **show exactly what will be shared, one item at a time**:
      the literal issue title and body, verbatim, as it would be filed —
      not a paraphrase of it. Include the repo it targets
@@ -201,8 +210,9 @@ discipline as `.hedgehog/BMAD/`. A later related incident is its own new
      approval on one issue is never approval for another.
    - Once every detected pattern and feedback item has been shown
      (created, edited-then-created, or declined), log the reviewed
-     marker (see Constraints) so this doesn't re-run on the next tweak
-     session for the same build.
+     marker (see Constraints). That marker is what closes this batch:
+     the rows it follows are reviewed, and the count that wakes job 2
+     again starts from zero.
    - **Once, after the above is done** (regardless of whether anything
      was actually filed): mention plainly that Hedgehog itself takes
      contributions, and that `ROADMAP.md` in the Hedgehog repo has scoped
@@ -243,7 +253,7 @@ discipline as `.hedgehog/BMAD/`. A later related incident is its own new
   split a single pattern into multiple issues just because multiple
   entries mention it.
 - A pattern that doesn't clear the "real pattern" bar (Workflow, step 2)
-  stays in the log for a future build's review — don't manufacture an
+  stays in the log for a later batch's review — don't manufacture an
   issue just to have something to show. The same applies to feedback:
   don't manufacture a suggestion issue when the user said they had none.
 - Friction-sourced issues are always labeled `bug` and `help wanted`;
@@ -253,8 +263,13 @@ discipline as `.hedgehog/BMAD/`. A later related incident is its own new
   `hedgehog friction add "reviewed: <date>, issues: <url[, url...] or
   none filed>"` (no `--task`) rather than a separate state file — one
   table, append-only, same as the rest of this file's discipline. Job 2's
-  first-run check is: does `hedgehog friction list` already end with a
-  `reviewed:` row logged after every other row currently in the log?
+  wake-up check reads that marker out of `hedgehog friction list`: count
+  the rows logged after the last `reviewed:` row (every row, when there
+  is none yet), and run job 2 only at **three or more**. The floor is
+  what makes the trigger a property of the log rather than of the
+  session — a project with no build boundary to hang "once" on still
+  gets exactly one review per accumulated batch, and a single stray
+  entry never interrupts a one-line fix.
 - Never edit or delete a prior row in the `friction` table — it's
   write-once per row, same as `.hedgehog/BMAD/`.
 - Don't expand a tweak into a rebuild. A request `hedgehog-daily` sizes
@@ -262,9 +277,9 @@ discipline as `.hedgehog/BMAD/`. A later related incident is its own new
   tweak that turns out mid-edit to reach a second layer or need a file
   that doesn't exist stops and re-enters that gate.
 - When the route is the Correction Protocol, use its **post-build entry**
-  (in this core's own loop skill): the build is already at its Stop
-  Condition, so there's no task in flight to stop and no loop to resume,
-  and the correction is fixed forward in new commits rather than by
+  (in this core's own loop skill): your entry condition is that nothing
+  is in flight, so there's no task to stop and no loop to resume, and
+  the correction is fixed forward in new commits rather than by
   reopening a `complete` task. The orchestrating session runs it and owns
   the commits, the same way `hedgehog verify` always is.
 - Don't run job 2's friction detection against anything other than

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.1.3",
+  "version": "6.1.4",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
Part of #321, implements #324, stacked on #336 (#322).

**Stacked PR.** Base branch is `feat/hedgehog-daily-triage-gate` (#336), not `master`, because this depends on `hedgehog-daily` and `hedgehog status --brief` from #322. The diff below therefore carries #336's commits too. Merge #336 first, then this.

## What

`src/agents/tweaker.md`, three changes:

- **The adopted-core exclusion is gone.** The section now states how an adopted repo's change-work routes through the shared gate: a small single-layer change stops at `hedgehog-daily`'s tweak exit and is committed here; anything above that line routes to `hedgehog-adopt`'s "Adding the first (or next) change-work" and `hedgehog-authored-loop`. The change-work exit in job 1 names that route explicitly.
- **Job 1 enters on \"nothing in flight\", not \"the build finished\".** Workflow step 1 runs `hedgehog status --brief` (`src/db/status.mjs:73`); a named task means work is in flight and belongs to the core's loop skill. Every core can answer that question. Job 1's three exits are already `hedgehog-daily`'s, delegated in #336.
- **Job 2 wakes on the log, not on a build boundary.** The trigger is three or more friction rows logged since the last `reviewed:` marker. What job 2 does is unchanged: show → edit → approve → create, `bug` + `help wanted` for friction and `suggestion` for user feedback, per-issue approval, `--repo skyf0xx/hedgehog`.

`CLAUDE.md`'s one-line description of `tweaker` follows.

**Judgment call — the floor is 3.** #324 requires a floor but names no number. Three is the smallest count at which a recurrence can exist across distinct entries, which is what job 2's own \"real pattern\" bar looks for (`src/agents/tweaker.md`, Workflow step 2). At 1 or 2, the most likely outcome is a review that finds no pattern and interrupts a one-line fix to say so. Rows below the floor stay in the log for the batch that does fire.

`src/hosts/capabilities.mjs` needs no change — `tweaker` is granted `full` (line 24) and its tool list is unchanged.

## Follow-up needed outside this repo

- **`@skyf0xx/hedgehog-core-adopted`** — `hedgehog-adopt` and `hedgehog-authored-loop` in that package state that change-work routes past `tweaker` entirely. That is no longer true after this merges. Not actionable from this repo; per CLAUDE.md a tracking issue for it belongs on `skyf0xx/hedgehog` with the target repo named in the body. No issue filed.
- **`src/registry/cores.json`** — the `adopted` core's version range may need widening once that package ships the change above. Nothing to do until it does.

## Test plan

- `npm run check` — passes (4 agents, 7 skills, 6 cores, tarball, CLI).
- `npm run repro` — 69 reproductions, all pass.
- Package version bumped to 6.1.4 via `npm run release`. No plugin bump: nothing under `skills/`, `hooks/`, `.claude-plugin/`, `.cursor-plugin/`, or root `gemini-extension.json` is touched.