### PR TITLE
docs: trim conventional-commits skill, bump to 6.2.17

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "hedgehog",
       "description": "Offers to set up the Hedgehog build discipline in any project you open",
-      "version": "6.2.16",
+      "version": "6.2.17",
       "source": "./",
       "skills": [
         "./skills/"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "6.2.16",
+  "version": "6.2.17",
   "author": {
     "name": "skyf0xx"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hedgehog",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
-  "version": "6.2.16",
+  "version": "6.2.17",
   "author": {
     "name": "skyf0xx"
   },

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.16",
+  "version": "6.2.17",
   "description": "Offers to set up the Hedgehog build discipline in any project you open",
   "contextFileName": "GEMINI.md"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.16",
+  "version": "6.2.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skyf0xx/hedgehog",
-      "version": "6.2.16",
+      "version": "6.2.17",
       "license": "MIT",
       "bin": {
         "hedgehog": "bin/cli.mjs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyf0xx/hedgehog",
-  "version": "6.2.16",
+  "version": "6.2.17",
   "description": "Install the Hedgehog build discipline (agents + skills) into a repo, for Claude Code, Cursor, or Gemini CLI.",
   "type": "module",
   "repository": {

--- a/src/hosts/gemini/gemini-extension.json
+++ b/src/hosts/gemini/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog",
-  "version": "6.2.16",
+  "version": "6.2.17",
   "description": "Hedgehog build discipline: ordered, tested, verified build steps.",
   "contextFileName": "GEMINI.md"
 }

--- a/src/skills/conventional-commits/SKILL.md
+++ b/src/skills/conventional-commits/SKILL.md
@@ -54,19 +54,14 @@ Group by step first, module second. A hunk in the `orders` schema and a
 hunk in the `orders` repository are different commits even though both
 are "orders" — different steps.
 
-Common groupings:
-- A schema change + its Drizzle migration
-- A service + its unit test (tests land with the step they test, not a
-  trailing "add tests" commit)
-- A Correction Protocol fix to an upstream step, split from each
-  fast-forwarded dependent step
-- Config/tooling changes (lefthook, eslint boundaries, env schema)
-  isolated from any domain step
+Group together: a schema change with its Drizzle migration; a service
+with its unit test (tests land with the step they test, not a trailing
+"add tests" commit); config/tooling changes (lefthook, eslint boundaries,
+env schema) isolated from any domain step.
 
-Do NOT group:
-- Two different build steps, even for the same module
-- A Correction Protocol fix mixed with unrelated new work
-- Two unrelated modules' changes
+Keep separate: different build steps, even for the same module; a
+Correction Protocol fix from the unrelated new work it landed alongside;
+different modules' changes.
 
 ### 3. Order the commits for review
 
@@ -77,7 +72,6 @@ Do NOT group:
    Correction Protocol cleanup — the fix commit needs to make sense
    before the commits that changed because of it.
 3. **Mechanical before novel.** Config, generated files, renames first.
-4. **Tests alongside the step they test**, same commit.
 
 ### 4. Propose the plan, then execute
 


### PR DESCRIPTION
## Summary
- Condenses the grouping and ordering sections of the `conventional-commits` skill, which restated the same distinctions from both directions (a "common groupings" list and a "do NOT group" list covering the same ground; an ordering rule repeating what the grouping step already established)
- Bumps package version to 6.2.17 per `npm run release`

## Test plan
- [x] `npm run check` passes