### PR TITLE
docs: add copywriting to CLAUDE.md's core list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,11 @@ discipline's stance and rationale.
 
 This repo is the engine: the CLI, the build graph, the host adapters, the
 core registry, and the agents and skills every core shares. Each core —
-`full-stack-app`, `pwa-app`, `landing-page`, `deepseek-harness`,
-`authored` (a from-scratch design), and `adopted` (brownfield adoption) —
-ships as its own npm package holding that core's workspace, agents,
-skills, and CLAUDE.md section. `src/registry/cores.json` names them;
-`init` fetches the one a project asks for.
+`full-stack-app`, `pwa-app`, `landing-page`, `copywriting`,
+`deepseek-harness`, `authored` (a from-scratch design), and `adopted`
+(brownfield adoption) — ships as its own npm package holding that core's
+workspace, agents, skills, and CLAUDE.md section. `src/registry/cores.json`
+names them; `init` fetches the one a project asks for.
 
 ## Layout
 


### PR DESCRIPTION
## Why

- `CLAUDE.md:11` enumerates cores by hand and omitted `copywriting`.
- `src/registry/cores.json` has carried the `copywriting` core since it shipped, and `SECURITY.md:41`, `ARCHITECTURE.md:23`, `CONTRIBUTING.md:56-57`, `skills/hedgehog/SKILL.md:38`, and `hooks/session-start:182` all already list it correctly — only this file's sweep was missed.

## What

- Add `copywriting` to the core list in `CLAUDE.md:11`, in the same position used elsewhere (after `landing-page`, before `deepseek-harness`).

## Test plan

- [x] `grep -n "full-stack-app.*pwa-app\|pwa-app.*landing-page\|landing-page.*deepseek" CLAUDE.md` confirms this is the only hand-enumerated core list left in the file.
- [x] No changes under `skills/`, `hooks/`, `.claude-plugin/`, `.cursor-plugin/`, or root `gemini-extension.json` — no version bump required per this repo's own releasing rules.