### PR TITLE
chore(community): wire the live showcase relay URL

### DIFF
--- a/src/db/community.mjs
+++ b/src/db/community.mjs
@@ -44,11 +44,11 @@ export const REPO_URL = 'https://github.com/skyf0xx/hedgehog';
 // the user go find it.
 export const SHOWCASE_REPO_URL = 'https://github.com/skyf0xx/hedgehog-showcase';
 
-// Placeholder until #365 (the Cloudflare Worker relay) ships and hands
-// over the real endpoint. Requests here fail closed (see
-// postShowcase below) so a stale or unreachable placeholder is silently
-// a no-op rather than a build-blocking error.
-const SHOWCASE_RELAY_URL = 'https://showcase-relay.hedgehog.build/submit';
+// The Cloudflare Worker relay from skyf0xx/hedgehog-showcase (#365). A
+// request here fails silently on any error (see postShowcase below), so
+// a future redeploy to a new URL degrades to a silent no-op rather than
+// a build-blocking error.
+const SHOWCASE_RELAY_URL = 'https://hedgehog-showcase-relay.hedgehog-showcase.workers.dev/';
 
 // How long "later" (and an unanswered "shown") defers for, shared by
 // both prompts — one cooldown constant, not one per prompt.


### PR DESCRIPTION
## Summary
- Replaces the placeholder `SHOWCASE_RELAY_URL` with the real deployed Cloudflare Worker URL from #365.
- Verified end-to-end live: relay validation, `repository_dispatch`, and the intake Action's commit to `skyf0xx/hedgehog-showcase` all confirmed working via manual test submissions (cleared from the data file afterward).

## Test plan
- [x] `npm run repro` — all 84 pass
- [x] `npm run check` — pass
- [x] Live smoke test via `postShowcase()` directly — real submission flowed through the relay, dispatched, and committed to `data/showcase.json` in `skyf0xx/hedgehog-showcase`

Closes #365.