### PR TITLE
feat(community): add showcase prompt alongside the star prompt

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -64,7 +64,12 @@ import {
   shouldPromptForStar,
   recordStarAnswer,
   formatStarPrompt,
+  shouldPromptForShowcase,
+  recordShowcaseAnswer,
+  formatShowcasePrompt,
+  postShowcase,
   REPO_URL,
+  SHOWCASE_REPO_URL,
 } from '../src/db/community.mjs';
 import { rebuildDb } from '../src/db/rebuild.mjs';
 import {
@@ -628,6 +633,9 @@ ${bold('Usage')}
   npx @skyf0xx/hedgehog decision list [<task-id>]     list declared decisions, oldest first
   npx @skyf0xx/hedgehog db migrate                bring the graph's schema up to the latest version
   npx @skyf0xx/hedgehog community star --answer <a>   record the star prompt's answer
+  npx @skyf0xx/hedgehog community showcase --repo <url> [--description <text>]
+                                                   share what you built to the public showcase
+  npx @skyf0xx/hedgehog community showcase --answer later|dismissed   defer or decline showcasing
   npx @skyf0xx/hedgehog --help
 
 Available cores: ${cores.join(', ')} (${bold('cores list')} for what each one is for)
@@ -2233,8 +2241,19 @@ async function verifyCommand(args) {
 
   // Fires once per project — see community.mjs. Deliberately last: after
   // the gate's own output, not before it.
-  if (await shouldPromptForStar(DEST_ROOT, { intentComplete: result.intentComplete })) {
+  const starJustShown = await shouldPromptForStar(DEST_ROOT, { intentComplete: result.intentComplete });
+  if (starJustShown) {
     console.log(formatStarPrompt());
+    console.log('');
+  }
+
+  // Independent second ask, gated on the star question already having a
+  // pre-existing answer or deferral — never on the same verify call that
+  // just showed the star prompt for the first time. See
+  // shouldPromptForShowcase for why `starJustShown` has to come from
+  // here rather than being re-derived from state.
+  if (await shouldPromptForShowcase(DEST_ROOT, { intentComplete: result.intentComplete, starJustShown })) {
+    console.log(formatShowcasePrompt());
     console.log('');
   }
 }
@@ -3836,20 +3855,34 @@ async function decisionCommand(args) {
   process.exitCode = 1;
 }
 
-// `hedgehog community star --answer starred|later|dismissed` — records
-// the star prompt's answer. No build graph or core needed: this is
-// project state about a question asked, not about the build.
+const COMMUNITY_USAGE = [
+  'hedgehog community star --answer starred|later|dismissed',
+  '   or: hedgehog community showcase --repo <url> [--description <text>]',
+  '   or: hedgehog community showcase --answer later|dismissed',
+].join('\n');
+
+// `hedgehog community star --answer starred|later|dismissed` and
+// `hedgehog community showcase ...` — record each prompt's answer. No
+// build graph or core needed: this is project state about questions
+// asked, not about the build.
 async function communityCommand(args) {
   const sub = args[0];
 
-  if (sub !== 'star') {
-    console.error(
-      `${red('Unknown community subcommand:')} ${sub ?? '(none)'}\n\nUsage: hedgehog community star --answer starred|later|dismissed\n`,
-    );
-    process.exitCode = 1;
+  if (sub === 'star') {
+    await communityStarCommand(args.slice(1));
     return;
   }
 
+  if (sub === 'showcase') {
+    await communityShowcaseCommand(args.slice(1));
+    return;
+  }
+
+  console.error(`${red('Unknown community subcommand:')} ${sub ?? '(none)'}\n\nUsage: ${COMMUNITY_USAGE}\n`);
+  process.exitCode = 1;
+}
+
+async function communityStarCommand(args) {
   const answerIdx = args.indexOf('--answer');
   const answer = answerIdx !== -1 ? args[answerIdx + 1] : undefined;
   const ANSWERS = ['starred', 'later', 'dismissed'];
@@ -3866,6 +3899,61 @@ async function communityCommand(args) {
   if (answer === 'starred') {
     console.log(`  ${green('thank you')}  ${dim(REPO_URL)}`);
   } else if (answer === 'later') {
+    console.log(`  ${dim('deferred')}  ${dim('asked again after about a week of building')}`);
+  } else {
+    console.log(`  ${dim('dismissed')}  ${dim('not asked again in this project')}`);
+  }
+}
+
+// `hedgehog community showcase --repo <url> [--description <text>]`
+// records and submits a showcase entry; `hedgehog community showcase
+// --answer later|dismissed` records a deferral or decline with nothing
+// to submit. `--repo` and `--answer` are mutually exclusive ways of
+// answering the same prompt, mirroring the star command's single
+// `--answer` flag but split in two because only this branch has a
+// network call and a second, optional flag (`--description`).
+async function communityShowcaseCommand(args) {
+  const repoIdx = args.indexOf('--repo');
+  const repoUrl = repoIdx !== -1 ? args[repoIdx + 1] : undefined;
+  const descIdx = args.indexOf('--description');
+  const description = descIdx !== -1 ? args[descIdx + 1] : undefined;
+  const answerIdx = args.indexOf('--answer');
+  const answer = answerIdx !== -1 ? args[answerIdx + 1] : undefined;
+
+  if (repoUrl) {
+    // Courtesy check only — well-formed and http(s). The relay (#365) is
+    // the real validation authority; this just catches an obvious typo
+    // before spending a network round trip on it.
+    let parsed;
+    try {
+      parsed = new URL(repoUrl);
+    } catch {
+      parsed = null;
+    }
+    if (!parsed || !['http:', 'https:'].includes(parsed.protocol)) {
+      console.error(`${red('Usage:')} hedgehog community showcase --repo <http(s) url> [--description <text>]\n`);
+      process.exitCode = 1;
+      return;
+    }
+
+    const core = (await installedCore(DEST_ROOT))?.name;
+    await postShowcase({ repoUrl, core, description });
+    await recordShowcaseAnswer(DEST_ROOT, 'shared', { repoUrl, core, description });
+
+    console.log(`  ${green('shared')}  ${dim(SHOWCASE_REPO_URL)}`);
+    return;
+  }
+
+  const ANSWERS = ['later', 'dismissed'];
+  if (!ANSWERS.includes(answer)) {
+    console.error(`${red('Usage:')} ${COMMUNITY_USAGE}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  await recordShowcaseAnswer(DEST_ROOT, answer);
+
+  if (answer === 'later') {
     console.log(`  ${dim('deferred')}  ${dim('asked again after about a week of building')}`);
   } else {
     console.log(`  ${dim('dismissed')}  ${dim('not asked again in this project')}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.1.8",
+  "version": "6.2.0",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/repro/showcase-prompt-asks-once.mjs
+++ b/repro/showcase-prompt-asks-once.mjs
@@ -1,0 +1,160 @@
+// Reproduction: the showcase prompt's own guarantees, parallel to
+// repro/star-prompt-asks-once.mjs for the star prompt.
+//
+// The showcase prompt is a second, independent ask on top of the star
+// prompt, and the one property unique to it — never sharing the star
+// prompt's "asks once" behavior would be almost as bad — is the gate: it
+// must never fire before the star question has an answer (or at least a
+// deferral) recorded in the same pass. Firing both blocking prompts on
+// one verify call would stack two interruptions instead of one at a
+// time, and firing showcase first would present the "optional" ask
+// before the "please star" one even has a resolution.
+//
+// So the properties worth pinning are:
+//
+//   A. Silent when the star prompt has never been shown at all — no
+//      `starPrompt` key in state.
+//   B. Fires once the star prompt has an answer — a terminal one
+//      (`starred`/`dismissed`) or a deferral (`later`, or an unanswered
+//      `shown`) — same verify pass or a later one.
+//   C. `shared` and `dismissed` are terminal for the showcase prompt —
+//      never asked again.
+//   D. `later` defers, then returns after the shared cooldown constant.
+//   E. An unreadable state file reads as "never asked" rather than
+//      "already answered" — same fail-open direction as the star prompt.
+//   F. A write that cannot land never throws.
+//   G. An unanswered showcase prompt defers itself, just like the star
+//      prompt's own self-deferral.
+//
+// Runs entirely inside a temp dir.
+
+import { mkdtemp, mkdir, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  shouldPromptForShowcase,
+  recordShowcaseAnswer,
+  recordStarAnswer,
+} from '../src/db/community.mjs';
+import { check, assert, finish } from './harness.mjs';
+
+console.log('repro: the showcase prompt gates on the star answer and asks once\n');
+
+const root = await mkdtemp(join(tmpdir(), 'hedgehog-showcase-'));
+await mkdir(join(root, '.hedgehog'), { recursive: true });
+console.log(`  temp project: ${root}\n`);
+
+const statePath = join(root, '.hedgehog', 'community.json');
+const fires = (intentComplete = true) => shouldPromptForShowcase(root, { intentComplete });
+
+// A fresh project for each case, with the star prompt already answered
+// (unless the case is specifically testing the gate) — these are
+// properties of the showcase prompt's own state, not the star prompt's.
+const reset = async (starAnswer = 'dismissed') => {
+  await writeFile(statePath, '{}\n');
+  if (starAnswer !== null) await recordStarAnswer(root, starAnswer);
+};
+
+// --- A. silent until the star prompt has an answer ---------------------
+
+await check('A. never fires with no starPrompt key at all', async () => {
+  await writeFile(statePath, '{}\n');
+  assert(!(await fires(false)), 'fired with no intent complete and no star answer');
+  assert(!(await fires(true)), 'fired before the star prompt had ever been shown');
+});
+
+await check('A. silent even with intentComplete when starPrompt is unset', async () => {
+  await writeFile(statePath, JSON.stringify({ showcasePrompt: undefined }));
+  assert(!(await fires()), 'fired with starPrompt still unset');
+});
+
+// --- B. fires once the star prompt has an answer or a deferral ---------
+
+for (const starAnswer of ['starred', 'dismissed', 'later']) {
+  await check(`B. fires once the star prompt is "${starAnswer}"`, async () => {
+    await reset(starAnswer);
+    assert(await fires(), `did not fire after star prompt answered "${starAnswer}"`);
+  });
+}
+
+await check('B. fires once the star prompt is merely "shown" (deferred, unanswered)', async () => {
+  await writeFile(statePath, JSON.stringify({ starPrompt: 'shown', deferredAt: new Date().toISOString() }));
+  assert(await fires(), 'did not fire once the star prompt was shown, even unanswered');
+});
+
+await check('B. does not fire on intentComplete: false even with a star answer', async () => {
+  await reset('dismissed');
+  assert(!(await fires(false)), 'fired with no intent complete');
+});
+
+// --- C. shared and dismissed are terminal -------------------------------
+
+for (const answer of ['shared', 'dismissed']) {
+  await check(`C. "${answer}" is terminal`, async () => {
+    await reset('dismissed');
+    assert(await fires(), 'did not fire before answering');
+    await recordShowcaseAnswer(root, answer);
+    assert(!(await fires()), `asked again after "${answer}"`);
+
+    const state = JSON.parse(await readFile(statePath, 'utf8'));
+    state.showcaseDeferredAt = new Date(Date.now() - 365 * 24 * 3600 * 1000).toISOString();
+    await writeFile(statePath, JSON.stringify(state));
+    assert(!(await fires()), `"${answer}" expired like a deferral`);
+  });
+}
+
+// --- D. later defers, then returns after the cooldown -------------------
+
+await check('D. "later" defers, and returns after the cooldown', async () => {
+  await reset('dismissed');
+  await recordShowcaseAnswer(root, 'later');
+  assert(!(await fires()), 'asked again immediately after "later"');
+
+  const state = JSON.parse(await readFile(statePath, 'utf8'));
+  state.showcaseDeferredAt = new Date(Date.now() - 8 * 24 * 3600 * 1000).toISOString();
+  await writeFile(statePath, JSON.stringify(state));
+  assert(await fires(), 'never came back after the cooldown elapsed');
+});
+
+await check('D. a corrupt showcase deferral timestamp stays silent', async () => {
+  await writeFile(
+    statePath,
+    JSON.stringify({ starPrompt: 'dismissed', showcasePrompt: 'later', showcaseDeferredAt: 'not-a-date' }),
+  );
+  assert(!(await fires()), 'an unparseable deferral re-asked on every verify');
+});
+
+// --- E. an unreadable state file reads as "never asked" -----------------
+//
+// Note this fails toward SILENCE here, unlike the star prompt's own
+// fail-open-to-shown behavior — a corrupt file can't be read for
+// starPrompt either, so the gate (A) legitimately can't tell the star
+// question has been answered yet. That's the correct, conservative
+// outcome: never showing showcase before star, even under corruption.
+
+await check('E. a corrupt state file does not fire (gate depends on reading starPrompt)', async () => {
+  await writeFile(statePath, '{ not json');
+  assert(!(await fires()), 'a corrupt state file fired despite being unable to confirm a star answer');
+});
+
+await check('E. recording into a missing project never throws', async () => {
+  await recordShowcaseAnswer(join(root, 'does', 'not', 'exist'), 'dismissed');
+});
+
+// --- F. an unanswered prompt defers itself -------------------------------
+
+await check('F. showing the prompt defers it even with no answer', async () => {
+  await reset('dismissed');
+  assert(await fires(), 'did not fire once gated open');
+  assert(!(await fires()), 're-fired at the next intent with no answer recorded');
+  assert(!(await fires()), 're-fired at the third intent with no answer recorded');
+});
+
+await check('F. an answer still overrides a self-deferral', async () => {
+  await reset('dismissed');
+  await fires(); // shown, unanswered
+  await recordShowcaseAnswer(root, 'shared', { repoUrl: 'https://example.com/x', core: 'full-stack-app' });
+  assert(!(await fires()), 'asked again after answering a shown prompt');
+});
+
+finish('showcase-prompt-asks-once');

--- a/repro/showcase-prompt-verify-integration.mjs
+++ b/repro/showcase-prompt-verify-integration.mjs
@@ -1,0 +1,111 @@
+// Reproduction: the showcase prompt as `hedgehog verify` actually fires
+// it, end to end through the real CLI — parallel to
+// repro/star-prompt-engine-state.mjs, which covers the same ground for
+// the star prompt alone.
+//
+// Three things only an integration test through the real binary can
+// confirm:
+//
+//   1. Closing an intent's last layer with the star prompt still
+//      unanswered shows the star prompt but NOT the showcase prompt in
+//      that same verify output — the gate in shouldPromptForShowcase
+//      (src/db/community.mjs) reads real on-disk state written by the
+//      real `community star` subcommand, not a mock.
+//   2. Once the star prompt is answered (`hedgehog community star
+//      --answer ...`), the NEXT intent to close its last layer shows the
+//      showcase prompt.
+//   3. `.hedgehog/community.json` — now carrying both starPrompt and
+//      showcasePrompt/showcaseDeferredAt/showcaseAnsweredAt keys — still
+//      rides free of `verify`'s scope gate and `boundary`'s clean-tree
+//      check, exactly as it did with the star prompt alone. This is the
+//      "no isEngineStatePath change needed" acceptance criterion, proven
+//      rather than just asserted: both isEngineStatePath functions match
+//      COMMUNITY_PATH by exact whole-path equality, so any new key
+//      inside that same file is invisible to both gates by construction
+//      — this run demonstrates it holds with the showcase keys present.
+
+import {
+  makeProject,
+  completeNextTask,
+  writeScopeFile,
+  runCli,
+  runCliCapturingBoth,
+  cleanup,
+  check,
+  checkExit,
+  checkContains,
+  report,
+} from './lib/fixture.mjs';
+
+const project = makeProject();
+try {
+  const alphaModel = completeNextTask(project); // ALPHA-MODEL
+  const alphaViewResult = runCli(project, ['claim', '--owner', 'repro']);
+  const match = alphaViewResult.stdout.match(/Task ([A-Z0-9-]+) leased/);
+  if (!match) throw new Error(`fixture: nothing claimable\n${alphaViewResult.stdout}${alphaViewResult.stderr}`);
+  const taskId = match[1];
+
+  // Write ALPHA-VIEW's scope file by hand (rather than completeNextTask)
+  // so the verify call's stdout can be captured and inspected directly.
+  writeScopeFile(project, taskId);
+  const verifyOut = runCli(project, ['verify', taskId, '--owner', 'repro']);
+
+  check('closing alpha (first intent) exits 0', { expected: 0, actual: verifyOut.status });
+  check('the star prompt fired on the first intent completion', {
+    expected: true,
+    actual: verifyOut.stdout.includes('STAR PROMPT'),
+  });
+  check('the showcase prompt did NOT fire in the same pass — star is unanswered', {
+    expected: false,
+    actual: verifyOut.stdout.includes('SHOWCASE PROMPT'),
+  });
+
+  check('alpha closed via ALPHA-MODEL + ALPHA-VIEW', {
+    expected: 'ALPHA-VIEW',
+    actual: taskId,
+  });
+  void alphaModel;
+
+  // Answer the star prompt, the real way — through the subcommand a
+  // human/agent would actually run.
+  const starAnswer = runCli(project, ['community', 'star', '--answer', 'dismissed']);
+  check('recording the star answer exits 0', { expected: 0, actual: starAnswer.status });
+
+  // Closing beta's last layer is the next intent completion — this is
+  // where the showcase prompt should appear for the first time.
+  completeNextTask(project); // BETA-MODEL
+  const betaViewClaim = runCli(project, ['claim', '--owner', 'repro']);
+  const betaTaskId = betaViewClaim.stdout.match(/Task ([A-Z0-9-]+) leased/)?.[1];
+  if (!betaTaskId) throw new Error(`fixture: nothing claimable for beta\n${betaViewClaim.stdout}`);
+  writeScopeFile(project, betaTaskId);
+  const betaVerifyOut = runCli(project, ['verify', betaTaskId, '--owner', 'repro']);
+
+  check('closing beta (second intent) exits 0', { expected: 0, actual: betaVerifyOut.status });
+  check('the showcase prompt fires once the star prompt has an answer', {
+    expected: true,
+    actual: betaVerifyOut.stdout.includes('SHOWCASE PROMPT'),
+  });
+  check('the star prompt does not fire again — already terminal', {
+    expected: false,
+    actual: betaVerifyOut.stdout.includes('STAR PROMPT'),
+  });
+
+  // Record the showcase answer too, through the real subcommand, so the
+  // tree is in the state a real project would actually reach.
+  const showcaseAnswer = runCli(project, ['community', 'showcase', '--answer', 'dismissed']);
+  check('recording the showcase answer exits 0', { expected: 0, actual: showcaseAnswer.status });
+
+  // boundary's clean-tree condition must still pass with both prompts'
+  // state written into the same untouched community.json.
+  const boundaryResult = runCliCapturingBoth(project, ['boundary']);
+  checkExit('boundary exits 0 with both prompts\' state left uncommitted', 0, boundaryResult);
+  checkContains(
+    'clean-tree condition passes despite community.json carrying showcase keys too',
+    'no uncommitted changes',
+    boundaryResult.stderr,
+  );
+} finally {
+  cleanup(project);
+}
+
+report('showcase-prompt-verify-integration');

--- a/src/db/community.mjs
+++ b/src/db/community.mjs
@@ -1,21 +1,33 @@
-// The one thing Hedgehog asks of the person using it: a prompt to star
-// and watch the repo, raised by `hedgehog verify` at the first intent to
-// close every one of its layers — the first point the user has seen
-// planned work come out complete rather than merely generated.
+// The two things Hedgehog asks of the person using it, both raised by
+// `hedgehog verify` at the first intent to close every one of its layers
+// — the first point the user has seen planned work come out complete
+// rather than merely generated:
 //
-//   1. It asks once. `starred` and `dismissed` end it permanently;
-//      `later` re-arms after a cooldown rather than repeating. Being
-//      shown at all defers it on the same cooldown, so a prompt the user
-//      talks past costs one interruption rather than one per intent.
-//   2. It stops the build. The instruction block tells the agent to hold
-//      the Loop until the user answers, unlike every other notice this
-//      CLI prints, which is advisory.
-//   3. It's framed as what the user gets: watching releases is how a user
-//      finds out their installed payload is behind; starring helps the
-//      project. Both stated plainly.
+//   1. STAR — a prompt to star and watch the repo.
+//   2. SHOWCASE — a prompt to share what got built: a repo URL, the
+//      installed core's name, and an optional description, POSTed to a
+//      public showcase relay. Independent of the star ask, and fires
+//      only after the star question has already been answered in the
+//      same verify pass — never on the same call as an unanswered star
+//      prompt, and never before it.
 //
-// State lives in `.hedgehog/community.json`, per project rather than in
-// `~/.hedgehog/`.
+// Both share one shape:
+//
+//   1. Each asks once. A terminal answer ends it permanently; `later`
+//      re-arms after a cooldown rather than repeating. Being shown at
+//      all defers it on the same cooldown, so a prompt the user talks
+//      past costs one interruption rather than one per intent.
+//   2. Each stops the build. The instruction block tells the agent to
+//      hold the Loop until the user answers, unlike every other notice
+//      this CLI prints, which is advisory.
+//   3. Each is framed as what the user gets, or plainly as what leaves
+//      the project: the star ask states that watching releases is how a
+//      user finds out their installed payload is behind, and starring
+//      helps the project; the showcase ask states plainly that what's
+//      submitted is a public data point, not private telemetry.
+//
+// State for both lives in `.hedgehog/community.json`, per project rather
+// than in `~/.hedgehog/`.
 
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
@@ -27,16 +39,28 @@ export const COMMUNITY_PATH = '.hedgehog/community.json';
 
 export const REPO_URL = 'https://github.com/skyf0xx/hedgehog';
 
-// How long "later" (and an unanswered "shown") defers for.
+// The public showcase repo submissions are committed into — named here
+// so formatShowcasePrompt can point at it directly rather than making
+// the user go find it.
+export const SHOWCASE_REPO_URL = 'https://github.com/skyf0xx/hedgehog-showcase';
+
+// Placeholder until #365 (the Cloudflare Worker relay) ships and hands
+// over the real endpoint. Requests here fail closed (see
+// postShowcase below) so a stale or unreachable placeholder is silently
+// a no-op rather than a build-blocking error.
+const SHOWCASE_RELAY_URL = 'https://showcase-relay.hedgehog.build/submit';
+
+// How long "later" (and an unanswered "shown") defers for, shared by
+// both prompts — one cooldown constant, not one per prompt.
 const LATER_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
 
-// `starPrompt` is one of:
+// Both `starPrompt` and `showcasePrompt` are one of:
 //   (unset)     never shown
 //   shown       displayed but not answered — deferred
 //   later       user asked to be reminded — deferred
-//   starred     terminal
+//   starred* / shared*   terminal (see each prompt's own answer set)
 //   dismissed   terminal
-const TERMINAL = new Set(['starred', 'dismissed']);
+const TERMINAL = new Set(['starred', 'shared', 'dismissed']);
 
 async function readState(root) {
   try {
@@ -127,4 +151,129 @@ export function formatStarPrompt() {
     '  is a legitimate answer and the correct response to it is to record it',
     '  and carry on with the build.',
   ].join('\n');
+}
+
+/**
+ * Whether the showcase prompt should fire now. Same terminal/cooldown
+ * state machine as shouldPromptForStar, keyed on its own `showcasePrompt`
+ * field — but gated first on the star question already having a
+ * pre-existing answer or deferral (from a *prior* verify pass), never on
+ * the same call that just showed the star prompt for the first time.
+ *
+ * `starJustShown` is the caller's own shouldPromptForStar return value
+ * from this same verify call: shouldPromptForStar's side effect writes
+ * `starPrompt: 'shown'` the instant it fires, so reading `starPrompt`
+ * back out of state right after can't otherwise tell "already shown
+ * before this call" apart from "shown just now, this call, unanswered"
+ * — both read as the string 'shown'. Passing the caller's own boolean is
+ * the one unambiguous signal for that distinction; the caller already
+ * has it for free as the value it just branched on to print the star
+ * prompt.
+ */
+export async function shouldPromptForShowcase(root, { intentComplete, starJustShown = false }) {
+  if (!intentComplete) return false;
+  if (starJustShown) return false;
+
+  const { starPrompt, showcasePrompt, showcaseDeferredAt } = await readState(root);
+
+  // Unset means the star prompt has never been shown at all — never
+  // before it, whether or not it's been answered yet.
+  if (!starPrompt) return false;
+
+  if (TERMINAL.has(showcasePrompt)) return false;
+
+  if (showcasePrompt === 'later' || showcasePrompt === 'shown') {
+    const since = Date.now() - Date.parse(showcaseDeferredAt ?? '');
+    if (!Number.isFinite(since) || since < LATER_COOLDOWN_MS) return false;
+  }
+
+  // Recorded before returning, so an unanswered display defers itself
+  // rather than re-firing at every later intent completion.
+  await writeState(root, { showcasePrompt: 'shown', showcaseDeferredAt: new Date().toISOString() });
+
+  return true;
+}
+
+/**
+ * Record the user's answer. `answer` is 'shared' | 'later' | 'dismissed'.
+ * `submission` (repoUrl, core, description) is attached only when
+ * `answer` is 'shared', for anyone reading community.json back later.
+ */
+export async function recordShowcaseAnswer(root, answer, submission) {
+  const patch = { showcasePrompt: answer, showcaseAnsweredAt: new Date().toISOString() };
+  if (answer === 'later') patch.showcaseDeferredAt = new Date().toISOString();
+  if (answer === 'shared' && submission) patch.showcaseSubmission = submission;
+  await writeState(root, patch);
+}
+
+/** The prompt itself, addressed to the agent — parallel to
+ * formatStarPrompt. Kept visually and textually distinct from the star
+ * ask: a separate heading, a separate command, and an explicit statement
+ * that this is public, optional, and unrelated to closing the intent. */
+export function formatShowcasePrompt() {
+  return [
+    'SHOWCASE PROMPT  — a separate, optional question. Ask the user this now,',
+    '  then STOP.',
+    '',
+    '  This is unrelated to the star question and does not affect whether the',
+    '  intent is done — it is already done. Put this question to the user, wait',
+    '  for their answer, and do not start the next task, claim, or any other',
+    '  work until they have answered. Ask it once. It will not be asked again.',
+    '',
+    '  Say, in your own words:',
+    '',
+    '    Want to share what you built? Hedgehog keeps a public showcase of',
+    `    projects built with it: ${SHOWCASE_REPO_URL}`,
+    '    Sharing submits your repo URL, the core you built with, and an',
+    '    optional description. This is a public data point, committed into',
+    '    that public repo — not private telemetry, and entirely optional.',
+    '',
+    '  Then offer exactly three options and wait:',
+    '',
+    '    1. Share it        — ask for a repo URL and an optional description',
+    "    2. Later           — ask again after about a week of building",
+    "    3. Don't show again — never ask in this project again",
+    '',
+    '  On option 1, ask for the repo URL (and, optionally, a short description),',
+    '  then record and submit it:',
+    '',
+    '    hedgehog community showcase --repo <url> [--description "<text>"]',
+    '',
+    '  On option 2 or 3, record the answer without submitting anything:',
+    '',
+    '    hedgehog community showcase --answer later|dismissed',
+    '',
+    '  Never re-ask after recording, and never pressure a decline — option 3',
+    '  is a legitimate answer and the correct response to it is to record it',
+    '  and carry on with the build.',
+  ].join('\n');
+}
+
+/**
+ * POST a showcase submission to the relay. Follows fetchLatest's
+ * (src/hosts/version.mjs) fail-silent convention exactly: a short abort
+ * timeout, catch-all, never throws, never blocks verify or the CLI. On
+ * any failure — unreachable host, timeout, non-2xx, relay not yet
+ * provisioned — this silently drops the submission. No retry, no stored
+ * pending state: the relay is the system of record once it exists (see
+ * #365), not this CLI.
+ */
+export async function postShowcase({ repoUrl, core, description }) {
+  try {
+    const body = JSON.stringify({
+      repoUrl,
+      core,
+      ...(description ? { description } : {}),
+      timestamp: new Date().toISOString(),
+    });
+    await fetch(SHOWCASE_RELAY_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body,
+      signal: AbortSignal.timeout(1500),
+    });
+  } catch {
+    // Unreachable, timed out, or the relay doesn't exist yet (#365) —
+    // all the same outcome from here: the submission is dropped.
+  }
 }

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.1.8",
+  "version": "6.2.0",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Summary
- Extends the one-shot star prompt (`src/db/community.mjs`) with a second, independent, optional showcase prompt asked after the star question is answered — "want to share what you built?" (repo URL, installed core name, optional description).
- New `hedgehog community showcase --repo <url> [--description <text>]` CLI subcommand; core name auto-filled from `.hedgehog/core.json` via `installedCore()`.
- Submission POSTs fail-silently (1.5s timeout, never throws, never blocks verify) to a relay URL — the real relay/Action doesn't exist yet (tracked in #365), so `SHOWCASE_RELAY_URL` is a placeholder for now.

## Test plan
- [x] `npm run repro` — all 84 scripts pass (82 pre-existing + 2 new)
- [x] `npm run check` — pass
- [x] Manual smoke test: valid submission, invalid URL rejected client-side, `--answer later`, unreachable-relay fail-silent POST exits sub-second, core auto-fill correct
- [x] New repro pins the sequencing fix: showcase prompt does not fire in the same verify pass the star prompt is first shown, only on a later pass once star has any answer/deferral

Closes #364.