### PR TITLE
fix: gitignore .hedgehog/ with trailing slash for clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .claude/settings.json
 __pycache__/
 .pytest_cache/
-.hedgehog
+.hedgehog/
 .tight-skills.md
 node_modules/


### PR DESCRIPTION
## Summary
The `.hedgehog/` directory contains runtime state including `.hedgehog/community.json` (tracks user responses to community prompts) that should never be committed to a project's repository. The ignore pattern was already in place but lacked the trailing slash to make it explicitly a directory pattern — this change adds it for clarity and consistency.

Closes #374

## Test plan
- [x] `npm run check` passes
- [x] `.hedgehog/community.json` is confirmed ignored by gitignore pattern