### PR TITLE
feat: add env vars for ephemeral, per-invocation core installs

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -2250,8 +2250,12 @@ async function verifyCommand(args) {
   }
 
   // Fires once per project — see community.mjs. Deliberately last: after
-  // the gate's own output, not before it.
-  const starJustShown = await shouldPromptForStar(DEST_ROOT, { intentComplete: result.intentComplete });
+  // the gate's own output, not before it. Suppressed by HEDGEHOG_NO_COMMUNITY_PROMPT
+  // for ephemeral workflows (temp-dir installs with no persistent .hedgehog/ to track
+  // cooldown state) that would otherwise re-fire on every invocation.
+  const starJustShown = process.env.HEDGEHOG_NO_COMMUNITY_PROMPT
+    ? false
+    : await shouldPromptForStar(DEST_ROOT, { intentComplete: result.intentComplete });
   if (starJustShown) {
     console.log(formatStarPrompt());
     console.log('');
@@ -2262,7 +2266,8 @@ async function verifyCommand(args) {
   // just showed the star prompt for the first time. See
   // shouldPromptForShowcase for why `starJustShown` has to come from
   // here rather than being re-derived from state.
-  if (await shouldPromptForShowcase(DEST_ROOT, { intentComplete: result.intentComplete, starJustShown })) {
+  if (!process.env.HEDGEHOG_NO_COMMUNITY_PROMPT &&
+      (await shouldPromptForShowcase(DEST_ROOT, { intentComplete: result.intentComplete, starJustShown }))) {
     console.log(formatShowcasePrompt());
     console.log('');
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.9",
+  "version": "6.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyf0xx/hedgehog",
-      "version": "6.2.9",
+      "version": "6.2.10",
       "license": "MIT",
       "bin": {
         "hedgehog": "bin/cli.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.9",
+  "version": "6.2.10",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.9",
+  "version": "6.2.10",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }

--- a/src/registry/fetch.mjs
+++ b/src/registry/fetch.mjs
@@ -41,6 +41,12 @@ export const CORE_CACHE_ROOT = join(homedir(), '.hedgehog', 'cores');
 // exercised end to end before it is published.
 const SOURCE_ENV = 'HEDGEHOG_CORE_SOURCE';
 
+// Skip cache (both reads and writes) when set; every invocation gets a fresh
+// npm pack with no persistence to ~/.hedgehog/cores/. Useful when the
+// caller's use of the fetched core is ephemeral or when accurate npm
+// download stats are needed.
+const NO_CACHE_ENV = 'HEDGEHOG_CORE_NO_CACHE';
+
 const exists = (p) =>
   access(p, constants.F_OK).then(
     () => true,
@@ -81,6 +87,13 @@ export async function fetchCore(entry) {
   } catch (err) {
     await rm(staged.tmp, { recursive: true, force: true });
     throw err;
+  }
+
+  // When NO_CACHE_ENV is set, skip cache entirely and return the staged
+  // extraction directly, leaving staged.tmp in place (since staged.root
+  // lives inside it).
+  if (process.env[NO_CACHE_ENV]) {
+    return { ...read, root: staged.root, version };
   }
 
   // Another install may have cached this exact version between the pack


### PR DESCRIPTION
## Summary
- `HEDGEHOG_CORE_NO_CACHE` (`src/registry/fetch.mjs`): `fetchCore` skips both reading from and writing to the shared `~/.hedgehog/cores/` cache when set, so every invocation registers as a genuinely fresh `npm pack`.
- `HEDGEHOG_NO_COMMUNITY_PROMPT` (`bin/cli.mjs`, `verifyCommand`): suppresses the star/showcase prompt, which assumes a long-lived `.hedgehog/` tracking its own cooldown state and would otherwise re-fire with no memory on every ephemeral install.
- Both are additive and inert unless set — no other core or existing workflow is affected.
- First consumer: `hedgehog-core-copywriting`'s loop skill (already published, v0.1.8), which now runs entirely inside a discarded temp directory per invocation, wrapping every `hedgehog` command with these two env vars set.

## Test plan
- [x] `npm run check` passes
- [x] Live smoke test: `HEDGEHOG_CORE_SOURCE=... HEDGEHOG_CORE_NO_CACHE=1 node bin/cli.mjs init --copywriting` in a scratch directory — install succeeded, resolved the local checkout's version, and confirmed no write landed in `~/.hedgehog/cores/copywriting/`