### PR TITLE
fix(planning-intake): skip bmad-prd/bmad-ux on copywriting's full shelf

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "6.2.12",
+      "version": "6.2.13",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "6.2.12",
+  "version": "6.2.13",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "6.2.12",
+  "version": "6.2.13",
   "author": {
     "name": "skyf0xx"
   },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.12",
+  "version": "6.2.13",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
   "contextFileName": "GEMINI.md"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.12",
+  "version": "6.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyf0xx/hedgehog",
-      "version": "6.2.12",
+      "version": "6.2.13",
       "license": "MIT",
       "bin": {
         "hedgehog": "bin/cli.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.12",
+  "version": "6.2.13",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.12",
+  "version": "6.2.13",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }

--- a/src/skills/hedgehog-planning-intake/SKILL.md
+++ b/src/skills/hedgehog-planning-intake/SKILL.md
@@ -82,6 +82,18 @@ Any skill may itself invoke `bmad-advanced-elicitation`
 (`vendor-skills/BMAD/core-skills/bmad-advanced-elicitation`) at its own pause
 points — that's expected, let it run.
 
+**Full-shelf carve-out on copywriting.** This core has no module axis —
+`hedgehog-copywriting-loop`'s mining step (its planning-intake section,
+step 2) draws only from `02-brief.md` and `03-prfaq.md`, never
+`04-prd.md` or `05-ux-spec/`. On a full run, stop the shelf after
+`bmad-prfaq` (step 4) — or after `bmad-deep-recon` (step 7) where the
+piece genuinely needs market/competitive/user-voice research — and skip
+`bmad-prd` and `bmad-ux` entirely. Neither has a module axis, a UI
+surface, or anything else to attach to on this core, so running them
+produces planning artifacts nothing downstream reads. `00-manifest.md`
+names `bmad-prd` and `bmad-ux` as not-run, the same as any other skipped
+step on this shelf.
+
 Write each skill's output to `.hedgehog/BMAD/`, per the fixed layout:
 
 ```


### PR DESCRIPTION
## Why

- `hedgehog-planning-intake`'s full-shelf path ran all 7 BMAD skills unconditionally (SKILL.md:60-79), including `bmad-prd` and `bmad-ux`, with no per-core exception the way compressed intake gets one.
- `hedgehog-copywriting-loop`'s mining step (its planning-intake section, step 2, in the `hedgehog-core-copywriting` repo) draws only from `02-brief.md` and `03-prfaq.md`, never `04-prd.md` or `05-ux-spec/` — confirmed by this skill's own compressed-intake note: "copywriting's mining draws from those two, never `04-prd.md`" (SKILL.md:150).
- Checked BMAD's own customization surface (`vendor-skills/BMAD/bmm-skills/plan/{bmad-prd,bmad-ux}/customize.toml`, and https://docs.bmad-method.org/customize/customize-bmad/) — its override mechanism tunes how a workflow runs once invoked, with no "don't invoke this skill at all" lever. That decision belongs to the orchestrating skill (`hedgehog-planning-intake`), not to a BMAD-side override.

Fixes #401.

## What

- Added a "Full-shelf carve-out on copywriting" section to `hedgehog-planning-intake`'s Phase 0: on a full run, stop the shelf after `bmad-prfaq` (or `bmad-deep-recon` where research is warranted), never run `bmad-prd` or `bmad-ux`.
- Bumped package version 6.2.12 → 6.2.13 per this repo's releasing rules (this changes `src/skills/`, part of the versioned payload).
- Companion fix in `hedgehog-core-copywriting`'s own `hedgehog-copywriting-loop` skill (separate repo/PR): points its step 1 at this carve-out and corrects a factual error in the same passage (it claimed `bmad-prd` was one of this core's primary inputs).

## Test plan

- [x] `node scripts/check.mjs` — PASS, 7 skills / 7 cores, all six version fields agree.
- [ ] `npm run lint` not run locally (eslint not installed in this environment) — CI runs it.