### PR TITLE
fix: init --copywriting never installs into the invoking directory

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "6.2.10",
+      "version": "6.2.11",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "6.2.10",
+  "version": "6.2.11",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "6.2.10",
+  "version": "6.2.11",
   "author": {
     "name": "skyf0xx"
   },

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -13,10 +13,11 @@
 //   npx @skyf0xx/hedgehog update                       refresh the installed agents + skills
 //   npx @skyf0xx/hedgehog --help
 
-import { cp, mkdir, access, readdir, stat, rm, readFile, writeFile } from 'node:fs/promises';
+import { cp, mkdir, access, readdir, stat, rm, readFile, writeFile, mkdtemp } from 'node:fs/promises';
 import { constants, existsSync, realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, relative, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 import { spawn, execFileSync } from 'node:child_process';
 import { dbInit, DB_PATH, dbAbsPath, openDb, openDbAt } from '../src/db/init.mjs';
 import { loadCore, lintCore, isModuleAxis } from '../src/db/core.mjs';
@@ -121,6 +122,40 @@ const BLOCKED_REASON_LABELS = {
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG_ROOT = resolve(__dirname, '..');
+
+// The copywriting core never installs into the directory it was invoked
+// from — every draft it produces is ephemeral scratch, and only the
+// finished piece is meant to reach the user's real project (as a plain
+// file, copied out by hedgehog-copywriting-loop's own courtesy-export
+// step). Relying on every caller (an agent reading a skill's prose, a
+// human typing the command by hand) to remember to cd into a scratch
+// directory first is exactly the kind of instruction that gets skipped
+// under context pressure — so `init --copywriting` enforces it here
+// instead, unconditionally, before DEST_ROOT is ever read. This has to
+// run before any other module-level state is computed from `process.cwd()`
+// — a raw argv scan rather than the full async arg parser lower in this
+// file, since nothing below has run yet at this point in module load.
+const ORIGDIR = process.cwd();
+{
+  // Catches both the shorthand (`--copywriting`) and the generic named-core
+  // form (`--core copywriting`, `--core=copywriting`) — namedCore()/
+  // coreFlags() do the real resolution later, async, off the registry, but
+  // this has to run synchronously before that and before DEST_ROOT below,
+  // so it matches the raw argv directly rather than waiting for it.
+  const rest = process.argv.slice(2);
+  const coreIdx = rest.indexOf('--core');
+  const isCopywriting =
+    rest.includes('--copywriting') ||
+    rest[coreIdx + 1] === 'copywriting' ||
+    rest.includes('--core=copywriting');
+  if (isCopywriting) {
+    const scratch = await mkdtemp(join(tmpdir(), 'hedgehog-copywriting-'));
+    process.chdir(scratch);
+    // No ANSI helpers yet — `dim` etc. are defined further down, after
+    // DEST_ROOT, and this has to run before DEST_ROOT is computed.
+    console.log(`  (copywriting installs to a scratch directory, never here — using ${scratch})`);
+  }
+}
 const DEST_ROOT = process.cwd();
 
 // The version of the payload this CLI carries — what `init` and
@@ -865,9 +900,22 @@ async function init({ force, core, host = DEFAULT_HOST, hostOnly = false, global
       `  0. ${bold(`npx @skyf0xx/hedgehog@latest update`)} ${dim(`(picks up ${globalInstall.latest} before intake begins)`)}`,
     );
   }
-  // A core that landed a workspace landed its root package.json with it,
-  // so there are dependencies to install before the first commit.
-  if (core?.manifest.workspace) {
+  // Copywriting never lands anywhere the caller can see directly (see the
+  // chdir into a scratch tempdir at module load, above) — the ordinary
+  // "commit here, describe what you want to build" steps assume a project
+  // the human is looking at, which this scratch directory isn't. Point at
+  // the loop skill instead; it owns pnpm install, the draft/checkCopy()
+  // cycle, and the courtesy export of the finished piece back to ORIGDIR.
+  if (core?.manifest.name === 'copywriting') {
+    console.log(
+      `  1. Read ${bold(`${HOSTS[host].skillsDir}/hedgehog-copywriting-loop/SKILL.md`)} and follow it`,
+    );
+    console.log(dim(`     for everything from here, staying inside ${bold(DEST_ROOT)}.`));
+    console.log(
+      dim(`     The finished piece lands back at ${bold(ORIGDIR)} on its own — nothing`),
+    );
+    console.log(dim('     else needs doing there.'));
+  } else if (core?.manifest.workspace) {
     // `pnpm install` before the first commit, not after it. The core's
     // commit gate is lefthook, and lefthook's hooks are written by its
     // own postinstall — so a commit made before the install is a commit
@@ -900,19 +948,23 @@ async function init({ force, core, host = DEFAULT_HOST, hostOnly = false, global
   // the session that ran this install — no restart, no dependence on whether
   // the harness re-scans its agent directory, and no chance of a bare
   // `planner` resolving to an unrelated global agent of the same name.
-  const agents = HOSTS[host].agentsDir;
-  const skills = HOSTS[host].skillsDir;
-  console.log(
-    dim(
-      `     Read ${bold(`${agents}/planner.md`)} and follow it — it runs planning\n` +
-        `     intake (${skills}/hedgehog-planning-intake/SKILL.md), then hands\n` +
-        `     off to ${agents}/bootstrap.md.\n` +
-        `     Some hosts register agents/skills once, at session start: if a\n` +
-        `     later dispatch by name reports one of these as not found, read\n` +
-        `     its file directly instead — it becomes dispatchable by name after\n` +
-        `     a session restart or a fresh context.`,
-    ),
-  );
+  // Copywriting's own branch above already named its hand-off (the loop
+  // skill, not planner/bootstrap — this core has no bootstrap step).
+  if (core?.manifest.name !== 'copywriting') {
+    const agents = HOSTS[host].agentsDir;
+    const skills = HOSTS[host].skillsDir;
+    console.log(
+      dim(
+        `     Read ${bold(`${agents}/planner.md`)} and follow it — it runs planning\n` +
+          `     intake (${skills}/hedgehog-planning-intake/SKILL.md), then hands\n` +
+          `     off to ${agents}/bootstrap.md.\n` +
+          `     Some hosts register agents/skills once, at session start: if a\n` +
+          `     later dispatch by name reports one of these as not found, read\n` +
+          `     its file directly instead — it becomes dispatchable by name after\n` +
+          `     a session restart or a fresh context.`,
+      ),
+    );
+  }
   console.log();
   if (core) {
     console.log(dim(`Core: ${bold(core.manifest.name)} ${dim(`(${core.version})`)}.`));

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.10",
+  "version": "6.2.11",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
   "contextFileName": "GEMINI.md"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.10",
+  "version": "6.2.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyf0xx/hedgehog",
-      "version": "6.2.10",
+      "version": "6.2.11",
       "license": "MIT",
       "bin": {
         "hedgehog": "bin/cli.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.10",
+  "version": "6.2.11",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/skills/hedgehog/SKILL.md
+++ b/skills/hedgehog/SKILL.md
@@ -44,6 +44,14 @@ Run the matching command:
   or fix existing copy, on its own — not bundled into a page or app
   build, where a landing page's own copy still goes through
   `landing-page`'s copy skill instead.
+
+  Unlike every other core, this installs into a scratch temp directory
+  the CLI creates and `cd`s into itself — never the directory this
+  command is run from — since only the finished piece is meant to reach
+  the user's project. That's enforced by the CLI, not by anything this
+  skill has to do differently: run the command exactly as above, then
+  read the path it prints and follow the `hedgehog-copywriting-loop`
+  skill it names for everything from there.
 - DeepSeek Harness plugin: `npx @skyf0xx/hedgehog init --deepseek-harness`
   — for building a tool, hook, or extension for DSH's Cordis-based agent
   framework, or otherwise extending an existing DSH installation via its

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.10",
+  "version": "6.2.11",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Summary
- A live run showed the gap directly: an agent followed `skills/hedgehog`'s prose instructions and ran `npx @skyf0xx/hedgehog init --copywriting` straight in the user's project directory, scaffolding `scripts/check-copy/` and friends there — exactly what the core's ephemeral design (`hedgehog-copywriting-loop`'s Phase -1) exists to prevent. A prose instruction telling the caller to `mktemp`/`cd` first is exactly the kind of step that gets skipped under context pressure.
- Makes it mechanical instead: `init --copywriting` now creates its own `os.tmpdir()`-based scratch directory and `chdir`s into it before `DEST_ROOT` is ever computed, catching the shorthand flag and both `--core <name>`/`--core=<name>` forms. No caller action required, so there's nothing left to forget.
- The closing "Next steps" text names the scratch path and points at `hedgehog-copywriting-loop` for the rest of the loop (including its own courtesy export back to the real directory) instead of the ordinary pnpm-install/git-commit steps, which assume a project the human can see.
- `skills/hedgehog/SKILL.md`'s copywriting bullet is trimmed to match — the CLI owns the scratch dir now, so the skill just says so instead of walking the agent through it by hand.

Companion PR in the core repo updates its loop skill to stop creating a redundant nested scratch dir now that the CLI owns this: skyf0xx/hedgehog-core-copywriting#9.

Also bumps package version 6.2.10 → 6.2.11 (all six version-carrying files, via `npm run release`).

## Test plan
- [x] `npm run check` (lint + `scripts/check.mjs`) — passes.
- [x] `node --experimental-sqlite repro/run-all.mjs` — all 86 reproductions pass.
- [x] Manually verified from a real directory: `init --copywriting` leaves the invoking directory completely untouched, installs into a printed system-tempdir path, and `pnpm install` + `check-copy` both work correctly from there.
- [x] Verified `--core copywriting` and `--core=copywriting` (previously bypassed the shorthand-only check in an earlier draft) are now caught too.
- [x] Verified other cores (`--landing-page`) and the coreless install (`init` with no flag) are unaffected — still install directly into cwd as before.