### PR TITLE
test: add copywriting to the shipped core.yaml fixture check

### DIFF
--- a/repro/fixtures/cores/copywriting.core.yaml
+++ b/repro/fixtures/cores/copywriting.core.yaml
@@ -1,0 +1,20 @@
+# Shipped core definition for copywriting. A linear chain of two layers:
+# brief intake, then a draft-check-revise loop gated by checkCopy()
+# rather than an agent's own self-report — the mechanism this core
+# exists to provide (see hedgehog-copywriting-loop for the loop itself).
+# `scripts/check-copy/` referenced below is this package's
+# `workspace/scripts/check-copy/`, copied to the project root at
+# install time — paths here are relative to the installed project, not
+# the package.
+id: copywriting
+pattern: layered
+layers:
+  - id: brief
+    scope: [".hedgehog/copy/00-brief.md"]
+    verify: "test -s .hedgehog/copy/00-brief.md"
+    commit: "chore(planning): copy brief"
+  - id: draft
+    depends_on: brief
+    scope: [".hedgehog/copy/**", "scripts/check-copy/**"]
+    verify: "node scripts/check-copy/index.mjs .hedgehog/copy/final.md"
+    commit: "feat(copy): draft"

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -306,20 +306,26 @@ for (const { label, text } of allEntries) {
 //    heuristic cries wolf.
 //
 //    Every core that ships a static `.core.yaml` fixture belongs in this
-//    list — `full-stack-app`, `landing-page`, `pwa-app`, and
-//    `deepseek-harness` all pre-build a workspace with a fixed layer
-//    sequence, so each has one. `adopted` and `authored` do not: neither
-//    ships a pre-built workspace at all (ARCHITECTURE.md, "Keeping a
-//    shipped core's workspace current") — `hedgehog-core-design` derives
-//    `authored`'s layers per project and `hedgehog-adopt` derives
-//    `adopted`'s from whatever repo it's adopting, so there is no single
-//    correct `core.yaml` for either to fix as a fixture; conformance for
-//    those two is instead carried by the writer skills' own worked
-//    examples and the "Verify the file loads" step each one runs against
-//    a real generated file. If either core ever grows a fixed starter
-//    workspace the way the other four have, add its `.core.yaml` fixture
-//    here in the same change. ───────────────────────────────────────────
-const CORE_YAML_FIXTURES = ['full-stack-app', 'landing-page', 'pwa-app', 'deepseek-harness'];
+//    list — `full-stack-app`, `landing-page`, `pwa-app`,
+//    `deepseek-harness`, and `copywriting` all pre-build a workspace
+//    with a fixed layer sequence, so each has one. `adopted` and
+//    `authored` do not: neither ships a pre-built workspace at all
+//    (ARCHITECTURE.md, "Keeping a shipped core's workspace current") —
+//    `hedgehog-core-design` derives `authored`'s layers per project and
+//    `hedgehog-adopt` derives `adopted`'s from whatever repo it's
+//    adopting, so there is no single correct `core.yaml` for either to
+//    fix as a fixture; conformance for those two is instead carried by
+//    the writer skills' own worked examples and the "Verify the file
+//    loads" step each one runs against a real generated file. If either
+//    core ever grows a fixed starter workspace the way the other five
+//    have, add its `.core.yaml` fixture here in the same change. ───────
+const CORE_YAML_FIXTURES = [
+  'full-stack-app',
+  'landing-page',
+  'pwa-app',
+  'deepseek-harness',
+  'copywriting',
+];
 let coreYamlFixturesLoaded = 0;
 for (const core of CORE_YAML_FIXTURES) {
   const path = join(ROOT, `repro/fixtures/cores/${core}.core.yaml`);


### PR DESCRIPTION
## Summary
- `scripts/check.mjs`'s `CORE_YAML_FIXTURES` list loads, validates, and lints every shipped core's `core.yaml` — but `copywriting` was missing from it even though it pre-builds a fixed two-layer workspace (`brief` → `draft`) the same way `full-stack-app`, `landing-page`, `pwa-app`, and `deepseek-harness` do.
- That gap is why skyf0xx/hedgehog-core-copywriting#384's actual bug (`core.yaml` never reaching the published package) went undetected here — there was no vendored fixture to catch it.
- Vendored `copywriting`'s `core.yaml` to `repro/fixtures/cores/copywriting.core.yaml` (matching the pattern for the other four) and added it to `CORE_YAML_FIXTURES`.

Related: skyf0xx/hedgehog#384 (fixed in skyf0xx/hedgehog-core-copywriting#3)

## Test plan
- [x] `npm run check` passes, reports `core.yaml fixtures loaded=5/5`