### PR TITLE
fix(hedgehog-daily): make Re-plan exit self-checking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyf0xx/hedgehog",
-      "version": "6.2.2",
+      "version": "6.2.3",
       "license": "MIT",
       "bin": {
         "hedgehog": "bin/cli.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }

--- a/src/skills/hedgehog-daily/SKILL.md
+++ b/src/skills/hedgehog-daily/SKILL.md
@@ -29,22 +29,31 @@ with a real cost, taken on stated conditions — not the safe default.
 ## The three exits
 
 Decide by the conditions, in order. The first one that holds is the exit.
+Re-plan is checked first, and its check is a read to make, not a
+suspicion to already hold — do not reach Change-work or Tweak without
+having made it.
 
 ### Re-plan
 
-The locked planning artifact that governs this project no longer
-describes what is being asked for. The core's own loop skill names which
-artifact governs — the brief and layer sequence for a shipped core,
-`.hedgehog/core-design.md` for an authored one, `.hedgehog/adoption.md`
-for an adopted one.
+The core's own loop skill names which artifact governs this project —
+the brief and layer sequence for a shipped core, `.hedgehog/core-design.md`
+for an authored one, `.hedgehog/adoption.md` for an adopted one. Read
+that artifact, then check:
 
-Route to `planner`'s re-entry pass, which adds intents for new work
-without re-running planning from scratch and without disturbing anything
-already built.
+- Does anything the request needs contradict a statement locked there —
+  an interface, a stack choice, a scope boundary?
 
-Where the artifact's failure means the request is a different project
-rather than an extension of this one, say so plainly instead of routing.
-That artifact is never rewritten to accommodate new scope.
+If it holds, this is Re-plan — regardless of how many layers the request
+reaches or whether every file it touches already exists. Route to
+`planner`'s re-entry pass, which adds intents for new work without
+re-running planning from scratch and without disturbing anything already
+built.
+
+Where the contradiction means the request is a different project rather
+than an extension of this one, say so plainly instead of routing. That
+artifact is never rewritten to accommodate new scope.
+
+If it does not hold, move on to Change-work.
 
 ### Change-work
 


### PR DESCRIPTION
## Summary
- `hedgehog-daily`'s Re-plan exit named the artifact that governs a project (core-design.md, adoption.md, or the shipped core's brief) but gave no checkable condition to run against it, unlike Change-work and Tweak, which are both answerable from `core.yaml` alone.
- Re-plan's section now states an explicit check — read the governing artifact and ask whether the request contradicts a statement locked there — ordered first, before Change-work and Tweak are evaluated, so routing there is a check made rather than a suspicion stumbled into.
- Change-work and Tweak conditions are unchanged.
- Bumped `package.json` to 6.2.3 (`npm run release`) since this change is scoped to `src/skills/`.

Closes #370

## Test plan
- [x] `npm run check` passes
- [x] Diff reviewed: only `src/skills/hedgehog-daily/SKILL.md` content changed plus the version bump files (`package.json`, `package-lock.json`, `src/hosts/gemini/gemini-extension.json`)