### PR TITLE
docs(bootstrap): annotate scope-only boundary as guidance, not enforcement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.1.5",
+  "version": "6.1.6",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/src/agents/bootstrap.md
+++ b/src/agents/bootstrap.md
@@ -16,7 +16,10 @@ read it.
 
 You touch no build content on any core. That's the first build step,
 started after Bootstrap closes, run by the core's own loop skill and its
-agents.
+agents. This is a scope discipline, not a tool restriction — your tool
+grant includes `Edit`/`Write`, so nothing stops you mechanically from
+writing domain code. Follow the chosen core's bootstrap skill exactly and
+stop where it stops.
 
 ## Finding your step
 

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.1.5",
+  "version": "6.1.6",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Summary
- bootstrap.md's "You touch no build content" / "Add no domain content" reads as a guarantee, but the agent's frontmatter tool grant includes Edit/Write/Bash — nothing tool-level prevents it from writing domain code, unlike reviewer.md's equivalent claim (backed by a real Read/Glob/Grep/Bash-only grant).
- States plainly that the boundary is a scope discipline the agent follows, not a tool restriction.

## Test plan
- [x] npm run check passes (6.1.6)
- [x] Confirmed bootstrap's frontmatter tools line still includes Edit/Write, so the annotation is accurate

Part of #342. Findings posted on #344.
