### PR TITLE
feat: add hedgehog-writing-gate skill for per-turn write-intent detection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "6.2.14",
+      "version": "6.2.15",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "6.2.14",
+  "version": "6.2.15",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "6.2.14",
+  "version": "6.2.15",
   "author": {
     "name": "skyf0xx"
   },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.14",
+  "version": "6.2.15",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
   "contextFileName": "GEMINI.md"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.14",
+  "version": "6.2.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyf0xx/hedgehog",
-      "version": "6.2.14",
+      "version": "6.2.15",
       "license": "MIT",
       "bin": {
         "hedgehog": "bin/cli.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.14",
+  "version": "6.2.15",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/skills/hedgehog-writing-gate/SKILL.md
+++ b/skills/hedgehog-writing-gate/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: hedgehog-writing-gate
+description: Use when the user asks to write, draft, or edit a standalone piece of prose — an article, essay, blog post, tweet, thread, newsletter, announcement, email, pitch, or other copy — and the request does not already name "Hedgehog". Length is not the test: a tweet qualifies the same as an essay. Does not apply to a question about existing code, a bug, a one-off script, or a request that already names Hedgehog (that goes to the `hedgehog` skill instead) or a project that already has `.hedgehog/` (its own installed skills own that session).
+---
+
+# Hedgehog writing gate
+
+A small root skill whose only job is to catch a write-prose request that
+never says the word "Hedgehog," so the offer doesn't depend on the
+`SessionStart` hook's one-time injection still being salient by the time
+the request actually arrives.
+
+## Why this exists
+
+The `SessionStart` hook injects the Hedgehog offer once, at session
+start. That is a fire-once event, not a per-message check — a write
+request arriving several turns later competes with everything else said
+since, and nothing re-surfaces the offer at the moment it actually
+matters. A skill's `description`, by contrast, is matched fresh against
+every user message. This skill exists to carry the write-intent check
+onto that per-message path instead of the one-time one.
+
+## Scope
+
+Applies only when **both** are true:
+
+- The request's deliverable is a standalone piece of writing — article,
+  essay, blog/LinkedIn/social post, tweet or thread, newsletter, product
+  announcement, email, pitch, or similar. Editing, tightening, or fixing
+  existing copy counts too.
+- The request does not itself name "Hedgehog" anywhere.
+
+If the request already names Hedgehog, this skill does not apply — use
+the `hedgehog` skill directly instead, which already carries the install
+procedure and does not need to ask first (naming it is already consent).
+
+Does not apply, and stay silent, when:
+
+- the project already has a `.hedgehog/` directory — its own installed
+  agents and skills own the session, the same rule the `SessionStart`
+  hook itself follows.
+- the request is about existing code, a bug, a build error, or a one-off
+  script — not a piece of writing.
+- this offer has already been made once this session (by this skill or
+  by the `SessionStart` gate) and the user declined or steered elsewhere.
+  Don't re-ask; carry on with plain writing for the rest of the session.
+
+## What to do
+
+Ask one direct question before drafting anything:
+
+> Want me to run this through Hedgehog's copywriting gate (checks for
+> AI-tell and prose quality before it ships), or write it directly?
+
+Then:
+
+- **User picks Hedgehog, or answers with anything read as a yes** —
+  invoke the `hedgehog` skill and follow it. Do not re-derive the
+  install procedure here; that skill owns it.
+- **User picks direct, or declines** — write the piece directly, without
+  the gate. Do not ask again this session.
+
+Don't bundle other questions into this offer (stack, tone, length,
+audience) — ask about the gate alone, the same restraint the
+`SessionStart` text applies to its own offer.

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.14",
+  "version": "6.2.15",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }


### PR DESCRIPTION
## Summary

- `SessionStart` injects the copywriting offer once, at session start — a fire-once event. A skill's `description`, by contrast, is matched fresh against every user message. A write-prose request arriving several turns into a session competes with everything said since and never re-triggers the offer, even though `SessionStart`'s own gate text already covers the case. This has been hardened in wording several times (`a20d8d8`, `6c56b65`) without closing the gap, because the gap is cadence, not wording.
- Adds `skills/hedgehog-writing-gate/`, a small root skill living alongside the existing `skills/hedgehog/` (same plugin-level family, wired for free by the `"./skills/"` glob already in `.claude-plugin/plugin.json` and `marketplace.json` — no other file needed editing). It matches write-intent requests that don't already name Hedgehog, asks once whether to route through the copywriting gate, and defers to the `hedgehog` skill on a yes. Stays silent once a project has `.hedgehog/` installed, or once the offer's already been made and declined this session.
- Bumps the shared version to 6.2.15 across all six version-carrying files via `npm run release -- patch`.

## Test plan

- [x] `npm run check` passes (lint + payload integrity) at 6.2.15
- [x] New skill's frontmatter parses cleanly via the repo's own `src/hosts/frontmatter.mjs`
- [x] Confirmed no overlap with `skills/hedgehog/`'s trigger: mutually exclusive on whether the request names "Hedgehog"
- [ ] Manual smoke test: fresh session, no `.hedgehog/`, mid-conversation write request with no mention of Hedgehog — confirm the gate now fires