### PR TITLE
docs(roadmap): remove Mobile core entry

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,11 +44,6 @@ the cost of a pre-built workspace.
    heaviest lift here: it's a new language toolchain, not just a new
    workspace shape, so treat it as a multi-session architectural item
    rather than a quick win.
-6. **Mobile** (React Native or similar) — navigation, offline state, and
-   native build tooling carry enough real decisions that a
-   `hedgehog-core-design` blueprint alone won't lock them down. High
-   demand, but the heaviest of the six: expect a full blueprint's worth
-   of decisions before this is buildable as a core. Perhaps this should be inside the full-stak-app core
 
 ### Add-ons beyond Auth, Queue, and Mobile
 


### PR DESCRIPTION
## Summary
- Deletes item 6 (Mobile) from ROADMAP.md's "New pre-built cores" list — Mobile shipped as a `full-stack-app` add-on (planner decision, `hedgehog-bootstrap` scaffold, `front-end-eng` stack support), not an unbuilt core.
- Resolves the contradiction with the Add-ons section further down, which already names Mobile as shipped.

Closes #332

## Test plan
- [x] Item 6 removed, remaining candidates still read 1-5 (no renumbering needed since only the last item was removed)
- [x] Grepped repo for other references to the deleted entry / `full-stak-app` typo — none found in tracked files