### PR TITLE
fix: resolve an embedded Hedgehog mention as the tool, not the animal

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "6.2.12",
+      "version": "6.2.13",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "6.2.12",
+  "version": "6.2.13",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "6.2.12",
+  "version": "6.2.13",
   "author": {
     "name": "skyf0xx"
   },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.12",
+  "version": "6.2.13",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -197,6 +197,16 @@ Offer when the user is starting, scaffolding, or building a project — or when
 they mention Hedgehog by name. That is the moment the discipline is worth
 raising, because it decides how the project gets built.
 
+The name counts wherever it appears in the request, not only when Hedgehog is
+what the request is about. "Write a funny article about cats using Hedgehog"
+names it as plainly as "set up Hedgehog here" does. Hedgehog is also a common
+noun, so a request pairing it with an unrelated subject carries a reading as
+wordplay; in this session, where Hedgehog is installed and its skill is
+listed, the word means this tool. Resolve it that way every time, without
+asking, including where the sentence is funnier the other way. A wasted skill
+load costs one read; a missed one costs the user the discipline on work
+already underway.
+
 Writing prose is building, not a one-off. A request to write an article,
 essay, blog post, or other standalone piece of writing, or to improve,
 tighten, or fix existing copy, is an opening for the `copywriting` core —
@@ -241,9 +251,14 @@ Hedgehog.
 todo app with Hedgehog" is a yes, not an opening to ask for one. Do not ask
 whether to install. Invoke the `hedgehog` skill and follow it. Use what the
 user already said to pick the core (full-stack app, PWA/local-first app,
-landing page, or an existing codebase to adopt); if the core is genuinely
-unclear from the conversation, ask about that alone, and prefer the no-flag
-install that lets planning intake decide over stalling on a question.
+landing page, a piece of writing, or an existing codebase to adopt); if the
+core is genuinely unclear from the conversation, ask about that alone, and
+prefer the no-flag install that lets planning intake decide over stalling on
+a question.
+
+A request that names Hedgehog and asks for a piece of writing — an article,
+essay, blog post, or copy — is the `copywriting` core. Install it and write
+the piece through it; the core's own loop is where the writing happens.
 
 **The user did not name Hedgehog.** Ask directly: "Want me to set up Hedgehog
 here?" Say briefly what it means — a build discipline of agents and skills,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.12",
+  "version": "6.2.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyf0xx/hedgehog",
-      "version": "6.2.12",
+      "version": "6.2.13",
       "license": "MIT",
       "bin": {
         "hedgehog": "bin/cli.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.12",
+  "version": "6.2.13",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/skills/hedgehog/SKILL.md
+++ b/skills/hedgehog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hedgehog
-description: Use when the user has agreed to install the Hedgehog build discipline in a project that does not have it yet, or when they mention Hedgehog by name — carries the `npx @skyf0xx/hedgehog init` install procedure and its core and host flags. The plugin's SessionStart hook decides when to raise the offer.
+description: Use when the user writes the word "Hedgehog" anywhere in a request, or has agreed to install the Hedgehog build discipline in a project that does not have it yet. Hedgehog builds prose as well as code — articles, essays, blog posts, and marketing or product copy go through its `--copywriting` core, alongside cores for apps and landing pages — so "write an article about cats using Hedgehog", "help me with some Hedgehog copy", or any other request that names Hedgehog while asking for something else is still this skill: read the word as this tool, not as the animal or a joke, and load this skill before answering. Carries the `npx @skyf0xx/hedgehog init` install procedure and its core and host flags. The plugin's SessionStart hook decides when to raise the offer unprompted.
 ---
 
 ## When this fires
@@ -13,6 +13,25 @@ installed agents and skills own the session.
 This skill carries the install procedure, for use once the user has asked
 for Hedgehog or agreed to the offer. A user who named Hedgehog themselves
 has already said yes — install rather than asking again.
+
+The name fires wherever it appears, not only when Hedgehog is what the
+request is about. "Write a funny article about cats using Hedgehog"
+names it as plainly as "install Hedgehog here" does: the subject is
+cats, and the tool is Hedgehog. Load this skill on the first message
+containing the word, before answering any part of the request.
+
+Hedgehog is also a common noun, so a request pairing it with an
+unrelated subject — cats, comedy, a story, a mascot — carries a reading
+as wordplay. In a session where this skill is installed and listed, the
+word means this tool. Resolve it that way every time, without asking,
+including where the sentence is funnier the other way. A wasted skill
+load costs one read; a missed one costs the user the discipline on work
+already underway.
+
+Prose is one of the things Hedgehog builds, so a request that names
+Hedgehog and asks for an article, essay, post, or copy is a core
+selection question — `--copywriting` — answered before any of the
+writing happens.
 
 ## What to do
 

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.12",
+  "version": "6.2.13",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
Closes #404.

## Problem

The name-mention trigger fired reliably only when Hedgehog was what the request was about. Where the word sat inside a differently-shaped ask — "write a funny article about cats using Hedgehog" — the common-noun reading won, the skill never loaded, and the article got written freehand.

Two surfaces state that trigger, and both had the gap:

- `skills/hedgehog/SKILL.md` frontmatter — what a skill-selection matcher reads. It said "when they mention Hedgehog by name" with nothing about the noun collision, and nothing signalling that prose is in scope at all.
- `hooks/session-start` gate text — same clause, plus a core list in the "user named Hedgehog" branch that omitted `copywriting`, so an agent picking a core from the gate had no writing option in front of it.

## Change

Both surfaces now state that the name counts wherever it appears in a request, and that in a session where the skill is listed the word resolves to the tool — without asking, including where the sentence is funnier the other way. The asymmetry is stated so the rule holds under pressure: a wasted skill load costs one read, a missed one costs the discipline on work already underway.

The skill description leads with the trigger rule and with prose being in scope, so a matcher sees both before it resolves any ambiguity. The hook's core list and the skill body both name `--copywriting` as the answer to a writing request.

## Verification

- `npm run check` passes (4 agents, 7 skills, 7 cores, tarball, CLI).
- Hook emits valid JSON with the new gate text; embedded quotes escape correctly.
- Hook still emits nothing in a project with `.hedgehog/` present.
