### PR TITLE
fix: cover short-form writing in the copywriting offer gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "6.2.13",
+      "version": "6.2.14",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "6.2.13",
+  "version": "6.2.14",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "6.2.13",
+  "version": "6.2.14",
   "author": {
     "name": "skyf0xx"
   },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.13",
+  "version": "6.2.14",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
   "contextFileName": "GEMINI.md"
 }

--- a/hooks/session-start
+++ b/hooks/session-start
@@ -208,13 +208,21 @@ load costs one read; a missed one costs the user the discipline on work
 already underway.
 
 Writing prose is building, not a one-off. A request to write an article,
-essay, blog post, or other standalone piece of writing, or to improve,
-tighten, or fix existing copy, is an opening for the `copywriting` core —
-the same as "build me an app" opens `full-stack-app`. Don't read "it's just
-writing, not code" as a reason to treat it as a question about existing
-content; a blank page is the same tell as an empty working directory. This
-applies even when the piece isn't marketing or product copy — `copywriting`
-gates prose quality generally, and an article is prose.
+essay, blog post, tweet, thread, LinkedIn or social post, newsletter,
+product announcement, email, pitch, or any other standalone piece of
+writing, or to improve, tighten, or fix existing copy, is an opening for the
+`copywriting` core — the same as "build me an app" opens `full-stack-app`.
+Don't read "it's just writing, not code" as a reason to treat it as a
+question about existing content; a blank page is the same tell as an empty
+working directory. This applies even when the piece isn't marketing or
+product copy — `copywriting` gates prose quality generally, and an article
+is prose.
+
+Length is not the test. A tweet is a standalone piece of writing the same
+way an essay is, and short-form copy is where an AI tell costs the most per
+word. "Help me write a tweet," "draft a LinkedIn post," and "write a
+launch announcement" are openings, judged by whether a piece of writing is
+the deliverable — not by how many words it runs to.
 
 Rebuilding, revamping, or redesigning an existing page or app is building, not
 maintenance. An empty working directory is the tell: whatever exists lives

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.13",
+  "version": "6.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyf0xx/hedgehog",
-      "version": "6.2.13",
+      "version": "6.2.14",
       "license": "MIT",
       "bin": {
         "hedgehog": "bin/cli.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.13",
+  "version": "6.2.14",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/skills/hedgehog/SKILL.md
+++ b/skills/hedgehog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hedgehog
-description: Use when the user writes the word "Hedgehog" anywhere in a request, or has agreed to install the Hedgehog build discipline in a project that does not have it yet. Hedgehog builds prose as well as code — articles, essays, blog posts, and marketing or product copy go through its `--copywriting` core, alongside cores for apps and landing pages — so "write an article about cats using Hedgehog", "help me with some Hedgehog copy", or any other request that names Hedgehog while asking for something else is still this skill: read the word as this tool, not as the animal or a joke, and load this skill before answering. Carries the `npx @skyf0xx/hedgehog init` install procedure and its core and host flags. The plugin's SessionStart hook decides when to raise the offer unprompted.
+description: Use when the user writes the word "Hedgehog" anywhere in a request, or has agreed to install the Hedgehog build discipline in a project that does not have it yet. Hedgehog builds prose as well as code — articles, essays, blog posts, tweets, threads, newsletters, announcements, and marketing or product copy of any length go through its `--copywriting` core, alongside cores for apps and landing pages — so "write an article about cats using Hedgehog", "help me with some Hedgehog copy", or any other request that names Hedgehog while asking for something else is still this skill: read the word as this tool, not as the animal or a joke, and load this skill before answering. Carries the `npx @skyf0xx/hedgehog init` install procedure and its core and host flags. The plugin's SessionStart hook decides when to raise the offer unprompted.
 ---
 
 ## When this fires
@@ -29,9 +29,11 @@ load costs one read; a missed one costs the user the discipline on work
 already underway.
 
 Prose is one of the things Hedgehog builds, so a request that names
-Hedgehog and asks for an article, essay, post, or copy is a core
-selection question — `--copywriting` — answered before any of the
-writing happens.
+Hedgehog and asks for a piece of writing — an article, essay, blog post,
+tweet, thread, newsletter, announcement, email, or any other standalone
+copy — is a core selection question, `--copywriting`, answered before
+any of the writing happens. Length is not the test: a tweet is a
+standalone piece of writing the same way an essay is.
 
 ## What to do
 

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.13",
+  "version": "6.2.14",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Problem

The SessionStart gate raised the `copywriting` core for "an article, essay, blog post, or other standalone piece of writing." The core's own `selects_when` in `src/registry/cores.json` is broader — "an email, a pitch, an article, an essay, a blog post, **or any other standalone written piece**."

Short-form fell in that gap. A tweet, thread, LinkedIn or social post, newsletter, or product announcement is inside the core's remit and outside the gate's list, so the offer never came up for the most common writing request there is.

## Change

Both trigger surfaces — the gate text in `hooks/session-start` and the `hedgehog` skill (frontmatter description and body) — now name the short forms and state that length is not the test: what qualifies is a piece of writing being the deliverable, whatever its word count. Short-form is also where an AI tell costs the most per word, which the gate now says.

This aligns the gate with the registry rather than widening either.

## Verification

- `npm run check` passes (4 agents, 7 skills, 7 cores, tarball, CLI).
- Hook emits valid JSON with the new gate text.
- Hook still emits nothing in a project with `.hedgehog/` present.
