### PR TITLE
fix(db): abandon dependency cleanup, rebuild worktree docs

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -21,7 +21,7 @@ import { spawn, execFileSync } from 'node:child_process';
 import { dbInit, DB_PATH, dbAbsPath, openDb, openDbAt } from '../src/db/init.mjs';
 import { loadCore, lintCore, isModuleAxis } from '../src/db/core.mjs';
 import { planTasks, CORE_INTENT_ID } from '../src/db/plan.mjs';
-import { addIntent, INTENTS_DIR } from '../src/db/intent.mjs';
+import { addIntent, INTENTS_DIR, intentFilePath } from '../src/db/intent.mjs';
 import {
   nextTask,
   formatNext,
@@ -595,9 +595,13 @@ ${bold('Usage')}
   npx @skyf0xx/hedgehog abandon <intent-id> --reason "<why>"
                                                    drop an intent that will never finish: records why,
                                                    resets its tasks to planned on trunk, removes its
-                                                   worktree and branch
+                                                   worktree and branch — the id stays taken; to change
+                                                   an abandoned intent, edit its .hedgehog/intents/<id>.json
+                                                   by hand and run 'hedgehog plan', not 'intent add' again
   npx @skyf0xx/hedgehog intent add [flags]        add an intent (rules/requirements/dependencies)
-  npx @skyf0xx/hedgehog intent add --file <path>  add an intent from a JSON file
+  npx @skyf0xx/hedgehog intent add --file <path>  add an intent from a JSON file — fails on an id already
+                                                   in the build graph, including one reset by 'hedgehog
+                                                   abandon' (still 'planned', not removed); see 'abandon' above
   npx @skyf0xx/hedgehog next                      print the task packet for one ready task
   npx @skyf0xx/hedgehog show <task-id>            print the task packet for any task, at any status
   npx @skyf0xx/hedgehog claim --owner <owner> [--count <n>]   atomically claim up to n ready tasks
@@ -1555,7 +1559,11 @@ async function planCommand(args = []) {
   }
 
   for (const { intentId, branch, path } of worktreesCreated) {
-    console.log(`  ${green('worktree')}  ${bold(intentId)} ${dim(`${branch} → ${path}`)}`);
+    console.log(
+      `  ${green('worktree')}  ${bold(intentId)} ${dim(`${branch} → ${path}`)}\n` +
+        `             ${dim(`compiling here, not onto trunk, because every intent ${intentId} depends_on is already complete —`)}\n` +
+        `             ${dim(`see \`hedgehog merge ${intentId}\`/\`hedgehog abandon ${intentId}\` to close it out later`)}`,
+    );
   }
 
   // Compiles the new worktree's own graph from inside it — a plain
@@ -1728,8 +1736,15 @@ async function intentCommand(args) {
   try {
     intent = await addIntent(db, record);
   } catch (err) {
+    const idTaken = /UNIQUE constraint failed: intents\.id/.test(err.message);
     console.error(
-      `${red('Failed to add intent:')} ${err.message}\n\nUsage: hedgehog intent add --id <id> --goal <goal> --outcome <outcome> [--rule <r>]... [--depends-on <id>]...\n   or: hedgehog intent add --file <path.json>\n`,
+      `${red('Failed to add intent:')} ${err.message}\n\n` +
+        (idTaken
+          ? `${bold(record.id)} already exists in the build graph — this includes an intent \`hedgehog abandon\`\n` +
+            `reset to 'planned' rather than removed. To change it, edit ${intentFilePath(record.id)}\n` +
+            `by hand and run \`hedgehog plan\` to recompile; don't run \`intent add\` again for this id.\n\n`
+          : '') +
+        `Usage: hedgehog intent add --id <id> --goal <goal> --outcome <outcome> [--rule <r>]... [--depends-on <id>]...\n   or: hedgehog intent add --file <path.json>\n`,
     );
     process.exitCode = 1;
     return;
@@ -3705,7 +3720,10 @@ async function abandonCommand(args) {
   console.log(
     `\n${bold('Abandoned.')} ${dim(`${id} is reset to planned on trunk. Commit ${ABANDONED_DIR}/${id.toLowerCase()}.json —`)}\n` +
       `${dim('the build graph is derived and gitignored, and an uncommitted abandonment')}\n` +
-      `${dim('is reverted by the next `hedgehog db rebuild`.')}\n`,
+      `${dim('is reverted by the next `hedgehog db rebuild`.')}\n\n` +
+      `${dim(`${bold(id)} still exists in the build graph at 'planned' — do not run \`hedgehog intent add\` for`)}\n` +
+      `${dim(`this id again (it will fail: the id is already taken). To change the intent, edit`)}\n` +
+      `${dim(`${intentFilePath(id)} by hand and run \`hedgehog plan\` to recompile it.`)}\n`,
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyf0xx/hedgehog",
-      "version": "6.2.2",
+      "version": "6.2.3",
       "license": "MIT",
       "bin": {
         "hedgehog": "bin/cli.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyf0xx/hedgehog",
-      "version": "6.2.4",
+      "version": "6.2.5",
       "license": "MIT",
       "bin": {
         "hedgehog": "bin/cli.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyf0xx/hedgehog",
-      "version": "6.2.3",
+      "version": "6.2.4",
       "license": "MIT",
       "bin": {
         "hedgehog": "bin/cli.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/repro/worktree-abandon-clears-dependency.mjs
+++ b/repro/worktree-abandon-clears-dependency.mjs
@@ -1,0 +1,169 @@
+// `hedgehog abandon` resets an intent's own status and tasks to planned
+// (worktree-abandon.mjs already covers that), but an `intent_dependencies`
+// row naming the abandoned intent — on either side — is a separate fact:
+// eligibleIntents (worktree.mjs) reads that table directly to decide
+// whether an intent gets its own worktree, so a stale row left behind by
+// abandonment can make an unrelated intent look worktree-eligible against
+// a dependency that no longer really applies, or make the abandoned intent
+// itself look eligible again against a dependency its own committed JSON
+// no longer declares.
+//
+// Repro shape: `beta` depends_on `alpha` (already complete), so `beta`
+// gets its own worktree the moment it's added — exactly the trigger
+// documented in `hedgehog plan`'s own help text. `beta` is then abandoned,
+// its intent file is edited to drop the dependency, and re-committed. A
+// `hedgehog db rebuild` from there must show no `intent_dependencies` row
+// for `beta` at all, and must not mark `beta` (fresh, zero commits since
+// the edit) complete.
+
+import { existsSync, writeFileSync, readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import {
+  makeProject,
+  cli,
+  openGraph,
+  commitTaskSubject,
+  cleanup,
+  check,
+} from './_lib.mjs';
+import { report } from './_lib.mjs';
+
+const CORE = `
+id: dep-cleanup-fixture
+layers:
+  - id: view
+    scope: ["src/{module}/**"]
+    verify: "true"
+    commit: "feat({module}): view"
+`;
+
+const dir = makeProject(CORE, { git: true });
+let worktreePath;
+try {
+  writeFileSync(
+    join(dir, '.gitignore'),
+    '.hedgehog/hedgehog.db\n.hedgehog/hedgehog.db-*\n.hedgehog/commit.lock\n',
+  );
+  execFileSync('git', ['add', '.gitignore'], { cwd: dir });
+  execFileSync('git', ['commit', '-q', '-m', 'chore: gitignore build graph'], { cwd: dir });
+
+  check(
+    'add alpha exits 0',
+    0,
+    cli(dir, ['intent', 'add', '--id', 'alpha', '--goal', 'g', '--outcome', 'o']).status,
+  );
+  check('first plan exits 0', 0, cli(dir, ['plan', '--no-open']).status);
+  commitTaskSubject(dir, 'ALPHA-VIEW');
+  check('rebuild exits 0', 0, cli(dir, ['db', 'rebuild']).status);
+
+  check(
+    'add beta (depends on complete alpha) exits 0',
+    0,
+    cli(dir, [
+      'intent',
+      'add',
+      '--id',
+      'beta',
+      '--goal',
+      'g',
+      '--outcome',
+      'o',
+      '--depends-on',
+      'alpha',
+    ]).status,
+  );
+  execFileSync('git', ['add', '-A'], { cwd: dir });
+  execFileSync('git', ['commit', '-q', '-m', 'chore: add beta intent'], { cwd: dir });
+
+  check('plan (creates the beta worktree) exits 0', 0, cli(dir, ['plan', '--no-open']).status);
+
+  const repoName = dir.split('/').filter(Boolean).pop();
+  worktreePath = join(dir, '..', `${repoName}.hedgehog-beta`);
+  check('the worktree exists before abandoning', true, existsSync(worktreePath));
+
+  const dbBefore = openGraph(dir);
+  let depRowBefore;
+  try {
+    depRowBefore = dbBefore
+      .prepare(
+        "SELECT COUNT(*) AS n FROM intent_dependencies WHERE intent_id = 'beta' OR depends_on_intent_id = 'beta'",
+      )
+      .get().n;
+  } finally {
+    dbBefore.close();
+  }
+  check('beta declares its dependency on alpha before abandoning', 1, depRowBefore);
+
+  const abandoned = cli(dir, ['abandon', 'beta', '--reason', 'requirements changed']);
+  check('abandon exits 0', 0, abandoned.status);
+  check('the worktree was removed', false, existsSync(worktreePath));
+
+  // The core assertion for this repro: abandon must clear the dependency
+  // edge, not just reset beta's own status.
+  const dbAfter = openGraph(dir);
+  let depRowAfter, betaStatus;
+  try {
+    depRowAfter = dbAfter
+      .prepare(
+        "SELECT COUNT(*) AS n FROM intent_dependencies WHERE intent_id = 'beta' OR depends_on_intent_id = 'beta'",
+      )
+      .get().n;
+    betaStatus = dbAfter.prepare("SELECT status FROM intents WHERE id = 'beta'").get().status;
+  } finally {
+    dbAfter.close();
+  }
+  check('no intent_dependencies row survives naming beta, either side', 0, depRowAfter);
+  check('beta intent is reset to planned on trunk', 'planned', betaStatus);
+
+  // Edit the committed intent file to drop the dependency — the documented
+  // recovery path (this repo's own `hedgehog abandon` output says so): no
+  // `intent add` re-run, just edit the file and replan.
+  const intentPath = join(dir, '.hedgehog/intents/beta.json');
+  const record = JSON.parse(readFileSync(intentPath, 'utf8'));
+  check('beta.json still declares the old dependency before editing', ['alpha'], record.depends_on);
+  record.depends_on = [];
+  writeFileSync(intentPath, JSON.stringify(record, null, 2));
+  execFileSync('git', ['add', '-A'], { cwd: dir });
+  execFileSync('git', ['commit', '-q', '-m', 'chore: drop beta dependency on alpha'], { cwd: dir });
+
+  // A rebuild from here must not mark beta or its tasks complete — no
+  // commit exists for BETA-VIEW, and its committed JSON no longer declares
+  // any dependency for a stale intent_dependencies row to leak from.
+  execFileSync('git', ['add', '-A'], { cwd: dir });
+  const rebuilt = cli(dir, ['db', 'rebuild']);
+  check('db rebuild exits 0', 0, rebuilt.status);
+
+  const dbFinal = openGraph(dir);
+  let betaFinalStatus, betaTaskStatuses, depRowFinal;
+  try {
+    betaFinalStatus = dbFinal.prepare("SELECT status FROM intents WHERE id = 'beta'").get()
+      .status;
+    betaTaskStatuses = dbFinal
+      .prepare("SELECT status FROM tasks WHERE intent_id = 'beta'")
+      .all()
+      .map((r) => r.status);
+    depRowFinal = dbFinal
+      .prepare(
+        "SELECT COUNT(*) AS n FROM intent_dependencies WHERE intent_id = 'beta' OR depends_on_intent_id = 'beta'",
+      )
+      .get().n;
+  } finally {
+    dbFinal.close();
+  }
+  check('beta intent is not complete after rebuild with zero commits', true, betaFinalStatus !== 'complete');
+  check(
+    'beta has no task marked complete with zero commits behind it',
+    true,
+    betaTaskStatuses.every((s) => s !== 'complete'),
+  );
+  check('rebuild replays no dependency row for beta (JSON no longer declares one)', 0, depRowFinal);
+} finally {
+  if (worktreePath) cleanup(worktreePath);
+  cleanup(dir);
+}
+
+report(
+  'hedgehog abandon clears intent_dependencies edges, and a rebuild after dropping the ' +
+    'dependency does not mark the intent complete with zero commits',
+);

--- a/repro/worktree-abandon.mjs
+++ b/repro/worktree-abandon.mjs
@@ -125,6 +125,24 @@ try {
   // use.
   const secondAbandon = cli(dir, ['abandon', 'beta', '--reason', 'again']);
   check('a second abandon of the same intent refuses', 1, secondAbandon.status);
+
+  // The intent row survives abandonment (reset to planned, not deleted),
+  // so `intent add` on the same id hits the intents.id PRIMARY KEY and
+  // must fail with a hint pointing at the actual recovery path — edit the
+  // committed intent file and replan, not `intent add` again.
+  const reAdd = cli(dir, ['intent', 'add', '--id', 'beta', '--goal', 'g2', '--outcome', 'o2']);
+  check('intent add on an abandoned id fails', true, reAdd.status !== 0);
+  const reAddOutput = `${reAdd.stdout}${reAdd.stderr}`;
+  check(
+    'the failure explains the id is already in the build graph',
+    true,
+    reAddOutput.includes('already exists in the build graph'),
+  );
+  check(
+    'the failure points at editing the intent file instead',
+    true,
+    reAddOutput.includes('hedgehog plan') && reAddOutput.includes('beta.json'),
+  );
 } finally {
   if (worktreePath) cleanup(worktreePath);
   cleanup(dir);

--- a/repro/worktree-trigger.mjs
+++ b/repro/worktree-trigger.mjs
@@ -130,6 +130,11 @@ try {
   const secondPlan = cli(dir, ['plan', '--no-open']);
   check('second plan exits 0', 0, secondPlan.status);
   check('second plan reports the new worktree', true, secondPlan.stdout.includes('BETA'));
+  check(
+    'second plan states why beta is worktreed instead of compiled onto trunk',
+    true,
+    secondPlan.stdout.includes('compiling here, not onto trunk'),
+  );
 
   const worktreesAfterSecond = execFileSync('git', ['worktree', 'list', '--porcelain'], {
     cwd: dir,

--- a/src/db/worktree.mjs
+++ b/src/db/worktree.mjs
@@ -431,6 +431,26 @@ function resetIntentTasksToPlanned(db, intentId) {
     .all(intentId);
 }
 
+// Deletes every `intent_dependencies` row naming `intentId` on either
+// side. An abandoned intent is reset to `planned` with no compiled tasks
+// on trunk, so a `depends_on` edge pointing at it (something else declared
+// as depending on it) or away from it (its own declared dependency) is
+// both stale the moment abandonment lands: `eligibleIntents` (this file)
+// reads that table directly to decide worktree eligibility, and a row
+// surviving abandonment lets an unrelated intent read as "its dependency
+// is satisfied" against an intent that no longer has any real status to
+// satisfy anything with, or lets this intent re-read as eligible against a
+// dependency it no longer declares. Re-adding the same id later
+// (`hedgehog intent add --file` with a JSON that still declares the
+// dependency) recreates the row from that file, same as any first-time
+// add — this only clears what abandonment made stale, not what a future
+// add might legitimately restate.
+function clearIntentDependencies(db, intentId) {
+  db.prepare(
+    'DELETE FROM intent_dependencies WHERE intent_id = ? OR depends_on_intent_id = ?',
+  ).run(intentId, intentId);
+}
+
 // Resets every task of `intentId` to `planned` on whichever DB `db` is
 // open against (trunk, by the CLI's own contract — see abandonCommand),
 // clears any lease, and reopens the intent itself to `planned` so a later
@@ -439,6 +459,11 @@ function resetIntentTasksToPlanned(db, intentId) {
 // only ever compiled inside its own worktree — this is simply a no-op on
 // tasks that don't exist yet). Mirrors reconcile.mjs#applyReconciliation's
 // shape: the committed file is written first, this is applied second.
+//
+// Also clears every `intent_dependencies` row naming this intent, on
+// either side (clearIntentDependencies, above) — an abandoned intent's own
+// declared dependency and any other intent's dependency on it are both
+// stale the instant it resets to `planned` with no shipped work.
 //
 // Refuses an intent already `complete` (merged, real shipped work) —
 // same reasoning as reconcile.mjs#confirmReconciliation refusing an
@@ -458,6 +483,7 @@ export function applyAbandonment(db, intentId) {
     );
   }
   const resetTasks = resetIntentTasksToPlanned(db, intentId);
+  clearIntentDependencies(db, intentId);
 
   if (intent) {
     db.prepare("UPDATE intents SET status = 'planned' WHERE id = ?").run(intentId);
@@ -501,6 +527,7 @@ export function replayAbandonments(db, abandonments) {
     }
     setPlanned.run(intentId);
     resetIntentTasksToPlanned(db, intentId);
+    clearIntentDependencies(db, intentId);
     replayed.push({ intentId, reason: record.reason });
   }
   return { replayed, orphaned };

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.3",
+  "version": "6.2.4",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.4",
+  "version": "6.2.5",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
Closes #371.

## What changed

- **abandon clears stale dependency edges.** `applyAbandonment` and `replayAbandonments` (`src/db/worktree.mjs`) now delete every `intent_dependencies` row naming the abandoned intent, either side. Before this, `eligibleIntents` could keep reading a stale edge and misfire the worktree trigger on an intent whose committed JSON no longer declares the dependency.
- **`hedgehog plan` explains the worktree trigger.** The printed line when an intent gets its own worktree now states why (`bin/cli.mjs:1559-1565`) and points at `merge`/`abandon` to close it out; usage help documents the same trigger for `plan`.
- **abandon/intent-add document the re-add path.** An abandoned intent's id stays taken (reset to `planned`, not removed), so `intent add` on it always failed with a raw `UNIQUE constraint failed` error. `abandon`'s own success output and `intent add`'s failure message now both say to edit the committed intent file and run `plan`, not `intent add` again. Usage help covers this too.

## Not attempted: rebuild requiring a `verifications` row

Acceptance criterion #2 ("`db rebuild` never sets complete without a corresponding `verifications` row") is not implemented — it is architecturally incompatible with how rebuild works, not merely hard.

<details>
<summary>Full reasoning</summary>

`rebuildDb` (`src/db/rebuild.mjs`) starts every run with `clearDerivedGraph`, which does `DELETE FROM intents` — this cascades (schema.mjs's `ON DELETE CASCADE`) through `tasks` to `verifications` before a single row is re-inserted. `markCompletedTasks` then runs against a `verifications` table that is unconditionally empty at that point, for every rebuild, always — a fresh clone, a `merge`, or a manual `db rebuild`. No worktree's `verifications` rows ever cross into trunk's DB either (`worktree.mjs`'s file header: "No DB row ever crosses from one worktree's `.hedgehog/hedgehog.db` to another's, or to trunk's"). Requiring a `verifications` row as literally stated would make rebuild never mark anything complete, breaking its whole purpose (recovering task status from git history on a fresh clone).

The actual bug in the issue's step 8 (5 tasks marked complete with zero commits) most likely shares its root cause with #373 (open, `fix/373-rebuild-commit-message-collision`): `markCompletedTasks` credits a task purely by matching `commit_message` against git history with no scoping to which intent a matching commit actually belongs to, and on a linear-chain core (no module axis) every intent's tasks share the same constant `commit_message`, so an unrelated intent's old commit can satisfy a brand-new intent's task. Per this issue's own instructions, fixing that mechanism is out of scope here (#373's job, and I did not touch `markCompletedTasks`'s matching logic).

This is flagged as a follow-up rather than silently dropped, per the issue's own "skip just that one, note it clearly" instruction for a sub-fix that proves architecturally gnarly.

</details>

## Test plan

- `repro/worktree-abandon-clears-dependency.mjs` (new): reproduces the issue's sequence — intent depends on an already-complete intent, gets worktree'd, is abandoned, dependency is dropped from the committed JSON — and asserts no `intent_dependencies` row survives and `db rebuild` does not mark the intent (or its tasks) complete with zero commits.
- `repro/worktree-abandon.mjs` (extended): asserts `intent add` on an abandoned id fails with the new hint text.
- `repro/worktree-trigger.mjs` (extended): asserts `plan`'s worktree line explains why.
- Ran `npm run check` — pass.
- Ran `npm run repro` — 85/85 reproductions pass.

`package.json` bumped to 6.2.3 (`npm run release`) per this repo's own CLAUDE.md, since the change touches `src/db/` and `bin/cli.mjs`.