### PR TITLE
feat(db): add hedgehog reconcile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,10 @@ skills, and CLAUDE.md section. `src/registry/cores.json` names them;
   (what to work on and lease it), `verify`/`gate` (close a layer, check a
   phase transition), `friction`, `debt`, `decision` (inherited context for
   dependent tasks — a limitation or a design choice, respectively),
-  `drift`, `boundary`, `why`, `overrides`, `conflict`, `commitLock`,
+  `drift`, `boundary`, `why`, `overrides`, `reconcile` (absorbs work that
+  landed outside the loop, on the user's per-task confirmation, recorded
+  in committed `.hedgehog/reconciled/*.json` so `db rebuild` replays it),
+  `conflict`, `commitLock`,
   `core`, `rebuild`, `graph-server` (serves `src/templates/graph.html`'s
   visualization), and `community` (the star prompt raised at the first
   completed intent). Schema changes are versioned: `schema.mjs`'s

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -62,6 +62,16 @@ import {
 } from '../src/db/community.mjs';
 import { rebuildDb } from '../src/db/rebuild.mjs';
 import { loadOverrides, addOverride, orphanedOverrides, OVERRIDES_DIR } from '../src/db/overrides.mjs';
+import {
+  gatherEvidence,
+  formatEvidence,
+  evidenceForTask,
+  confirmReconciliation,
+  loadReconciliations,
+  orphanedReconciliations,
+  formatReconciliations,
+  RECONCILED_DIR,
+} from '../src/db/reconcile.mjs';
 import { HOSTS, HOST_FLAGS, DEFAULT_HOST, availableHosts } from '../src/hosts/index.mjs';
 import { recordHosts, installedHosts } from '../src/hosts/installed.mjs';
 import { wrapSection } from '../src/hosts/claude-md-merge.mjs';
@@ -545,6 +555,12 @@ ${bold('Usage')}
   npx @skyf0xx/hedgehog override add <task-id> --scope <glob> [--scope <glob>...] --reason "<why>"
                                                    record a committed, additive-only scope exception for one task
   npx @skyf0xx/hedgehog override list             list recorded scope overrides
+  npx @skyf0xx/hedgehog reconcile                 propose which open tasks hand-written commits may have
+                                                   already satisfied; reads only, changes nothing
+  npx @skyf0xx/hedgehog reconcile confirm <task-id> --reason "<why>"
+                                                   close one task on your judgment — no scope gate and no
+                                                   verify command run; records it under .hedgehog/reconciled/
+  npx @skyf0xx/hedgehog reconcile list            list recorded reconciliations
   npx @skyf0xx/hedgehog intent add [flags]        add an intent (rules/requirements/dependencies)
   npx @skyf0xx/hedgehog intent add --file <path>  add an intent from a JSON file
   npx @skyf0xx/hedgehog next                      print the task packet for one ready task
@@ -1186,6 +1202,21 @@ async function dbRebuildCommand() {
   console.log(
     `${green('rebuilt')}  ${dim(`${result.intentsReplayed} intent(s) replayed, ${result.tasksMarkedComplete} task(s) marked complete`)}\n`,
   );
+  // Reported separately from the count above, not folded into it: a task
+  // closed from a committed reconciliation had no verify run behind it,
+  // and a rebuild is exactly where that distinction would otherwise
+  // vanish into a single "marked complete" number.
+  if (result.tasksReconciled > 0) {
+    console.log(
+      `${dim(`${result.tasksReconciled} task(s) replayed from ${RECONCILED_DIR}/ — closed by reconciliation, not verification`)}\n`,
+    );
+  }
+  if (result.orphanedReconciled?.length > 0) {
+    console.log(
+      `${yellow(bold('Reconciliations without a task.'))} ${result.orphanedReconciled.join(', ')} —\n` +
+        `no task with this id exists in the rebuilt graph, so each closes nothing.\n`,
+    );
+  }
   warnOrphanedNotes(result);
   warnRebuildDrift(result, corePath);
 }
@@ -3134,6 +3165,107 @@ async function overrideCommand(args) {
   process.exitCode = 1;
 }
 
+// `hedgehog reconcile` / `hedgehog reconcile confirm <task-id> --reason
+// "<why>"` / `hedgehog reconcile list` — absorbs work that landed outside
+// the loop into the build graph (see src/db/reconcile.mjs).
+//
+// The bare form only reads: it prints which commits since the newest
+// graph-written commit touched files inside each open task's scope, and
+// changes nothing. `confirm` takes exactly one task id — there is no
+// bulk form, because a single "yes to all" is the unexamined assertion
+// this command exists to avoid. Nothing else in the CLI calls into this;
+// `status`, `next`, and `claim` never reconcile on their own.
+async function reconcileCommand(args) {
+  await ensureDb();
+
+  if (!(await exists(DB_PATH))) {
+    console.error(`${red('No build graph found.')} Run ${bold('hedgehog db init')} first.\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const sub = args[0];
+
+  if (sub === 'list') {
+    const reconciliations = await loadReconciliations();
+    const db = openDb({ readOnly: true });
+    let orphaned = [];
+    try {
+      orphaned = orphanedReconciliations(db, reconciliations);
+    } finally {
+      db.close();
+    }
+    console.log(`${formatReconciliations(reconciliations, orphaned)}\n`);
+    return;
+  }
+
+  if (sub === 'confirm') {
+    const taskId = args[1];
+    const reasonIdx = args.indexOf('--reason');
+    const reason = reasonIdx !== -1 ? args[reasonIdx + 1] : undefined;
+
+    if (!taskId || taskId.startsWith('--') || !reason) {
+      console.error(
+        `${red('Usage:')} hedgehog reconcile confirm <task-id> --reason "<why this work satisfies it>"\n`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    printDbTarget();
+    const db = openDb();
+    let result;
+    try {
+      const evidence = evidenceForTask(db, taskId);
+      result = await confirmReconciliation(db, { taskId, reason, evidence });
+    } catch (err) {
+      console.error(`${red('Failed to reconcile:')} ${err.message}\n`);
+      process.exitCode = 1;
+      return;
+    } finally {
+      db.close();
+    }
+
+    const file = `${RECONCILED_DIR}/${result.record.task.toLowerCase()}.json`;
+    console.log(`  ${green('complete')}  ${bold(result.record.task)} ${dim('(reconciled, not verified)')}`);
+    console.log(`  ${green('recorded')}  ${file}`);
+    if (result.unlocked.length > 0) {
+      console.log(`  ${dim(`unlocked: ${result.unlocked.join(', ')}`)}`);
+    }
+    console.log(
+      `\n  ${bold('Commit that file.')} ${dim('The build graph is derived and gitignored — an')}\n` +
+        `  ${dim('uncommitted reconciliation is reverted by the next `hedgehog db rebuild`.')}\n`,
+    );
+    return;
+  }
+
+  if (sub !== undefined) {
+    console.error(
+      `${red('Unknown reconcile subcommand:')} ${sub}\n\n` +
+        `Usage: hedgehog reconcile\n` +
+        `   or: hedgehog reconcile confirm <task-id> --reason "<why>"\n` +
+        `   or: hedgehog reconcile list\n`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // Bare `hedgehog reconcile` — read only.
+  const reconciliations = await loadReconciliations();
+  const db = openDb({ readOnly: true });
+  let evidence;
+  try {
+    evidence = gatherEvidence(db, { reconciliations });
+  } catch (err) {
+    console.error(`${red('Failed to read evidence:')} ${err.message}\n`);
+    process.exitCode = 1;
+    return;
+  } finally {
+    db.close();
+  }
+  console.log(`${formatEvidence(evidence)}\n`);
+}
+
 // `hedgehog debt add <task-id> "<note>"` / `hedgehog debt list [<task-id>]`
 // — declared debt between tasks. A note recorded against a task is
 // rendered into the INHERITED DEBT section of the packet of every task
@@ -3592,6 +3724,11 @@ async function main() {
 
   if (cmd === 'override') {
     await overrideCommand(args.slice(1));
+    return;
+  }
+
+  if (cmd === 'reconcile') {
+    await reconcileCommand(args.slice(1));
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.1.4",
+  "version": "6.1.5",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/repro/reconcile-proposes-never-asserts.mjs
+++ b/repro/reconcile-proposes-never-asserts.mjs
@@ -1,0 +1,125 @@
+// `hedgehog reconcile` proposes; it never closes a task on its own.
+//
+// The evidence it gathers is a diff overlap: files a commit touched, and
+// the scope globs a task compiled. That says work landed where a task
+// would have put it. It says nothing about whether the task's objective
+// was met — two tasks can share a scope prefix, and one commit inside it
+// satisfies neither on the strength of the overlap alone.
+//
+// So the command has exactly one shape that closes anything: `confirm`,
+// naming one task id. This asserts the properties that keeps true:
+//   1. running `reconcile` with matching evidence changes no task status
+//   2. there is no bulk confirm — no flag closes more than one task
+//   3. confirming one candidate leaves every other candidate open
+//   4. `status`, `next`, and `claim` never reconcile on their own
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  makeProject,
+  addIntent,
+  cli,
+  taskStatuses,
+  cleanup,
+  check,
+  checkContains,
+  report,
+} from './_lib.mjs';
+
+// Two modules on one layer, so one commit can put files in both tasks'
+// scopes at once — the shape a bulk confirm would close wholesale.
+const CORE = `
+id: reconcile-fixture
+layers:
+  - id: schema
+    scope: ["libs/{module}/schema/**"]
+    verify: "true"
+    commit: "feat({module}): schema"
+`;
+
+function git(dir, args) {
+  return execFileSync('git', args, { cwd: dir, encoding: 'utf8', stdio: 'pipe' });
+}
+
+const dir = makeProject(CORE, { git: true });
+try {
+  addIntent(dir, 'alpha');
+  addIntent(dir, 'beta');
+  check('plan exits 0', 0, cli(dir, ['plan']).status);
+
+  // One hand-written commit touching both modules' scopes.
+  for (const module of ['alpha', 'beta']) {
+    mkdirSync(join(dir, `libs/${module}/schema`), { recursive: true });
+    writeFileSync(join(dir, `libs/${module}/schema/model.txt`), 'hand-written\n');
+  }
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', 'add both schemas by hand']);
+
+  const openBefore = taskStatuses(dir);
+
+  // 1. Reading the evidence changes nothing.
+  const proposal = cli(dir, ['reconcile']);
+  check('reconcile exits 0', 0, proposal.status);
+  checkContains('it proposes ALPHA-SCHEMA', proposal.stdout, 'ALPHA-SCHEMA');
+  checkContains('it proposes BETA-SCHEMA', proposal.stdout, 'BETA-SCHEMA');
+  check('no task status changed', openBefore, taskStatuses(dir));
+
+  // 2. No bulk form exists. Each of these is rejected rather than
+  //    quietly interpreted as "every candidate".
+  for (const args of [
+    ['reconcile', 'confirm', '--all', '--reason', 'all of them'],
+    ['reconcile', 'confirm-all', '--reason', 'all of them'],
+    ['reconcile', 'confirm', '--reason', 'no task named'],
+  ]) {
+    check(`\`${args.join(' ')}\` is refused`, 1, cli(dir, args).status);
+  }
+  check('no task status changed by a refused bulk form', openBefore, taskStatuses(dir));
+
+  // 3. Confirming one candidate leaves the other open.
+  check(
+    'confirming ALPHA-SCHEMA exits 0',
+    0,
+    cli(dir, ['reconcile', 'confirm', 'ALPHA-SCHEMA', '--reason', 'read the diff, it is done'])
+      .status,
+  );
+  const after = taskStatuses(dir);
+  check('ALPHA-SCHEMA is complete', 'complete', after['ALPHA-SCHEMA']);
+  check(
+    'BETA-SCHEMA is untouched by that confirmation',
+    openBefore['BETA-SCHEMA'],
+    after['BETA-SCHEMA'],
+  );
+
+  // A reason is mandatory — the permanent record of why a task closed
+  // with nothing checked cannot be blank.
+  check(
+    'confirming without a reason is refused',
+    1,
+    cli(dir, ['reconcile', 'confirm', 'BETA-SCHEMA']).status,
+  );
+  check('BETA-SCHEMA is still open', openBefore['BETA-SCHEMA'], taskStatuses(dir)['BETA-SCHEMA']);
+
+  // 4. The read-only commands never reconcile on their own.
+  const settled = taskStatuses(dir);
+  cli(dir, ['status']);
+  cli(dir, ['next']);
+  cli(dir, ['claim', '--owner', 'repro']);
+  cli(dir, ['ready']);
+  const stillOpen = taskStatuses(dir);
+  check(
+    'BETA-SCHEMA was not reconciled by status/next/claim/ready',
+    settled['BETA-SCHEMA'],
+    // claim legitimately leases it; what must not happen is `complete`.
+    stillOpen['BETA-SCHEMA'] === 'building' ? settled['BETA-SCHEMA'] : stillOpen['BETA-SCHEMA'],
+  );
+  check(
+    'no command other than reconcile closed BETA-SCHEMA',
+    false,
+    stillOpen['BETA-SCHEMA'] === 'complete',
+  );
+} finally {
+  cleanup(dir);
+}
+
+report('hedgehog reconcile proposes evidence and closes only what the user names');

--- a/repro/reconcile-scope-match.mjs
+++ b/repro/reconcile-scope-match.mjs
@@ -1,0 +1,57 @@
+// `hedgehog reconcile`'s scope comparison agrees with the gate
+// `hedgehog verify` runs.
+//
+// verify.mjs hands a task's scope globs to git as `:(glob)…` pathspecs
+// and lets git decide what is in scope. reconcile.mjs cannot: its paths
+// already came out of `git log --name-only`, and re-asking git per task
+// per commit would be one subprocess per pair. It matches in-process
+// instead — so the syntax has to be the same syntax, or a task's evidence
+// would be gathered against a different scope than its gate enforces.
+//
+// The three rules that differ between glob dialects, asserted here:
+//   - `**` spans separators; a single `*` and `?` never do
+//   - a trailing `/**` also matches the directory it names
+//   - every other character is a literal, `.` included
+
+import { pathInScope } from '../src/db/reconcile.mjs';
+import { check, report } from './_lib.mjs';
+
+const CASES = [
+  // `**` spans separators.
+  ['libs/alpha/schema/model.txt', ['libs/alpha/schema/**'], true],
+  ['libs/alpha/schema/deep/nested/model.txt', ['libs/alpha/schema/**'], true],
+  ['src/x/y.ts', ['**/*.ts'], true],
+  ['y.ts', ['**/*.ts'], true],
+  ['a/x/y/b.txt', ['a/**/b.txt'], true],
+  ['a/b.txt', ['a/**/b.txt'], true],
+
+  // A trailing `/**` also matches the directory itself, so a glob and the
+  // directory it names agree.
+  ['libs/alpha/schema', ['libs/alpha/schema/**'], true],
+
+  // A single `*` and `?` stay inside one segment.
+  ['src/alpha/schema.txt', ['src/*/schema.txt'], true],
+  ['src/alpha/deep/schema.txt', ['src/*/schema.txt'], false],
+  ['a.txt', ['*.txt'], true],
+  ['dir/a.txt', ['*.txt'], false],
+
+  // A prefix that is not a path prefix does not match.
+  ['libs/alpha/schemax/model.txt', ['libs/alpha/schema/**'], false],
+  ['libs/alpha/schemax', ['libs/alpha/schema/**'], false],
+  ['libs/beta/schema/model.txt', ['libs/alpha/schema/**'], false],
+
+  // Regex metacharacters in a glob are literals.
+  ['a.b.txt', ['a.b.txt'], true],
+  ['axbxtxt', ['a.b.txt'], false],
+  ['x+y.ts', ['x+y.ts'], true],
+
+  // Any one glob in the list matching is enough.
+  ['apps/api/orders/route.ts', ['libs/orders/**', 'apps/api/orders/**'], true],
+  ['apps/web/page.tsx', ['libs/orders/**', 'apps/api/orders/**'], false],
+];
+
+for (const [path, globs, expected] of CASES) {
+  check(`${path}  vs  ${globs.join(', ')}`, expected, pathInScope(path, globs));
+}
+
+report("reconcile's scope match implements the same glob syntax the verify gate does");

--- a/repro/reconcile-survives-rebuild.mjs
+++ b/repro/reconcile-survives-rebuild.mjs
@@ -1,0 +1,201 @@
+// `hedgehog reconcile` absorbs hand-written work into the build graph,
+// and the confirmation survives `hedgehog db rebuild`.
+//
+// The scenario is the one the graph had no answer for: a user hand-codes
+// a layer's work between sessions and commits it with their own message.
+// `hedgehog verify` never ran, so the commit subject is not the one
+// core.yaml declares — and `db rebuild`, which credits a task only when
+// some commit subject matches its `commit_message` exactly, sees the work
+// as absent. `hedgehog next` then points at work that is already done.
+//
+// What this asserts, in order:
+//   1. bare `reconcile` proposes the task and changes nothing
+//   2. `reconcile confirm` closes it, writes .hedgehog/reconciled/<id>.json,
+//      and records the "not verified" provenance as an inheritable note
+//   3. `status` says the task closed by reconciliation
+//   4. a rebuild from a deleted DB replays the confirmation — without it
+//      the rebuild silently reverts the reconciliation, which is the
+//      failure this command exists to prevent
+//   5. the provenance note is not duplicated by that replay
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  makeProject,
+  addIntent,
+  cli,
+  openGraph,
+  taskStatuses,
+  rebuildFromScratch,
+  cleanup,
+  check,
+  checkContains,
+  report,
+} from './_lib.mjs';
+
+// A plain two-layer module-axis core: `schema` then `api`, so the
+// reconciled task has a dependent whose readiness must be unlocked.
+const CORE = `
+id: reconcile-fixture
+layers:
+  - id: schema
+    scope: ["libs/{module}/schema/**"]
+    verify: "true"
+    commit: "feat({module}): schema"
+  - id: api
+    depends_on: schema
+    scope: ["apps/api/{module}/**"]
+    verify: "true"
+    commit: "feat({module}): api"
+`;
+
+function git(dir, args) {
+  return execFileSync('git', args, { cwd: dir, encoding: 'utf8', stdio: 'pipe' });
+}
+
+const dir = makeProject(CORE, { git: true });
+try {
+  addIntent(dir, 'alpha');
+  check('plan exits 0', 0, cli(dir, ['plan']).status);
+
+  const before = taskStatuses(dir);
+  check('ALPHA-SCHEMA starts open', true, ['planned', 'ready'].includes(before['ALPHA-SCHEMA']));
+
+  // The hand-written work: a real file inside ALPHA-SCHEMA's compiled
+  // scope, committed under the user's own message rather than the one
+  // core.yaml declares for that layer.
+  mkdirSync(join(dir, 'libs/alpha/schema'), { recursive: true });
+  writeFileSync(join(dir, 'libs/alpha/schema/model.txt'), 'hand-written between sessions\n');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', 'add the alpha schema by hand']);
+
+  // A rebuild cannot credit that commit — this is the gap, asserted
+  // rather than assumed.
+  check('db rebuild exits 0', 0, rebuildFromScratch(dir).status);
+  check(
+    'a hand-written commit is not credited by a rebuild',
+    true,
+    ['planned', 'ready'].includes(taskStatuses(dir)['ALPHA-SCHEMA']),
+  );
+
+  // 1. Bare `reconcile` proposes and changes nothing.
+  const proposal = cli(dir, ['reconcile']);
+  check('reconcile exits 0', 0, proposal.status);
+  checkContains('it proposes the task', proposal.stdout, 'ALPHA-SCHEMA');
+  checkContains('it names the in-scope path', proposal.stdout, 'libs/alpha/schema/model.txt');
+  checkContains('it says nothing was changed', proposal.stdout, 'evidence only');
+  check(
+    'the task is still open after the proposal',
+    true,
+    ['planned', 'ready'].includes(taskStatuses(dir)['ALPHA-SCHEMA']),
+  );
+
+  // 2. Confirming one task closes it and writes the committed record.
+  const confirmed = cli(dir, [
+    'reconcile',
+    'confirm',
+    'ALPHA-SCHEMA',
+    '--reason',
+    'the schema landed in the hand-written commit',
+  ]);
+  check('reconcile confirm exits 0', 0, confirmed.status);
+  check('ALPHA-SCHEMA is complete', 'complete', taskStatuses(dir)['ALPHA-SCHEMA']);
+  check('its dependent is unlocked', 'ready', taskStatuses(dir)['ALPHA-API']);
+
+  const recordPath = join(dir, '.hedgehog/reconciled/alpha-schema.json');
+  check('the committed record exists', true, existsSync(recordPath));
+  const record = JSON.parse(readFileSync(recordPath, 'utf8'));
+  check('the record names the task', 'ALPHA-SCHEMA', record.task);
+  check(
+    'the record carries the reason',
+    'the schema landed in the hand-written commit',
+    record.reason,
+  );
+  check(
+    'the record carries the evidence path',
+    ['libs/alpha/schema/model.txt'],
+    record.evidence.paths,
+  );
+
+  // The provenance: an inheritable note saying no verify ran.
+  {
+    const db = openGraph(dir);
+    try {
+      const notes = db
+        .prepare('SELECT task_id, note FROM decisions ORDER BY id')
+        .all();
+      check('one provenance note is recorded', 1, notes.length);
+      check('it is attached to the reconciled task', 'ALPHA-SCHEMA', notes[0]?.task_id);
+      checkContains(
+        'it states the task was not verified',
+        notes[0]?.note ?? '',
+        'Closed by reconciliation, not verification',
+      );
+    } finally {
+      db.close();
+    }
+  }
+
+  // 3. Status surfaces the distinction.
+  const status = cli(dir, ['status']);
+  checkContains('status names the section', status.stdout, 'CLOSED BY RECONCILIATION');
+  checkContains('status names the task', status.stdout, 'ALPHA-SCHEMA');
+
+  // A second confirmation of the same task is refused rather than
+  // silently overwriting the first record.
+  const again = cli(dir, ['reconcile', 'confirm', 'ALPHA-SCHEMA', '--reason', 'again']);
+  check('a repeat confirmation fails', 1, again.status);
+
+  // 4. The centre of the design: the confirmation survives a rebuild.
+  const rebuilt = rebuildFromScratch(dir);
+  check('db rebuild after reconciling exits 0', 0, rebuilt.status);
+  check(
+    'the reconciled task is still complete after a rebuild',
+    'complete',
+    taskStatuses(dir)['ALPHA-SCHEMA'],
+  );
+  checkContains(
+    'the rebuild reports the replay separately from verified completions',
+    rebuilt.stdout,
+    'closed by reconciliation, not verification',
+  );
+
+  // 5. The replay does not duplicate the provenance note.
+  {
+    const db = openGraph(dir);
+    try {
+      check(
+        'the provenance note is not duplicated by the replay',
+        1,
+        db.prepare('SELECT COUNT(*) AS n FROM decisions').get().n,
+      );
+    } finally {
+      db.close();
+    }
+  }
+
+  // A second rebuild does not compound it either.
+  check('a second db rebuild exits 0', 0, rebuildFromScratch(dir).status);
+  {
+    const db = openGraph(dir);
+    try {
+      check(
+        'a second rebuild still leaves exactly one note',
+        1,
+        db.prepare('SELECT COUNT(*) AS n FROM decisions').get().n,
+      );
+    } finally {
+      db.close();
+    }
+  }
+
+  // `reconcile list` reads the committed records back.
+  const listed = cli(dir, ['reconcile', 'list']);
+  check('reconcile list exits 0', 0, listed.status);
+  checkContains('it lists the reconciled task', listed.stdout, 'ALPHA-SCHEMA');
+} finally {
+  cleanup(dir);
+}
+
+report('hedgehog reconcile absorbs hand-written work and survives db rebuild');

--- a/src/db/rebuild.mjs
+++ b/src/db/rebuild.mjs
@@ -2,8 +2,10 @@
 // source-of-truth files, for a fresh clone (no `.hedgehog/hedgehog.db`)
 // or after suspected corruption. The DB itself is a derived artifact:
 // everything it holds is either replayable from `.hedgehog/intents/*.json`
-// (via the same normalize/insert path `intent add`/`plan` already use) or
-// recoverable from git history (which tasks' commits already landed).
+// (via the same normalize/insert path `intent add`/`plan` already use),
+// recoverable from git history (which tasks' commits already landed), or
+// replayable from `.hedgehog/reconciled/*.json` (which tasks a user
+// confirmed as done by work git history cannot credit — reconcile.mjs).
 // What isn't recoverable — `verifications.output`, the ephemeral
 // diagnostics of a run that already passed — is an accepted loss; this
 // only reconciles `tasks.status`.
@@ -23,6 +25,13 @@ import { planTasks, CORE_MODULE } from './plan.mjs';
 import { loadCore } from './core.mjs';
 import { detectDrift } from './drift.mjs';
 import { loadOverrides, OVERRIDES_DIR } from './overrides.mjs';
+import {
+  loadReconciliations,
+  orphanedReconciliations,
+  reconciledNote,
+  RECONCILED_DIR,
+  RECONCILED_NOTE_PREFIX,
+} from './reconcile.mjs';
 
 // Alphabetical by filename, purely to make the *tie-break* deterministic
 // across machines and runs. It is NOT the replay order — see
@@ -59,9 +68,19 @@ function intentExists(db, id) {
 // so a note re-attaches to the same task the replay recompiles). A note
 // whose task no longer exists in the new graph has nowhere to live and is
 // reported rather than silently dropped.
+//
+// One class of decision row is excluded from that carry-across: the
+// provenance note a reconciliation writes (reconcile.mjs). That one DOES
+// have a committed source — `.hedgehog/reconciled/*.json` — and
+// replayReconciliations below re-writes it from that file. Carrying it
+// across as well would give a reconciled task two identical notes after
+// the first rebuild, and one more on every rebuild after that.
 function clearDerivedGraph(db) {
   const debt = db.prepare('SELECT task_id, note, logged_at FROM debt').all();
-  const decisions = db.prepare('SELECT task_id, note, logged_at FROM decisions').all();
+  const decisions = db
+    .prepare('SELECT task_id, note, logged_at FROM decisions')
+    .all()
+    .filter((row) => !row.note.startsWith(RECONCILED_NOTE_PREFIX));
   const friction = db.prepare('SELECT task_id, note, logged_at FROM friction').all();
 
   db.prepare('DELETE FROM intents').run();
@@ -312,10 +331,48 @@ function markCompletedTasks(db, commitSubjects) {
   return complete.size;
 }
 
+// Replays `.hedgehog/reconciled/*.json` — the committed record of every
+// task a user confirmed as already done by work that landed outside the
+// loop (reconcile.mjs).
+//
+// This runs after markCompletedTasks and does the same job by a different
+// route. markCompletedTasks credits a task only when some commit subject
+// matches its `commit_message` exactly, which is the subject `verify`
+// itself writes — a hand-written commit never matches, by construction,
+// which is the whole reason reconcile exists. So a reconciled task needs
+// no commit-message match here: the committed confirmation IS the source,
+// exactly as an override file is the source for a widened scope.
+//
+// Without this step a rebuild silently reverts every confirmed
+// reconciliation and reintroduces the problem reconcile was run to fix,
+// which is worse than never reconciling — it looks like it worked.
+//
+// The provenance note is re-written here too, so a reconciled task's
+// "closed without a verify run" fact reaches its dependents' packets on a
+// fresh clone the same as it did on the machine that confirmed it.
+function replayReconciliations(db, reconciliations) {
+  const setComplete = db.prepare(
+    "UPDATE tasks SET status = 'complete', blocked_reason = NULL WHERE id = ?",
+  );
+  const insertNote = db.prepare('INSERT INTO decisions (task_id, note) VALUES (?, ?)');
+  const taskExists = db.prepare('SELECT 1 FROM tasks WHERE id = ?');
+
+  let replayed = 0;
+  for (const [taskId, record] of reconciliations) {
+    if (taskExists.get(taskId) === undefined) continue;
+    setComplete.run(taskId);
+    insertNote.run(taskId, reconciledNote(record));
+    replayed++;
+  }
+  return replayed;
+}
+
 // Rebuilds `db` from scratch: schema, then every committed intent
 // replayed in dependency order, then planTasks to re-derive tasks +
 // dependencies, then git history to reconcile which tasks already
-// completed. Returns a summary for the CLI to print.
+// completed, then `.hedgehog/reconciled/*.json` for the tasks a user
+// confirmed as done by work that git history cannot credit. Returns a
+// summary for the CLI to print.
 //
 // `drift` in the return is the honest disclosure this rebuild owes its
 // caller. A rebuild re-derives every task's layer-derived fields from
@@ -330,7 +387,12 @@ function markCompletedTasks(db, commitSubjects) {
 // of something they discover three layers later.
 export async function rebuildDb(
   db,
-  { corePath, intentsDir = INTENTS_DIR, overridesDir = OVERRIDES_DIR } = {},
+  {
+    corePath,
+    intentsDir = INTENTS_DIR,
+    overridesDir = OVERRIDES_DIR,
+    reconciledDir = RECONCILED_DIR,
+  } = {},
 ) {
   applySchema(db);
 
@@ -340,15 +402,26 @@ export async function rebuildDb(
 
   const core = await loadCore(corePath);
   const overrides = await loadOverrides(overridesDir);
+  const reconciliations = await loadReconciliations(reconciledDir);
 
   planTasks(db, core, overrides);
 
   const commitSubjects = loadCommitSubjects();
   const tasksMarkedComplete = markCompletedTasks(db, commitSubjects);
 
+  const tasksReconciled = replayReconciliations(db, reconciliations);
+  const orphanedReconciled = orphanedReconciliations(db, reconciliations);
+
   const orphanedNotes = restoreNotes(db, notes);
 
   const drift = detectDrift(db, core, { overrides });
 
-  return { intentsReplayed, tasksMarkedComplete, orphanedNotes, drift };
+  return {
+    intentsReplayed,
+    tasksMarkedComplete,
+    tasksReconciled,
+    orphanedReconciled,
+    orphanedNotes,
+    drift,
+  };
 }

--- a/src/db/reconcile.mjs
+++ b/src/db/reconcile.mjs
@@ -1,0 +1,591 @@
+// `hedgehog reconcile` — absorbs work that landed outside the loop into
+// the build graph, on the user's word rather than on the engine's.
+//
+// `hedgehog claim` fingerprints the working tree at claim time and
+// `verify` excludes every path that did not move during the lease
+// (claim.mjs, verify.mjs#attributedToTask), so a hand edit is correctly
+// never *blamed* on a task. It is also never *credited* to one.
+// `hedgehog db rebuild` does not close that gap either: it recovers
+// `tasks.status` by matching each task's `commit_message` against commit
+// subjects exactly (rebuild.mjs#markCompletedTasks), and that subject is
+// the one `verify` itself writes from core.yaml. A hand-written commit
+// never matches, by construction. So `hedgehog next` and `hedgehog
+// status` point at work that is already done, and the only remaining
+// moves are to redo the work through the loop or to hand-patch a task row
+// — which every loop skill forbids, because the graph is derived and
+// gitignored and the patch dies at the next rebuild.
+//
+// Four properties, each load-bearing:
+//
+//   - **It proposes; it never asserts.** `gatherEvidence` reports which
+//     commits since the newest graph-written commit touched files inside
+//     an open task's compiled scope_globs. A diff cannot tell you a
+//     task's intent was met, so nothing here closes a task on its own.
+//   - **The user confirms one task at a time.** `confirmReconciliation`
+//     takes exactly one task id and one reason. There is deliberately no
+//     bulk confirm: a single "yes to all" is exactly the unexamined
+//     assertion the evidence path refuses to make.
+//   - **A confirmed task records why.** Closing a task from reconciliation
+//     is not the fact `verify` records: no scope gate ran and no verify
+//     command ran. That distinction is inherited context for everything
+//     downstream, so `applyReconciliation` writes it as a `decisions` row
+//     (decision.mjs) which next.mjs renders into every dependent task's
+//     packet.
+//   - **It survives a rebuild.** The confirmation is a committed file
+//     under `.hedgehog/reconciled/`, in the same shape overrides.mjs uses
+//     for the same reason: a decision with no other committed source has
+//     to be replayable, or the next `db rebuild` silently reverts it and
+//     reintroduces the problem. `rebuild.mjs` replays these alongside
+//     `.hedgehog/overrides/*.json`.
+//
+// It never runs on its own. No `status`, `next`, or `claim` path calls
+// into this file — reconciliation is a deliberate act, because it is the
+// one way a task reaches `complete` without the engine having checked
+// anything.
+
+import { readdir, readFile, mkdir, writeFile, rename, rm } from 'node:fs/promises';
+import { execFileSync } from 'node:child_process';
+import { applySchema } from './schema.mjs';
+
+export const RECONCILED_DIR = '.hedgehog/reconciled';
+
+// The note attached to a reconciled task, and the prefix every such note
+// carries. next.mjs renders `decisions` rows into each dependent task's
+// INHERITED DECISIONS section, so a dependent's packet says outright that
+// its prerequisite closed unverified. The prefix is also how the replay
+// and the status surface recognize their own rows without a second table.
+export const RECONCILED_NOTE_PREFIX = 'Closed by reconciliation, not verification';
+
+export function reconciledNote(record) {
+  return (
+    `${RECONCILED_NOTE_PREFIX}: ${record.reason} ` +
+    `(no scope gate and no verify command ran; evidence: ${record.evidence.commits.length} commit(s), ` +
+    `${record.evidence.paths.length} path(s) in scope)`
+  );
+}
+
+function reconciledFilePath(taskId, reconciledDir = RECONCILED_DIR) {
+  return `${reconciledDir}/${taskId.toLowerCase()}.json`;
+}
+
+// Runs git with an argv array and no shell, so a path or a glob reaches
+// git as one literal argument — the same rule verify.mjs#git follows for
+// the same reason.
+function git(args, options = {}) {
+  return execFileSync('git', args, { encoding: 'utf8', ...options });
+}
+
+// Validates one parsed reconciliation record. Throws with the offending
+// file's path, since this runs at load time over the whole directory and
+// a bad record has to name itself to be findable — overrides.mjs's
+// validateOverride, same contract.
+function validateReconciled(record, path) {
+  if (record === null || typeof record !== 'object') {
+    throw new Error(`${path}: reconciliation must be a JSON object`);
+  }
+  let { task } = record;
+  const { reason, confirmed_at: confirmedAt, evidence } = record;
+
+  if (!task || typeof task !== 'string') {
+    throw new Error(`${path}: reconciliation requires a "task" id (string)`);
+  }
+  // plan.mjs#taskId upper-cases every id it compiles a task under, and
+  // the replay looks tasks up by that exact string. Normalizing here,
+  // once, keeps the id space exact-match everywhere else — the same
+  // reason overrides.mjs normalizes.
+  task = task.toUpperCase();
+
+  if (!reason || typeof reason !== 'string') {
+    throw new Error(
+      `${path}: reconciliation "${task}" requires a "reason" (string) — this is the permanent record of why a task closed without a verify run`,
+    );
+  }
+  if (!confirmedAt || typeof confirmedAt !== 'string') {
+    throw new Error(`${path}: reconciliation "${task}" requires a "confirmed_at" timestamp (string)`);
+  }
+  if (evidence === null || typeof evidence !== 'object' || Array.isArray(evidence)) {
+    throw new Error(`${path}: reconciliation "${task}" requires an "evidence" object`);
+  }
+  for (const field of ['commits', 'paths']) {
+    if (!Array.isArray(evidence[field])) {
+      throw new Error(`${path}: reconciliation "${task}" requires "evidence.${field}" (array)`);
+    }
+    for (const entry of evidence[field]) {
+      if (typeof entry !== 'string' || entry.trim() === '') {
+        throw new Error(
+          `${path}: reconciliation "${task}" has a non-string or empty entry in evidence.${field}`,
+        );
+      }
+    }
+  }
+
+  return {
+    task,
+    reason,
+    confirmed_at: confirmedAt,
+    evidence: { commits: [...evidence.commits], paths: [...evidence.paths] },
+  };
+}
+
+// Every *.json in `reconciledDir`, validated, as a Map from task id to
+// its record. One file per task: a second confirmation of the same task
+// is a mistake rather than a second distinct fact, unlike an override,
+// where two separately-reasoned widenings of one task are both real.
+// Absent directory reads as "nothing reconciled", the same way
+// overrides.mjs#loadOverrides treats a missing overrides directory.
+export async function loadReconciliations(reconciledDir = RECONCILED_DIR) {
+  let entries;
+  try {
+    entries = await readdir(reconciledDir);
+  } catch {
+    return new Map();
+  }
+
+  const byTask = new Map();
+  for (const name of entries.filter((n) => n.endsWith('.json')).sort()) {
+    const path = `${reconciledDir}/${name}`;
+    let parsed;
+    try {
+      parsed = JSON.parse(await readFile(path, 'utf8'));
+    } catch (err) {
+      throw new Error(`could not read reconciliation file ${path}: ${err.message}`);
+    }
+    const record = validateReconciled(parsed, path);
+    byTask.set(record.task, record);
+  }
+  return byTask;
+}
+
+// Reconciled task ids matching no row in `tasks` — a typo'd id, a task
+// from a renamed module or layer, or one whose intent file is gone. The
+// read side that keeps a dead record discoverable, exactly as
+// overrides.mjs#orphanedOverrides does: the replay skipping an unknown id
+// is a no-op, not a throw, so without this the file would sit there
+// closing nothing forever.
+export function orphanedReconciliations(db, reconciliations) {
+  const known = new Set(db.prepare('SELECT id FROM tasks').all().map((r) => r.id));
+  return [...reconciliations.keys()].filter((taskId) => !known.has(taskId)).sort();
+}
+
+// ── evidence ──────────────────────────────────────────────────────────
+
+// The newest commit the graph itself wrote — the newest commit whose
+// subject matches some task's `commit_message`, which is the exact
+// predicate rebuild.mjs#markCompletedTasks uses to decide a task ran.
+// Everything above it in history is the window this command reads: it is
+// where hand-written work necessarily sits, because a graph-written
+// commit below it has already been credited by rebuild.
+//
+// Returns null when no commit matches any task's message (nothing has
+// been verified yet) — the caller then reads the whole history, which is
+// the honest window for a project whose loop has not closed a task.
+function newestGraphCommit(db) {
+  const messages = new Set(
+    db.prepare('SELECT commit_message FROM tasks').all().map((r) => r.commit_message),
+  );
+  if (messages.size === 0) return null;
+
+  const output = git(['log', '--topo-order', '--format=%H%x00%s']);
+  for (const line of output.split('\n')) {
+    if (!line) continue;
+    const [sha, subject] = line.split('\0');
+    if (subject !== undefined && messages.has(subject)) return sha;
+  }
+  return null;
+}
+
+// Every commit after `sinceSha` (exclusive), newest first, with the paths
+// it touched. `sinceSha` null means the whole history.
+function commitsSince(sinceSha) {
+  const range = sinceSha ? [`${sinceSha}..HEAD`] : ['HEAD'];
+  let output;
+  try {
+    output = git(['log', '--topo-order', '--name-only', '--format=%x01%H%x00%s', ...range]);
+  } catch {
+    // An empty repository has no HEAD to log.
+    return [];
+  }
+
+  const commits = [];
+  for (const block of output.split('\x01')) {
+    if (!block.trim()) continue;
+    const [header, ...rest] = block.split('\n');
+    const [sha, subject] = header.split('\0');
+    if (!sha) continue;
+    const paths = rest.map((p) => p.trim()).filter(Boolean);
+    commits.push({ sha, subject: subject ?? '', paths });
+  }
+  return commits;
+}
+
+// True when `path` matches `glob`.
+//
+// The scope globs compiled onto a task are git pathspec globs
+// (`apps/api/src/orders/**`), and verify.mjs's gate hands them straight
+// to git as `:(glob)…` pathspecs. Here the paths already came out of `git
+// log --name-only`, so there is no second git call to make: the match is
+// done in-process against the same syntax git implements — `**` spans
+// separators, a single `*` and `?` do not, and a trailing `/**` also
+// matches the directory's own path, which is what makes a glob and the
+// directory it names agree.
+//
+// Segment-by-segment rather than character-by-character, so the two `**`
+// forms (a whole segment, versus a `*` pair inside one) can't be confused
+// for each other.
+function globToRegExp(glob) {
+  const escape = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  // A `*` or `?` inside one path segment never crosses a separator.
+  const segmentPattern = (segment) =>
+    segment
+      .split(/(\*|\?)/)
+      .map((part) => (part === '*' ? '[^/]*' : part === '?' ? '[^/]' : escape(part)))
+      .join('');
+
+  const segments = glob.split('/');
+  let out = '';
+  for (const [i, segment] of segments.entries()) {
+    if (segment === '**') {
+      // `**` and the separator on one side of it are optional together,
+      // so `a/**` also matches `a` and `**/x.ts` also matches `x.ts`.
+      if (i === segments.length - 1) {
+        // Trailing: the separator *before* it goes optional with it —
+        // unless there is nothing before it, and the glob is the bare
+        // `**` that matches everything.
+        out += i === 0 ? '.*' : '(?:/.*)?';
+      } else {
+        // Interior or leading: the separator *after* it goes optional
+        // with it. A preceding literal segment still needs its own
+        // separator written first.
+        if (i > 0) out += '/';
+        out += '(?:.*/)?';
+      }
+      continue;
+    }
+    // Only a preceding literal segment contributes the separator — a
+    // preceding `**` already carried its own.
+    if (i > 0 && segments[i - 1] !== '**') out += '/';
+    out += segmentPattern(segment);
+  }
+
+  return new RegExp(`^${out}$`);
+}
+
+export function pathInScope(path, scopeGlobs) {
+  return scopeGlobs.some((glob) => globToRegExp(glob).test(path));
+}
+
+// Tasks a reconciliation could apply to: `planned` or `ready`, the two
+// statuses `hedgehog next` would still hand out. A `building`/`verifying`
+// task is leased and belongs to whoever holds it; a `blocked` task failed
+// a gate the loop already ran and has `retry` as its way back; a
+// `complete` task is done.
+const OPEN_TASKS_SQL = `
+  SELECT id, layer, module, objective, scope_globs, status
+  FROM tasks
+  WHERE status IN ('planned', 'ready')
+  ORDER BY priority, id;
+`;
+
+// The read path. For every open task, which of the commits since the
+// newest graph-written commit touched files inside that task's compiled
+// scope_globs.
+//
+// Returns { since, commits, candidates, alreadyReconciled }:
+//   - `since` the sha the window starts above, or null for whole history
+//   - `commits` every commit in the window (so a caller can report a
+//     window that contained nothing)
+//   - `candidates` one entry per open task with at least one matching
+//     path: { task, commits: [{sha, subject, paths}], paths }
+//   - `alreadyReconciled` open task ids that already have a committed
+//     confirmation on disk (their file exists but the graph has not been
+//     rebuilt since)
+//
+// This is evidence, not proof. A commit touching a task's scope says
+// files moved where that task would have moved them; it says nothing
+// about whether the task's objective was met. Every caller must put the
+// judgment to the user.
+export function gatherEvidence(db, { reconciliations = new Map() } = {}) {
+  const since = newestGraphCommit(db);
+  const commits = commitsSince(since);
+  const openTasks = db.prepare(OPEN_TASKS_SQL).all();
+
+  const candidates = [];
+  const alreadyReconciled = [];
+  for (const task of openTasks) {
+    if (reconciliations.has(task.id)) alreadyReconciled.push(task.id);
+
+    const scopeGlobs = JSON.parse(task.scope_globs);
+    const matched = [];
+    const paths = new Set();
+    for (const commit of commits) {
+      const hits = commit.paths.filter((p) => pathInScope(p, scopeGlobs));
+      if (hits.length === 0) continue;
+      matched.push({ sha: commit.sha, subject: commit.subject, paths: hits });
+      for (const p of hits) paths.add(p);
+    }
+    if (matched.length > 0) {
+      candidates.push({ task, commits: matched, paths: [...paths].sort() });
+    }
+  }
+
+  return { since, commits, candidates, alreadyReconciled };
+}
+
+// ── confirmation ──────────────────────────────────────────────────────
+
+// Writes one reconciliation record to
+// RECONCILED_DIR/<task-id-lowercased>.json via temp file + rename, so a
+// crash mid-write can never leave a half-written file for
+// loadReconciliations to trip on — overrides.mjs#writeOverrideFile and
+// intent.mjs#writeIntentFile use the same pattern for the same reason.
+//
+// Refuses to overwrite silently. A task is reconciled once; a second
+// confirmation for the same id is a wrong id or a forgotten first run,
+// and either is worth stopping for.
+export async function writeReconciledFile(record, reconciledDir = RECONCILED_DIR) {
+  const path = reconciledFilePath(record.task, reconciledDir);
+  try {
+    await readFile(path, 'utf8');
+    throw new Error(
+      `${path} already exists — ${record.task} is already recorded as reconciled. Edit that file directly rather than re-confirming.`,
+    );
+  } catch (err) {
+    if (!err || err.code !== 'ENOENT') throw err;
+  }
+
+  await mkdir(reconciledDir, { recursive: true });
+  const tempPath = `${path}.tmp-${process.pid}`;
+  try {
+    await writeFile(tempPath, `${JSON.stringify(record, null, 2)}\n`);
+    await rename(tempPath, path);
+  } catch (err) {
+    await rm(tempPath, { force: true }).catch(() => {});
+    throw err;
+  }
+  return record;
+}
+
+// Applies one confirmed reconciliation to the graph: the task goes
+// `complete`, its provenance note is written as a `decisions` row, and
+// its dependents are re-evaluated for readiness the same way verify.mjs
+// does on a pass.
+//
+// Marking the status directly is correct here for the same reason
+// rebuild.mjs#markCompletedTasks does it: there is no lease to check, no
+// working-tree diff to gate, and no verify_command to run. The difference
+// from verify is exactly what the note records.
+export function applyReconciliation(db, record) {
+  applySchema(db);
+
+  const task = db.prepare('SELECT id, status FROM tasks WHERE id = ?').get(record.task);
+  if (!task) throw new Error(`no such task: ${record.task}`);
+  if (task.status === 'complete') return { taskId: record.task, unlocked: [], alreadyComplete: true };
+  if (task.status === 'building' || task.status === 'verifying') {
+    throw new Error(
+      `Task ${record.task} is leased (${task.status}) — release it with \`hedgehog release ${record.task} --owner <owner>\` before reconciling it.`,
+    );
+  }
+
+  let unlocked;
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    db.prepare(
+      "UPDATE tasks SET status = 'complete', blocked_reason = NULL WHERE id = ?",
+    ).run(record.task);
+    db.prepare('INSERT INTO decisions (task_id, note) VALUES (?, ?)').run(
+      record.task,
+      reconciledNote(record),
+    );
+    unlocked = unlockDependents(db, record.task);
+    completeIntentIfDone(db, record.task);
+    db.exec('COMMIT');
+  } catch (err) {
+    try {
+      db.exec('ROLLBACK');
+    } catch {
+      // Rollback failing must not mask the original error.
+    }
+    throw err;
+  }
+
+  return { taskId: record.task, unlocked, alreadyComplete: false };
+}
+
+// Marks `taskId`'s direct dependents `ready` wherever every one of their
+// dependencies is now complete — the same rule and the same restriction
+// verify.mjs#unlockReadyDependents applies: a dependent already `blocked`
+// is stalled on its own failure, not on this dependency, and must not be
+// cleared back to ready here.
+function unlockDependents(db, taskId) {
+  const dependents = db
+    .prepare(
+      `SELECT t.id, t.status FROM tasks t
+       JOIN dependencies d ON d.task_id = t.id
+       WHERE d.depends_on_task_id = ?
+       ORDER BY t.priority, t.id`,
+    )
+    .all(taskId);
+
+  const unlocked = [];
+  for (const dependent of dependents) {
+    if (dependent.status !== 'planned') continue;
+    const blocker = db
+      .prepare(
+        `SELECT 1 FROM dependencies d
+         JOIN tasks dep ON dep.id = d.depends_on_task_id
+         WHERE d.task_id = ? AND dep.status <> 'complete'`,
+      )
+      .get(dependent.id);
+    if (blocker !== undefined) continue;
+    db.prepare("UPDATE tasks SET status = 'ready' WHERE id = ?").run(dependent.id);
+    unlocked.push(dependent.id);
+  }
+  return unlocked;
+}
+
+// Closes the task's intent once every task compiled from it is complete
+// — the same terminal bookkeeping verify.mjs#completeIntentIfDone does,
+// so an intent whose last open task closes by reconciliation does not sit
+// `active` forever.
+function completeIntentIfDone(db, taskId) {
+  const row = db.prepare('SELECT intent_id FROM tasks WHERE id = ?').get(taskId);
+  if (!row) return;
+  const openTask = db
+    .prepare("SELECT 1 FROM tasks WHERE intent_id = ? AND status <> 'complete'")
+    .get(row.intent_id);
+  if (openTask !== undefined) return;
+  db.prepare("UPDATE intents SET status = 'complete' WHERE id = ?").run(row.intent_id);
+}
+
+// The `hedgehog reconcile confirm <task-id> --reason "<why>"` entry
+// point: builds the record from the task's own evidence, writes the
+// committed file first, then applies it to the graph.
+//
+// File before graph, deliberately. The graph is derived and gitignored;
+// the file is the permanent record. If the write fails, nothing has been
+// closed on a fact that would not survive the next rebuild.
+export async function confirmReconciliation(
+  db,
+  { taskId, reason, evidence },
+  reconciledDir = RECONCILED_DIR,
+) {
+  if (!taskId) throw new Error('reconcile requires a task id');
+  if (!reason) throw new Error('reconcile requires a --reason');
+
+  const id = taskId.toUpperCase();
+  const task = db.prepare('SELECT id, status FROM tasks WHERE id = ?').get(id);
+  if (!task) throw new Error(`no such task: ${id}`);
+  if (task.status === 'complete') {
+    throw new Error(`Task ${id} is already complete — there is nothing to reconcile.`);
+  }
+
+  const record = validateReconciled(
+    {
+      task: id,
+      reason,
+      confirmed_at: new Date().toISOString(),
+      evidence: {
+        commits: evidence?.commits ?? [],
+        paths: evidence?.paths ?? [],
+      },
+    },
+    '(new reconciliation)',
+  );
+
+  await writeReconciledFile(record, reconciledDir);
+  const applied = applyReconciliation(db, record);
+  return { record, ...applied };
+}
+
+// Evidence for exactly one task, in the shape confirmReconciliation
+// wants. Returns null when that task is not an open candidate — a caller
+// confirming a task the evidence path never proposed still gets to
+// record the confirmation, with an empty evidence set that says so.
+export function evidenceForTask(db, taskId) {
+  const { candidates } = gatherEvidence(db);
+  const entry = candidates.find((c) => c.task.id === taskId.toUpperCase());
+  if (!entry) return null;
+  return {
+    commits: entry.commits.map((c) => c.sha),
+    paths: entry.paths,
+  };
+}
+
+// ── rendering ─────────────────────────────────────────────────────────
+
+// Renders a gatherEvidence() result as a proposal. Every line is written
+// to read as a question the user answers, not as a finding the command
+// acted on — the confirm command is printed per task, one at a time, and
+// no "confirm all" form exists to print.
+export function formatEvidence({ since, commits, candidates, alreadyReconciled }) {
+  const lines = [];
+
+  lines.push(
+    since
+      ? `Reading ${commits.length} commit(s) since ${since.slice(0, 8)} — the newest commit the build graph itself wrote.`
+      : `Reading ${commits.length} commit(s) — no commit in this history was written by the build graph.`,
+  );
+  lines.push('');
+
+  if (candidates.length === 0) {
+    lines.push('No open task has files in its scope touched by those commits.');
+    lines.push('');
+    lines.push('Nothing to propose. No task was changed.');
+    return lines.join('\n');
+  }
+
+  lines.push('PROPOSED — evidence only. None of these tasks has been changed.');
+  lines.push('');
+  for (const { task, commits: matched, paths } of candidates) {
+    lines.push(`  ${task.id}   ${task.layer}   ${task.objective}`);
+    for (const commit of matched) {
+      lines.push(`    ${commit.sha.slice(0, 8)}  ${commit.subject}`);
+    }
+    for (const path of paths) {
+      lines.push(`      in scope: ${path}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('A commit touching a task\'s scope is not proof the task\'s objective was met.');
+  lines.push('Read the work, then confirm each task you judge done, one at a time:');
+  lines.push('');
+  lines.push('  hedgehog reconcile confirm <task-id> --reason "<why this work satisfies it>"');
+  lines.push('');
+  lines.push('Confirming closes the task without a scope gate or a verify run, and records');
+  lines.push(`that in ${RECONCILED_DIR}/<task-id>.json — commit that file, or the next`);
+  lines.push('`hedgehog db rebuild` reverts the reconciliation.');
+
+  if (alreadyReconciled.length > 0) {
+    lines.push('');
+    lines.push('ALREADY CONFIRMED (still open in this graph — run `hedgehog db rebuild`)');
+    for (const taskId of alreadyReconciled) lines.push(`  ${taskId}`);
+  }
+
+  return lines.join('\n');
+}
+
+// Renders loadReconciliations() as a listing — `hedgehog reconcile list`.
+export function formatReconciliations(reconciliations, orphaned = []) {
+  if (reconciliations.size === 0) return 'No reconciliations recorded.';
+
+  const lines = [];
+  for (const [taskId, record] of reconciliations) {
+    lines.push(taskId);
+    lines.push(`  ${record.reason}`);
+    lines.push(`  confirmed ${record.confirmed_at}`);
+    for (const sha of record.evidence.commits) lines.push(`  commit ${sha.slice(0, 8)}`);
+    for (const path of record.evidence.paths) lines.push(`  path   ${path}`);
+    lines.push('');
+  }
+
+  if (orphaned.length > 0) {
+    lines.push(
+      `Orphaned: ${orphaned.join(', ')} — no task with this id exists in the build graph. ` +
+        `Each closes nothing until the id matches.`,
+    );
+  }
+
+  return lines.join('\n').trimEnd();
+}

--- a/src/db/status.mjs
+++ b/src/db/status.mjs
@@ -15,6 +15,7 @@ import { listDebt } from './debt.mjs';
 import { detectDrift, formatDrift } from './drift.mjs';
 import { listFriction } from './friction.mjs';
 import { orphanedOverrides } from './overrides.mjs';
+import { RECONCILED_DIR, RECONCILED_NOTE_PREFIX } from './reconcile.mjs';
 import { formatMissingRequirements } from './requires.mjs';
 import { readyTasks, heldBackReason } from './ready.mjs';
 
@@ -123,6 +124,34 @@ function loadDebtByTask(db) {
     .sort((a, b) => a.taskId.localeCompare(b.taskId));
 }
 
+// Every task that reached `complete` through `hedgehog reconcile` rather
+// than through `hedgehog verify`, in task-id order.
+//
+// A reconciled task is `complete` like any other, so it is invisible in
+// the counts above and in every list below them — and it is the one
+// `complete` status the engine never checked: no scope gate ran and no
+// verify command ran on it. Reading it back off the provenance note
+// reconcile.mjs writes (a `decisions` row carrying
+// RECONCILED_NOTE_PREFIX) keeps that fact in one place rather than adding
+// a task column that every other command would then have to know about,
+// and it survives a rebuild for free, since the replay re-writes the same
+// note from the committed file.
+function loadReconciledTasks(db) {
+  try {
+    return db
+      .prepare(
+        `SELECT DISTINCT d.task_id AS taskId, t.layer AS layer
+         FROM decisions d JOIN tasks t ON t.id = d.task_id
+         WHERE d.note LIKE ? || '%'
+         ORDER BY d.task_id`,
+      )
+      .all(RECONCILED_NOTE_PREFIX);
+  } catch {
+    // No `decisions` table yet (a build graph from before it existed).
+    return [];
+  }
+}
+
 // The friction row count, or 0. `listFriction` reads the table
 // unguarded, so a build graph predating it throws here where `listDebt`
 // would return [] — caught rather than propagated for the same reason
@@ -138,7 +167,7 @@ function countFriction(db) {
 }
 
 // Returns { counts, ready, heldBack, inFlight, attention, drift,
-// orphanedOverrides, debt, frictionCount, total } —
+// orphanedOverrides, debt, frictionCount, reconciled, total } —
 // counts keyed by every status in the tasks CHECK constraint (present
 // even at zero), ready the full list of currently-pickable tasks,
 // heldBack the subset of those that `hedgehog claim` would skip over
@@ -181,6 +210,14 @@ function countFriction(db) {
 // only the existence signal: `debt list` needs a task id the operator
 // has no way to guess, and `friction list` needs the operator to
 // already suspect there is something to read.
+//
+// `reconciled` is the tasks that reached `complete` through `hedgehog
+// reconcile` rather than through `hedgehog verify`. Those are the only
+// `complete` tasks the engine never checked — no scope gate, no verify
+// command — and they are otherwise indistinguishable from verified ones
+// in every count and list here. Reported unconditionally, not as a
+// warning: reconciling is a supported act, and the point is that the
+// distinction stays visible after the session that made it is gone.
 export function graphStatus(db, { core = null, overrides = new Map() } = {}) {
   const counts = countTasksByStatus(db);
   const ready = loadReadyTasks(db);
@@ -191,6 +228,7 @@ export function graphStatus(db, { core = null, overrides = new Map() } = {}) {
   const orphaned = orphanedOverrides(db, overrides);
   const debt = loadDebtByTask(db);
   const frictionCount = countFriction(db);
+  const reconciled = loadReconciledTasks(db);
   const total = Object.values(counts).reduce((a, b) => a + b, 0);
   return {
     counts,
@@ -202,6 +240,7 @@ export function graphStatus(db, { core = null, overrides = new Map() } = {}) {
     orphanedOverrides: orphaned,
     debt,
     frictionCount,
+    reconciled,
     total,
   };
 }
@@ -216,8 +255,9 @@ const BLOCKED_REASON_LABELS = {
 // status (only non-zero ones, in lifecycle order), any declared binary
 // this environment can't resolve, the ready list, tasks currently in
 // flight, anything needing attention, core.yaml drift, overrides
-// pointing at no task, and what has been recorded in the two
-// append-only side channels (declared debt, logged friction).
+// pointing at no task, what has been recorded in the two append-only
+// side channels (declared debt, logged friction), and which complete
+// tasks closed by reconciliation rather than by verification.
 //
 // `missingRequirements` comes from the core definition rather than the
 // database (src/db/requires.mjs#coreMissingRequirements), so the caller
@@ -235,6 +275,7 @@ export function formatStatus({
   orphanedOverrides = [],
   debt = [],
   frictionCount = 0,
+  reconciled = [],
   total,
   missingRequirements,
 }) {
@@ -344,6 +385,23 @@ export function formatStatus({
     lines.push(`FRICTION LOGGED  ${frictionCount}`);
     lines.push('');
     lines.push('  Reviewed as a batch at the end of a build. See: hedgehog friction list');
+  }
+
+  // Last, because it is the only section here that reports something
+  // already settled rather than something outstanding. It is reported at
+  // all because a reconciled task is `complete` in every count above and
+  // is the one `complete` the engine never checked — the distinction is
+  // invisible without this line, and it is exactly what a reader deciding
+  // how much to trust the graph needs.
+  if (reconciled.length > 0) {
+    lines.push('');
+    lines.push(`CLOSED BY RECONCILIATION  ${reconciled.length}`);
+    for (const { taskId, layer } of reconciled) {
+      lines.push(`  ${taskId}   ${layer}   confirmed by the user, not verified`);
+    }
+    lines.push('');
+    lines.push(`  No scope gate and no verify command ran on these. Recorded in ${RECONCILED_DIR}/.`);
+    lines.push('  See: hedgehog reconcile list');
   }
 
   return lines.join('\n');

--- a/src/db/verify.mjs
+++ b/src/db/verify.mjs
@@ -63,19 +63,21 @@ import { reapExpiredLeases, pathFingerprint } from './claim.mjs';
 import { ensureTaskColumns } from './schema.mjs';
 import { FRICTION_DIR } from './friction.mjs';
 import { OVERRIDES_DIR } from './overrides.mjs';
+import { RECONCILED_DIR } from './reconcile.mjs';
 import { INTENTS_DIR } from './intent.mjs';
 import { COMMUNITY_PATH } from './community.mjs';
 
 // Build-graph state directories: written by their own command
-// (`friction add`, `override add`, `intent add`/`db rebuild`), committed
-// by that command's own next step, never by a layer's verify_command. A
+// (`friction add`, `override add`, `intent add`/`db rebuild`, `reconcile
+// confirm`), committed by that command's own next step, never by a
+// layer's verify_command. A
 // layer's own work never lands here, so a path under one of these is
 // never this task's doing regardless of when it changed relative to
 // claim time — unlike attributedToTask's fingerprint check, which only
 // excludes a path unchanged since claim and so still attributes a
 // friction note logged mid-layer (exactly what the loop skill instructs)
 // to whichever task happened to be building when it was logged.
-const BUILD_GRAPH_STATE_DIRS = [FRICTION_DIR, OVERRIDES_DIR, INTENTS_DIR];
+const BUILD_GRAPH_STATE_DIRS = [FRICTION_DIR, OVERRIDES_DIR, INTENTS_DIR, RECONCILED_DIR];
 
 function isBuildGraphStatePath(path) {
   return BUILD_GRAPH_STATE_DIRS.some((dir) => path === dir || path.startsWith(`${dir}/`));

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.1.4",
+  "version": "6.1.5",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
Part of #321, implements #323.

## What

`hedgehog reconcile` absorbs work that landed outside the loop into the build graph, on the user's word rather than on the engine's.

- **Bare `reconcile` reads only.** It lists the commits since the newest graph-written commit and, for each `planned`/`ready` task, which of the files those commits touched fall inside that task's compiled `scope_globs`. It changes no task.
- **`reconcile confirm <task-id> --reason "<why>"` closes exactly one named task.** There is no bulk form. `--all`, `confirm-all`, and a bare `confirm` with no task id are all refused, and a missing `--reason` is refused too — the reason is the permanent record of why a task closed with nothing checked.
- **`reconcile list`** reads the committed records back, and reports any whose task id matches no row (`orphanedReconciliations`, modelled on `orphanedOverrides`).
- Nothing else calls into it. `status`, `next`, and `claim` never reconcile.

## Record format

`.hedgehog/reconciled/<task-id>.json`, one file per task, written via temp-file + rename:

```json
{
  "task": "ALPHA-SCHEMA",
  "reason": "the schema landed in the hand-written commit",
  "confirmed_at": "2026-08-30T12:00:00.000Z",
  "evidence": { "commits": ["<sha>"], "paths": ["libs/alpha/schema/model.txt"] }
}
```

The shape follows `src/db/overrides.mjs` deliberately: task id normalized to upper case at validation (so the replay's `tasks` lookup is exact-match), load-time validation that names the offending file, an absent directory reading as "nothing recorded", and a refusal to overwrite an existing record. `evidence` is stored because a reviewer reading the file a year later needs to see what the confirmation was made against — the reason alone does not say which commits were on screen.

One file per task, unlike overrides, which allow several files per task: two separately-reasoned scope widenings are both real facts, but a second confirmation of the same task is a wrong id or a forgotten first run.

## Rebuild survival

`markCompletedTasks` credits a task only when a commit subject matches its `commit_message` exactly (`src/db/rebuild.mjs:273`) — the subject `verify` itself writes from `core.yaml`. A hand-written commit never matches. `replayReconciliations` runs after it and marks those tasks complete from the committed file instead, with no commit-message match required.

`clearDerivedGraph` stops carrying the reconciliation provenance note across by task id (`src/db/rebuild.mjs:78`). That note now has a committed source, and carrying it *and* replaying it added one duplicate per rebuild. Covered by an assertion over two consecutive rebuilds.

## Provenance

Closing a task by reconciliation is not the fact `verify` records: no scope gate and no verify command ran. `applyReconciliation` writes that as a `decisions` row prefixed `Closed by reconciliation, not verification`, so `next.mjs` renders it into every dependent task's INHERITED DECISIONS section — the existing mechanism for a fact a downstream task needs and cannot read off a diff.

`status.mjs` reads the same rows back into a `CLOSED BY RECONCILIATION` section. A reconciled task is `complete` in every count above it, and is the one `complete` the engine never checked.

## Judgment calls the issue left open

- **`decisions` row, not a new table or a `tasks` column.** The issue named `decision.mjs`/`debt.mjs` as the pattern for inherited context. A column would need every other command to know about it; a table would need a schema migration and a second thing for `rebuild` to carry. The prefixed note reaches dependents' packets for free and is what `status` reads.
- **In-process glob matching.** `verify.mjs` hands scope globs to git as `:(glob)` pathspecs. `reconcile`'s paths already came out of `git log --name-only`, and re-asking git per task per commit is one subprocess per pair. `pathInScope` implements the same three rules (`**` spans separators, single `*`/`?` do not, a trailing `/**` matches the directory itself), pinned by `repro/reconcile-scope-match.mjs`.
- **The read window starts above the newest graph-written commit.** Anything below it has already been credited by `markCompletedTasks`. When no commit matches any task's message, the window is the whole history — the honest reading for a project whose loop has not closed a task yet.
- **A leased task is refused.** `building`/`verifying` means someone holds it; the message points at `hedgehog release`.
- **`db rebuild` reports replayed reconciliations on their own line**, not folded into "N task(s) marked complete" — a rebuild is exactly where that distinction would otherwise vanish into one number.
- **`.hedgehog/reconciled/` added to `verify.mjs`'s `BUILD_GRAPH_STATE_DIRS`**, so a record written mid-build is never attributed to whichever task happens to be building, the same as `.hedgehog/overrides/`.

## Test plan

Ran `npm run repro` — 71 of 71 pass, including three added here:

- `repro/reconcile-survives-rebuild.mjs` — hand-writes a file into a task's scope, commits it under a non-graph message, asserts `db rebuild` does not credit it, then asserts the proposal changes nothing, the confirmation closes the task and unlocks its dependent and writes the record, `status` names it, and two consecutive rebuilds neither revert the reconciliation nor duplicate its note.
- `repro/reconcile-proposes-never-asserts.mjs` — two tasks sharing one commit's paths; asserts reading evidence changes no status, three bulk-confirm forms are refused, confirming one leaves the other open, a missing reason is refused, and `status`/`next`/`claim`/`ready` close nothing.
- `repro/reconcile-scope-match.mjs` — 19 glob cases.

Ran `npm run check` — passes. Version bumped to 6.1.3 with `npm run release`; no tag pushed.
