### PR TITLE
docs(planner): drop history-leak framing from core-selection rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.1.5",
+  "version": "6.1.6",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/src/agents/planner.md
+++ b/src/agents/planner.md
@@ -135,13 +135,13 @@ substitutes for `hedgehog-planning-intake`'s own elicitation once a
 core is chosen — that's a full BMAD-driven pass; this is three
 questions to pick which pass to run.
 
-Data that gets stored is not, by itself, `full-stack-app` — that used to
-be the rule, and it swallowed every candidate for `pwa-app` (a tracker,
+Data that gets stored is not, by itself, `full-stack-app` — a tracker,
 journal, notebook, or planner whose data belongs on the user's own
-device). The real question is where the data lives and who needs to
-enforce the rules around it. A description naming a local-first app —
-offline capability or installability named explicitly is a strong
-signal — is `pwa-app`, even with sharing, accounts, or multi-device sync
+device is `pwa-app` even though it stores data. The real question is
+where the data lives and who needs to enforce the rules around it. A
+description naming a local-first app — offline capability or
+installability named explicitly is a strong signal — is `pwa-app`, even
+with sharing, accounts, or multi-device sync
 in scope (Dexie Cloud covers that), and even with a small number of
 entities that must be server-authoritative (those go `--remote`, backed
 by Supabase, without moving the whole project off `pwa-app`). What

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.1.5",
+  "version": "6.1.6",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Summary
- `planner.md`'s data-locality rule opened with "that used to be the rule, and it swallowed every candidate for `pwa-app`" — narrating a past decision instead of stating current policy, against the `no-history-in-output` standard this file is held to.
- Restates the rule as current fact: local-first data storage is `pwa-app` even though it stores data.

## Test plan
- [x] `npm run check` passes (6.1.6)
- [x] Re-read the edited paragraph in context to confirm it reads as current-state-only

Part of #342. Findings posted on #344.